### PR TITLE
SQLEngineWinMD: resolve TypeSpec generic bases in the identities keystone

### DIFF
--- a/Sources/SQLEngineWinMD/Database+SQL.swift
+++ b/Sources/SQLEngineWinMD/Database+SQL.swift
@@ -68,16 +68,41 @@ extension WinMD.Storage: SQLEngine.Catalog {
         return WinMDRelation(self, tables[index])
       }
     }
+    // `TypeSpec` (ECMA-335 §II.22.39) is an optional table — a database with no
+    // generic instantiation omits it from the tables stream — yet the bundled
+    // `identities`/`bases` views union a `TypeSpec` arm. Resolve an absent
+    // `TypeSpec` to an empty relation so such a view reads no rows rather than
+    // faulting on a missing relation.
+    if name.caseInsensitiveCompare("TypeSpec") == .orderedSame {
+      return WinMDRelation(self, .empty(Metadata.Tables.TypeSpec.self))
+    }
     return nil
   }
 
-  /// The schema names of every open table — the `INFORMATION_SCHEMA` overlay's
-  /// base-relation enumeration, mapped from the database's open relations.
+  /// The schema names of every base relation — the `INFORMATION_SCHEMA`
+  /// overlay's base-relation enumeration, mapped from the database's open
+  /// tables, plus the synthetic `TypeSpec` when the physical table is absent.
+  ///
+  /// `table(named:)` resolves an absent `TypeSpec` (ECMA-335 §II.22.39, an
+  /// optional table) to an empty relation, so the enumeration must name it too:
+  /// `relations()` must list every base relation `table(named:)` resolves, or
+  /// `INFORMATION_SCHEMA` would omit a `TypeSpec` a `SELECT … FROM TypeSpec`
+  /// still reads. A database with a generic instantiation has the table
+  /// physically and needs no synthetic entry — appended only when absent, so
+  /// the name is never duplicated.
   public borrowing func relations() -> Array<String> {
     var names = Array<String>()
-    names.reserveCapacity(tables.count)
+    names.reserveCapacity(tables.count + 1)
+    var spec = false
     for index in 0 ..< tables.count {
       names.append("\(tables[index].description)")
+      if tables[index].description.caseInsensitiveCompare("TypeSpec")
+          == .orderedSame {
+        spec = true
+      }
+    }
+    if !spec {
+      names.append("TypeSpec")
     }
     return names
   }
@@ -342,22 +367,24 @@ public struct WinMDRelation: SQLEngine.Table, ~Escapable {
 
   /// The virtual column names, in ordinal order — `Id` at `width`, then its
   /// join keys: the owner foreign key (on a list-owned table only) leading the
-  /// coded-index join keys.
+  /// coded-index join keys, then the generic-base keys (on a `TypeSpec` only).
   public var virtuals: Array<String> {
     let owner = self.owner.map { [$0] } ?? [] // the list-ownership key
     return ["Id"] // the universal identity, at `width`
         + owner // present only on a list-owned table
         + keys.map(\.name) // coded-index join keys
+        + bases.map(\.name) // generic-base keys, present only on a `TypeSpec`
   }
 
   /// One past the highest ordinal this relation can address — its real `width`
   /// plus the universal `Id` and its join keys (the owner foreign key when
-  /// list-owned, then the coded-index join keys).
+  /// list-owned, then the coded-index join keys, then the generic-base keys).
   public var extent: Int {
     width // real fields
         + 1 // `Id`
         + (owner == nil ? 0 : 1) // the owner foreign key
         + keys.count // coded-index join keys
+        + bases.count // generic-base keys (a `TypeSpec` only)
   }
 
   /// The ordinal of the `Id` virtual column — the first ordinal past the
@@ -407,6 +434,12 @@ public struct WinMDRelation: SQLEngine.Table, ~Escapable {
     for index in keys.indices
         where keys[index].name.caseInsensitiveCompare(name) == .orderedSame {
       return lead + index
+    }
+    // The generic-base keys (a `TypeSpec` only) follow the coded-index keys.
+    let bases = self.bases
+    for index in bases.indices
+        where bases[index].name.caseInsensitiveCompare(name) == .orderedSame {
+      return lead + keys.count + index
     }
     return nil
   }
@@ -522,7 +555,7 @@ public struct WinMDRelation: SQLEngine.Table, ~Escapable {
 
   @_lifetime(borrow self)
   public borrowing func cursor() -> WinMDCursor {
-    WinMDCursor(storage, table, WinMDRelation.Link(storage, table))
+    WinMDCursor(storage, table, WinMDRelation.Link(storage, table), bases)
   }
 }
 
@@ -588,6 +621,75 @@ extension WinMDRelation {
           Key.all(column: column, named: "\(fields[column].name)", kind: kind))
     }
     return keys
+  }
+}
+
+// MARK: - Generic-base virtual columns
+
+extension WinMDRelation {
+  /// A decoded generic-base virtual column on the `TypeSpec` relation: the
+  /// 1-based `Id`, in one candidate base table, of the type a `TypeSpec`'s
+  /// `GENERICINST` signature instantiates.
+  ///
+  /// A `TypeSpec` (ECMA-335 §II.22.39) is a single `Signature` `#Blob` — for a
+  /// generic instantiation, `GENERICINST <base TypeDefOrRef> <args…>`. The base
+  /// names a `TypeDef`/`TypeRef` through a `TypeDefOrRef` coded token, so —
+  /// like the coded-index join keys — one `Base_<TargetSchemaName>` column is
+  /// exposed per candidate base table, whose value is the base's row when the
+  /// token tags that target and its row is non-null, else SQL `NULL`. Resolving
+  /// the base to a namespace/name would need the borrowed `~Escapable`
+  /// `Storage`, so it cannot be a scalar UDF (the reason the `SIGNATURE` UDF
+  /// degrades named types to `opaque`); exposed as a join key, a view resolves
+  /// the base against `identities` uniformly, the way `types` resolves
+  /// `Extends`.
+  package struct Base {
+    /// The ordinal of the `TypeSpec.Signature` `#Blob` column.
+    package let column: Int
+    /// The `TypeDefOrRef` tag selecting `target`.
+    package let tag: Int
+    /// The candidate base table the key navigates to.
+    package let target: TableSchema.Type
+    /// The key's exposed name, `Base_<TargetSchemaName>`.
+    package let name: String
+  }
+
+  /// The generic-base virtual columns of this relation, in ordinal order — one
+  /// `Base_<TargetSchemaName>` per `TypeDefOrRef` base table (`TypeDef`,
+  /// `TypeRef`) a `GENERICINST` can name, and empty on every relation but
+  /// `TypeSpec`.
+  ///
+  /// A `GENERICINST`'s base is a `TypeDef`/`TypeRef` (never a nested
+  /// `TypeSpec`), so the self `TypeSpec` target is omitted; the two keys let a
+  /// view equi-join the base into `identities` across its `TypeDef`/`TypeRef`
+  /// arms, exactly as the coded-index join keys resolve a coded index.
+  package var bases: Array<Base> {
+    guard table.schema.number == Metadata.Tables.TypeSpec.number,
+        let signature = column(named: "Signature") else {
+      return []
+    }
+    var bases = Array<Base>()
+    for tag in 0 ..< TypeDefOrRef.tables.count {
+      guard let target = TypeDefOrRef.tables[tag],
+          target.number != Metadata.Tables.TypeSpec.number else {
+        continue
+      }
+      bases.append(Base(column: signature, tag: tag, target: target,
+                        name: "Base_\(target)"))
+    }
+    return bases
+  }
+
+  /// The ordinal of the real field named `name`, or `nil` when the relation has
+  /// no such field — the schema-only lookup `bases` locates the `Signature`
+  /// `#Blob` column with, independent of the virtual-column layout
+  /// `ordinal(of:)` weaves.
+  private func column(named name: String) -> Int? {
+    for column in 0 ..< table.schema.fields.count
+        where "\(table.schema.fields[column].name)"
+                  .caseInsensitiveCompare(name) == .orderedSame {
+      return column
+    }
+    return nil
   }
 }
 
@@ -684,12 +786,17 @@ public struct WinMDCursor: SQLEngine.Cursor, ~Escapable {
   /// The relation's list link, when it is a list-child.
   private let link: WinMDRelation.Link?
 
+  /// The relation's generic-base keys, present only on a `TypeSpec`.
+  private let bases: Array<WinMDRelation.Base>
+
   @_lifetime(borrow storage)
   package init(_ storage: borrowing WinMD.Storage, _ table: WinMD.Table,
-               _ link: WinMDRelation.Link?) {
+               _ link: WinMDRelation.Link?,
+               _ bases: Array<WinMDRelation.Base>) {
     self.storage = copy storage
     self.cursor = WinMD.Cursor(copy storage, table)
     self.link = link
+    self.bases = bases
   }
 
   public var count: Int {
@@ -699,7 +806,7 @@ public struct WinMDCursor: SQLEngine.Cursor, ~Escapable {
   @_lifetime(copy self)
   public borrowing func row(_ index: Int) -> WinMDRow? {
     guard let tuple = cursor[index] else { return nil }
-    return WinMDRow(tuple, storage, link)
+    return WinMDRow(tuple, storage, link, bases)
   }
 }
 
@@ -728,13 +835,18 @@ public struct WinMDRow: SQLEngine.Row, ~Escapable {
   /// The relation's list link, when it is a list-child.
   private let link: WinMDRelation.Link?
 
+  /// The relation's generic-base keys, present only on a `TypeSpec`.
+  private let bases: Array<WinMDRelation.Base>
+
   @_lifetime(copy tuple, copy storage)
   package init(_ tuple: borrowing WinMD.Tuple,
                 _ storage: borrowing WinMD.Storage,
-                _ link: WinMDRelation.Link?) {
+                _ link: WinMDRelation.Link?,
+                _ bases: Array<WinMDRelation.Base>) {
     self.tuple = copy tuple
     self.storage = copy storage
     self.link = link
+    self.bases = bases
   }
 
   public subscript(_ column: Int) -> Value {
@@ -747,28 +859,40 @@ public struct WinMDRow: SQLEngine.Row, ~Escapable {
       if column > tuple.count {
         // Past `Id`: the join keys. On a list-owned table the owner foreign key
         // leads them (the owning parent's 1-based `Id`, zero for a row no owner
-        // claims) and the coded-index join keys follow it; on a non-list table
-        // the coded-index join keys follow `Id` directly.
+        // claims); the coded-index join keys and — on a `TypeSpec` — the
+        // generic-base keys follow it. On a non-list table those keys follow
+        // `Id` directly.
         let virtual = column - (tuple.count + 1)
-        guard let link else { return self.key(virtual) }
+        guard let link else { return self.join(virtual) }
         return virtual == 0
             ? .integer(storage.owner(of: tuple.index, link))
-            : self.key(virtual - 1)
+            : self.join(virtual - 1)
       }
       if case .index(.heap(.string)) = tuple.type(of: column) {
         return .text((try? tuple.string(column)) ?? "")
       }
       if case .index(.heap(.blob)) = tuple.type(of: column) {
-        guard let blob = try? tuple.blob(column) else { return .null }
-        var bytes = Array<UInt8>()
-        bytes.reserveCapacity(blob.count)
-        for i in 0 ..< blob.count {
-          bytes.append(blob.load(at: i, as: UInt8.self))
-        }
+        guard let bytes = try? self.blob(of: column) else { return .null }
         return .blob(bytes)
       }
       return .integer(tuple[column])
     }
+  }
+
+  /// The `column`th `#Blob` cell's raw heap payload, copied out of the borrowed
+  /// scan — the bytes a scalar UDF (`GUID`, `SIGNATURE`) decodes, and the
+  /// `TypeSpec.Signature` a generic-base key decodes.
+  private func blob(of column: Int) throws(WinMDError) -> Array<UInt8> {
+    try tuple.bytes(of: column)
+  }
+
+  /// The `index`th join key past the owner foreign key: the coded-index join
+  /// keys first, then — on a `TypeSpec` — the generic-base keys, in the order
+  /// `WinMDRelation.virtuals` exposes them.
+  private func join(_ index: Int) -> Value {
+    let keys = self.keys
+    return index < keys.count ? self.key(index)
+                              : self.base(index - keys.count)
   }
 
   /// The coded-index join keys of this row's tuple, in ordinal order — the
@@ -802,6 +926,64 @@ public struct WinMDRow: SQLEngine.Row, ~Escapable {
     let value = key.kind.init(rawValue: tuple[key.column])
     guard value.tag == key.tag, value.row != 0 else { return .null }
     return .integer(value.row)
+  }
+
+  /// The decoded value of this row's `index`th generic-base key.
+  ///
+  /// The base keys are the `TypeSpec` relation's, in the order `bases` exposes
+  /// them. The `TypeSpec.Signature` `#Blob` is decoded to its `SignatureType`;
+  /// when it is a `GENERICINST` whose base `TypeDefOrRef` tags the key's target
+  /// table and its row is non-null, the value is that 1-based row (the target
+  /// relation's `Id`), so a view can equi-join it into `identities`. A
+  /// signature that is not a `GENERICINST`, a base tagging another target, a
+  /// null base reference, or an undecodable blob is SQL `NULL`.
+  private func base(_ index: Int) -> Value {
+    guard index >= 0, index < bases.count else { return .null }
+    let base = bases[index]
+    guard let bytes = try? self.blob(of: base.column),
+        let type = try? WinMD.decode(type: bytes),
+        let reference = WinMDRow.reference(of: type),
+        reference.tag == base.tag, reference.row != 0 else {
+      return .null
+    }
+    return .integer(reference.row)
+  }
+
+  /// The base `TypeDefOrRef` a `GENERICINST` signature instantiates, or `nil`
+  /// for any other `SignatureType` (a pointer, array, bare named type, …, which
+  /// names no generic base).
+  ///
+  /// A valid `TypeSpec` may decorate its `GENERICINST` with leading custom
+  /// modifiers (`CMOD_REQD`/`CMOD_OPT`), which decode to an outer `.modified`
+  /// layer wrapping the instantiation, so peel any `.modified` layer to reach
+  /// the type it decorates before matching the instantiation. A modifier over a
+  /// non-instantiation (a modified pointer, array, …) still names no generic
+  /// base and yields `nil`.
+  private static func reference(of type: SignatureType) -> TypeDefOrRef? {
+    if case let .modified(inner, _) = type {
+      return reference(of: inner)
+    }
+    guard case let .instance(base, _) = type,
+        case let .named(_, reference) = base else {
+      return nil
+    }
+    return reference
+  }
+}
+
+extension WinMD.Tuple {
+  /// The `column`th `#Blob` cell's raw heap payload, copied out of the borrowed
+  /// scan as owned bytes — the payload a scalar UDF (`GUID`, `SIGNATURE`) or a
+  /// signature decode reads without holding the scan open. The shared copy a
+  /// `WinMDRow` `.blob` cell and the `TypeSpec.Signature` decode both take.
+  package func bytes(of column: Int) throws(WinMDError) -> Array<UInt8> {
+    let blob = try blob(column)
+    var bytes = Array<UInt8>()
+    bytes.reserveCapacity(blob.count)
+    for i in 0 ..< blob.count {
+      bytes.append(blob.load(at: i, as: UInt8.self))
+    }
+    return bytes
   }
 }
 

--- a/Sources/SQLEngineWinMD/Resources/Queries/bases.sql
+++ b/Sources/SQLEngineWinMD/Resources/Queries/bases.sql
@@ -1,6 +1,7 @@
 CREATE VIEW bases AS
 SELECT
-  b.TypeName AS base
+  b.TypeName AS base,
+  NULL AS spec
 FROM
   InterfaceImpl i
   JOIN TypeRef b ON i.Interface_TypeRef = b.Id
@@ -8,9 +9,27 @@ WHERE
   i.Class = :parent
 UNION
 SELECT
-  d.TypeName AS base
+  d.TypeName AS base,
+  NULL AS spec
 FROM
   InterfaceImpl i
   JOIN TypeDef d ON i.Interface_TypeDef = d.Id
+WHERE
+  i.Class = :parent
+UNION
+-- A generic base interface is named through a TypeSpec: the InterfaceImpl's
+-- Interface coded index tags TypeSpec, which has no TypeName of its own, so it
+-- resolves through `identities` — whose TypeSpec arm names the TypeSpec by its
+-- generic base's identity. Without this arm the generic base is dropped. The
+-- TypeSpec's own Id rides alongside as `spec` (NULL on a plain base): the
+-- generic definition's TypeName carries an invalid arity suffix and drops the
+-- type arguments, so the render decodes the complete constructed spelling from
+-- the TypeSpec signature rather than emitting that TypeName.
+SELECT
+  s.TypeName AS base,
+  i.Interface_TypeSpec AS spec
+FROM
+  InterfaceImpl i
+  JOIN identities s ON i.Interface_TypeSpec = s.Id AND s.kind = 'TypeSpec'
 WHERE
   i.Class = :parent

--- a/Sources/SQLEngineWinMD/Resources/Queries/identities.sql
+++ b/Sources/SQLEngineWinMD/Resources/Queries/identities.sql
@@ -2,3 +2,17 @@ CREATE VIEW identities AS
   SELECT 'TypeDef' AS kind, Id, TypeNamespace, TypeName FROM TypeDef
   UNION ALL
   SELECT 'TypeRef' AS kind, Id, TypeNamespace, TypeName FROM TypeRef
+  UNION ALL
+  -- A TypeSpec (ECMA-335 §II.22.39) names a constructed type through a single
+  -- Signature blob, not a TypeName; a generic instantiation
+  -- (GENERICINST <base> <args…>) resolves to the identity of its generic base.
+  -- The adapter decodes that base to the Base_TypeRef/Base_TypeDef keys — the
+  -- 1-based Id of the base type in its table — so the base resolves against the
+  -- base tables directly, the way `types` resolves Extends. A non-generic
+  -- TypeSpec (a pointer, array, …) leaves both keys null and so names no
+  -- identity row.
+  SELECT 'TypeSpec' AS kind, ts.Id, r.TypeNamespace, r.TypeName
+  FROM TypeSpec ts JOIN TypeRef r ON ts.Base_TypeRef = r.Id
+  UNION ALL
+  SELECT 'TypeSpec' AS kind, ts.Id, d.TypeNamespace, d.TypeName
+  FROM TypeSpec ts JOIN TypeDef d ON ts.Base_TypeDef = d.Id

--- a/Sources/SQLEngineWinMD/Session+Run.swift
+++ b/Sources/SQLEngineWinMD/Session+Run.swift
@@ -77,15 +77,17 @@ extension Session {
   ///
   /// The `bases` view navigates the interface's single `InterfaceImpl` row
   /// (whose simple `Class` index is the interface's 1-based `Id`) to its
-  /// base type's simple name, projecting `TypeRef.TypeName` as `base`. The
+  /// base type's simple name, projecting the resolved `TypeName` as `base`. The
   /// `Class` column is a *simple* `TypeDef` index — it stores the `Id`
   /// directly, so the predicate is `i.Class = :parent` (there is no decoded
   /// `Class_TypeDef` join key — `WinMDRelation.keys` derives keys only for
-  /// *coded* indices). `Interface` is the coded `TypeDefOrRef`, so its decoded
-  /// `Interface_TypeRef` key equi-joins the base `TypeRef`. Both arms of the
-  /// coded index resolve, `UNION`ed: a cross-file base through
-  /// `Interface_TypeRef` (a `TypeRef`) and a same-file base through
-  /// `Interface_TypeDef` (a `TypeDef` in this module).
+  /// *coded* indices). `Interface` is the coded `TypeDefOrRef`, so its three
+  /// decoded arms resolve, `UNION`ed: a cross-file base through
+  /// `Interface_TypeRef` (a `TypeRef`), a same-file base through
+  /// `Interface_TypeDef` (a `TypeDef` in this module), and a *generic* base
+  /// through `Interface_TypeSpec` — a `TypeSpec` has no `TypeName`, so that arm
+  /// resolves it through `identities`, whose `TypeSpec` arm names the
+  /// constructed type by its generic base's identity.
   ///
   /// A query resource is static, well-formed SQL, so a parse failure is a
   /// programming error rather than user input; it is silently skipped here (the

--- a/Sources/WinMD/Signature.swift
+++ b/Sources/WinMD/Signature.swift
@@ -498,6 +498,24 @@ public func decode(method bytes: Array<UInt8>) throws(WinMDError)
   return signature
 }
 
+/// The `SignatureType` a raw standalone-`Type` `#Blob` payload decodes to
+/// (ECMA-335 §II.23.2.14) — a `TypeSpec.Signature`.
+///
+/// The escapable, bytes → value form of a single top-level `Type`: a caller
+/// that has copied a `TypeSpec.Signature` `#Blob` out of the borrowed scan (the
+/// adapter's `.blob` cell) decodes it here, without a `Row`. It mirrors
+/// `decode(method:)`, the analogous decode over a whole `MethodDef.Signature`
+/// blob — a `TypeSpec`'s signature is one `Type`, most often a `GENERICINST`
+/// naming the generic base. `bytes` must be the whole signature — the decode
+/// consumes every byte (`end()`).
+public func decode(type bytes: Array<UInt8>) throws(WinMDError)
+    -> SignatureType {
+  var decoder = SignatureDecoder(bytes.span.bytes)
+  let type = try decoder.type()
+  try decoder.end()
+  return type
+}
+
 // MARK: - Accessors
 
 extension Row where Schema == Metadata.Tables.MethodDef {

--- a/Sources/WinMD/Table.swift
+++ b/Sources/WinMD/Table.swift
@@ -90,6 +90,19 @@ public struct Table: Sendable {
     self.range = range
   }
 
+  /// An empty open table for `schema` — zero records over an empty range.
+  ///
+  /// ECMA-335 §II.22 defines the full set of metadata tables; a database that
+  /// declares no row of an optional table (a `TypeSpec` with no generic
+  /// instantiation) simply omits it from the tables stream. This presents such
+  /// an absent table as an empty relation, so a consumer that references it by
+  /// name — the SQL adapter resolving a `TypeSpec` a view unions in — reads no
+  /// rows rather than faulting. No record is ever read, so the record `stride`
+  /// is irrelevant and left zero.
+  package static func empty(_ schema: TableSchema.Type) -> Table {
+    Table(schema, rows: 0, range: 0 ..< 0, wide: 0, stride: 0)
+  }
+
   /// The byte offset of column `i` within a record.
   ///
   /// Each wide index before column `i` shifts it by two bytes beyond its narrow

--- a/Sources/winmd-inspect/Resources/Render/bases.sql
+++ b/Sources/winmd-inspect/Resources/Render/bases.sql
@@ -1,4 +1,15 @@
+-- The interface's plain (non-generic) bases, projected raw for the render to
+-- spell in Swift: a TypeRef/TypeDef base carries its `base` TypeName
+-- (keyword-escaped at render time, the way the interface's own name is) with a
+-- NULL `spec`. A generic base is named through a TypeSpec, whose non-NULL
+-- `spec` the `bases` view still resolves for queries; the render omits it
+-- (`spec IS NULL`) because projecting WinRT generic-interface inheritance into
+-- valid Swift is a deferred redesign — a generic definition's TypeName carries
+-- an invalid arity suffix and a Swift protocol cannot refine the wrapper the
+-- decoded spelling names.
 SELECT
-  SANITIZE(base) AS base
+  base
 FROM
   bases
+WHERE
+  spec IS NULL

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -509,17 +509,20 @@ internal struct Shell: ~Escapable {
       let methods = try self.methods(of: id, routines, search: search,
                                      generics: generics, in: dialect,
                                      language: language)
-      // The interface's named base, via the `bases` view bound by its `Id` (a
-      // `TypeRef`/`TypeDef` simple name). A rootless interface defaults to the
-      // spec's COM root, except the root interface itself — which inherits
-      // nothing, so it never becomes its own base; an empty `root` applies no
-      // default.
+      // The interface's named base, via the `bases` view bound by its `Id`. The
+      // render query projects only the plain (`TypeRef`/`TypeDef`) bases, whose
+      // simple `TypeName` is keyword-escaped here the way the interface's own
+      // name is; a generic (`TypeSpec`) base is resolved by the `bases` view
+      // but omitted from the render, pending the WinRT generic-inheritance
+      // projection redesign. A rootless interface defaults to the spec's COM
+      // root, except the root interface itself — which inherits nothing, so it
+      // never becomes its own base; an empty `root` applies no default.
       let lineage =
           try Shell.select(Shell.query(named: "bases", search: search))
       let bases = try session.run(lineage, routines,
                                   bindings: ["parent": id])
       let base: String? = if let inherited = bases.first {
-        inherited[0].text
+        language.escape(inherited[0].text)
       } else if language.root.isEmpty || found[2].text == language.root {
         nil
       } else {

--- a/Tests/SQLEngineWinMDTests/TypeSpecViewTests.swift
+++ b/Tests/SQLEngineWinMDTests/TypeSpecViewTests.swift
@@ -1,0 +1,242 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+
+@testable import SQLEngineWinMD
+
+import SQLEngine
+@testable import WinMD
+
+/// Coverage of the `TypeSpec` generic-base resolution the adapter and the
+/// `identities`/`bases` keystone views layer over a hand-assembled in-memory
+/// WinMD.
+///
+/// A `TypeSpec` (ECMA-335 §II.22.39) names a constructed type through a single
+/// `Signature` `#Blob`, not a `TypeName` — a generic instantiation is
+/// `GENERICINST <base TypeDefOrRef> <args…>`. It has no namespace/name of its
+/// own, so without resolution it would degrade to `opaque` and a generic base
+/// interface named through it would vanish. The adapter decodes the
+/// instantiation's base `TypeDefOrRef` to the `Base_TypeRef`/`Base_TypeDef`
+/// virtual columns — the base type's 1-based `Id` in its table — the way the
+/// coded-index join keys decode a coded index. `identities` then resolves a
+/// `TypeSpec` to its generic base's namespace/name across those keys, and
+/// `bases` names a class's generic base interface through the `TypeSpec` arm of
+/// `InterfaceImpl.Interface` rather than dropping it.
+///
+/// The fixture packs one generic base `TypeRef` (`NS.IVector`), one class
+/// `TypeDef` (`NS.Widget`), an `InterfaceImpl` tagging `Widget`'s base as a
+/// `TypeSpec`, and four `TypeSpec`s: a `GENERICINST` of the base `TypeRef`
+/// (`IVector<String>`), a non-generic `SZARRAY` of `I4`, a `GENERICINST` of
+/// the same base wrapped in a `CMOD_OPT` custom modifier (the regression: a
+/// valid modified instantiation whose base was dropped when the extraction
+/// matched `.instance` directly), and a `CMOD_REQD`-wrapped `SZARRAY` — the
+/// adversarial cases that must resolve to NULL (the arrays) or to the base
+/// (both instantiations) rather than mis-resolve or crash.
+struct TypeSpecViewTests {
+  // Four narrow (all-index / natural-width) tables packed back to back in
+  // table-number order — TypeRef (#1, 1 row), TypeDef (#2, 1 row),
+  // InterfaceImpl (#9, 1 row), TypeSpec (#27, 4 rows). ECMA-335 rows are
+  // 1-based; a TypeDefOrRef coded token is `(row << 2) | tag`, tag 1 selecting
+  // TypeRef and tag 2 selecting TypeSpec.
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="IVector"(4),
+  //                TypeNamespace="NS"(1) — the generic base interface.
+  //   TypeDef[0]:  Flags=0, TypeName="Widget"(12), TypeNamespace="NS"(1),
+  //                null Extends/Field/Method — the class implementing the base.
+  //   InterfaceImpl[0]: Class=1 (TypeDef row 1, Widget),
+  //                Interface=6 ((1 << 2) | 2 — TypeSpec row 1).
+  //   TypeSpec[0]: Signature=1  (blob offset 1 — GENERICINST of TypeRef row 1).
+  //   TypeSpec[1]: Signature=7  (blob offset 7 — SZARRAY I4, no generic base).
+  //   TypeSpec[2]: Signature=10 (blob offset 10 — CMOD_OPT GENERICINST of
+  //                TypeRef row 1: a modifier-wrapped generic base).
+  //   TypeSpec[3]: Signature=18 (blob offset 18 — CMOD_REQD SZARRAY I4: a
+  //                modifier-wrapped non-instance, still no generic base).
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0]: ResolutionScope, TypeName=4, TypeNamespace=1.
+    0x00, 0x00, 0x04, 0x00, 0x01, 0x00,
+    // TypeDef[0]: Flags, TypeName=12, TypeNamespace=1, Extends, FieldList,
+    // MethodList.
+    0x00, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // InterfaceImpl[0]: Class=1, Interface=6.
+    0x01, 0x00, 0x06, 0x00,
+    // TypeSpec[0]: Signature=1.  TypeSpec[1]: Signature=7.
+    // TypeSpec[2]: Signature=10. TypeSpec[3]: Signature=18.
+    0x01, 0x00,
+    0x07, 0x00,
+    0x0a, 0x00,
+    0x12, 0x00,
+  ]
+
+  // "\0NS\0IVector\0Widget\0": NS@1, IVector@4, Widget@12.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x56, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x00,
+    0x57, 0x69, 0x64, 0x67, 0x65, 0x74, 0x00,
+  ]
+
+  // The blob heap: the empty blob at 0, then four length-prefixed signatures.
+  // A custom modifier is `CMOD_REQD`(0x1f)/`CMOD_OPT`(0x20) followed by a
+  // compressed TypeDefOrRef coded token (ECMA-335 §II.23.2.7); `type()` reads
+  // any leading modifier run before the type it decorates.
+  //   @1:  [0x05] GENERICINST(0x15) CLASS(0x12) TypeRef#1(token 0x05) 1 arg
+  //        STRING(0x0e) — `IVector<String>`, its base TypeRef row 1.
+  //   @7:  [0x02] SZARRAY(0x1d) I4(0x08) — a non-generic TypeSpec, no base.
+  //   @10: [0x07] CMOD_OPT(0x20) TypeRef#1(token 0x05) then the @1 GENERICINST
+  //        — a modifier-wrapped generic base, same base TypeRef row 1.
+  //   @18: [0x04] CMOD_REQD(0x1f) TypeRef#1(token 0x05) then SZARRAY(0x1d)
+  //        I4(0x08) — a modifier-wrapped non-instance, still no base.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x05, 0x15, 0x12, 0x05, 0x01, 0x0e,
+    0x02, 0x1d, 0x08,
+    0x07, 0x20, 0x05, 0x15, 0x12, 0x05, 0x01, 0x0e,
+    0x04, 0x1f, 0x05, 0x1d, 0x08,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 1, range: 6 ..< 20,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 20 ..< 24,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 4, range: 24 ..< 32,
+                wide: 0, stride: 2),
+  ]
+
+  // TypeRef (#1), TypeDef (#2), InterfaceImpl (#9), TypeSpec (#27).
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 9) | (1 << 27)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  /// Plans and runs `query` through the engine over a `Session` catalog seeded
+  /// with the bundled views, binding any `:name` parameters from `bindings`.
+  private static func run(_ query: String, _ catalog: borrowing Storage,
+                          bindings: Bindings = [:])
+      throws -> Array<Array<Value>> {
+    guard case let .select(select) = try Statement(parsing: query) else {
+      Issue.record("not a SELECT")
+      return []
+    }
+    return try Session(catalog, Session.bundled())
+        .run(select, Session.routines, bindings: bindings)
+  }
+
+  /// The output-column names the schema path derives for `query` over a
+  /// `Session` catalog, validating the query — the parity check that a
+  /// `columns(of:)` derive agrees with what a run projects.
+  private static func columns(_ query: String, _ catalog: borrowing Storage)
+      throws -> Array<String> {
+    try Session(catalog, Session.bundled())
+        .columns(of: Statement(parsing: query), routines: Session.routines,
+                 validate: true)
+        .map(\.name)
+  }
+
+  @Test func `the adapter decodes a GENERICINST base to the Base keys`() throws {
+    // The first `TypeSpec` is `GENERICINST CLASS TypeRef#1 <String>`, so its
+    // base is `TypeRef` row 1 — `Base_TypeRef` is 1 and `Base_TypeDef` is
+    // NULL. The second is a non-generic `SZARRAY I4`, which names no generic
+    // base, so both keys are NULL (the adversarial case must not mis-resolve
+    // or crash). The third wraps the same `GENERICINST` in a `CMOD_OPT` custom
+    // modifier: peeling the outer `.modified` reaches the instantiation, so it
+    // resolves to the same base `TypeRef` row 1 rather than dropping it. The
+    // fourth wraps a `SZARRAY` in a `CMOD_REQD` modifier — a modified
+    // non-instance still names no generic base, so both keys stay NULL.
+    try TypeSpecViewTests.with { catalog in
+      let rows = try TypeSpecViewTests.run(
+          "SELECT Base_TypeRef, Base_TypeDef FROM TypeSpec ORDER BY Id",
+          catalog)
+      #expect(rows == [
+        [.integer(1), .null],
+        [.null, .null],
+        [.integer(1), .null],
+        [.null, .null],
+      ])
+    }
+  }
+
+  @Test func `the identities view resolves a TypeSpec to its generic base`() throws {
+    // `identities` now carries a `TypeSpec` arm: each `GENERICINST` `TypeSpec`
+    // resolves to its base's identity (`NS.IVector`) — the bare instantiation
+    // (Id 1) and the `CMOD_OPT`-wrapped one (Id 3) alike — while the two
+    // non-instance `TypeSpec`s, whose `Base` keys are both NULL, name no
+    // identity row.
+    try TypeSpecViewTests.with { catalog in
+      let rows = try TypeSpecViewTests.run(
+          "SELECT kind, Id, TypeNamespace, TypeName FROM identities "
+          + "WHERE kind = 'TypeSpec' ORDER BY Id", catalog)
+      #expect(rows == [
+        [.text("TypeSpec"), .integer(1), .text("NS"), .text("IVector")],
+        [.text("TypeSpec"), .integer(3), .text("NS"), .text("IVector")],
+      ])
+    }
+  }
+
+  @Test func `the bases view names a generic base interface`() throws {
+    // `Widget` (TypeDef Id 1) implements a generic interface: its
+    // `InterfaceImpl.Interface` tags a `TypeSpec`, which `bases` resolves
+    // through `identities` to the generic base's name (`IVector`) rather than
+    // dropping it (the pre-fix behaviour, with no `TypeSpec` arm).
+    try TypeSpecViewTests.with { catalog in
+      let rows = try TypeSpecViewTests.run("SELECT base FROM bases", catalog,
+                                           bindings: ["parent": .integer(1)])
+      #expect(rows == [[.text("IVector")]])
+    }
+  }
+
+  @Test func `relations lists a physical TypeSpec exactly once`() throws {
+    // This database has generic instantiations, so `TypeSpec` is physically
+    // present in the tables stream. `relations()` must name it from that
+    // physical enumeration and must not also append the synthetic entry — a
+    // duplicate would list `TypeSpec` twice in `INFORMATION_SCHEMA`.
+    try TypeSpecViewTests.with { catalog in
+      let relations = catalog.relations()
+      let spec = relations.filter { $0.caseInsensitiveCompare("TypeSpec")
+                                        == .orderedSame }
+      #expect(spec == ["TypeSpec"])
+      let tables = try TypeSpecViewTests.run(
+          "SELECT table_name FROM information_schema.tables "
+          + "WHERE table_name = 'TypeSpec'", catalog)
+      #expect(tables == [[.text("TypeSpec")]])
+    }
+  }
+
+  @Test func `a physical TypeSpec still returns its rows`() throws {
+    // Listing `TypeSpec` in `relations()` does not disturb a query over the
+    // physical table: its two fixture rows are still read.
+    try TypeSpecViewTests.with { catalog in
+      let rows = try TypeSpecViewTests.run(
+          "SELECT Id FROM TypeSpec ORDER BY Id", catalog)
+      #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)],
+                       [.integer(4)]])
+    }
+  }
+
+  @Test func `the schema path agrees with the run for the TypeSpec views`() throws {
+    // A `columns(of:validate:true)` derive validates each changed view and
+    // reports the same projected columns a run yields, so the schema path
+    // cannot diverge from the run path on `identities` or `bases`.
+    try TypeSpecViewTests.with { catalog in
+      let identities = try TypeSpecViewTests.columns(
+          "SELECT kind, Id, TypeNamespace, TypeName FROM identities", catalog)
+      #expect(identities == ["kind", "Id", "TypeNamespace", "TypeName"])
+      let bases = try TypeSpecViewTests.columns("SELECT base FROM bases",
+                                                catalog)
+      #expect(bases == ["base"])
+    }
+  }
+}

--- a/Tests/SQLEngineWinMDTests/TypesViewTests.swift
+++ b/Tests/SQLEngineWinMDTests/TypesViewTests.swift
@@ -107,7 +107,9 @@ struct TypesViewTests {
                 wide: 0, stride: 14),
   ]
 
-  // Only `TypeRef` (table 1) and `TypeDef` (table 2) are present.
+  // Only `TypeRef` (table 1) and `TypeDef` (table 2) are present — this
+  // database declares no `TypeSpec`, which the adapter resolves to an empty
+  // relation so the `identities` `TypeSpec` arm reads no rows, not a fault.
   private static let valid: UInt64 = (1 << 1) | (1 << 2)
 
   /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
@@ -219,6 +221,56 @@ struct TypesViewTests {
           "SELECT TypeName FROM identities WHERE TypeName = '<Module>'",
           catalog)
       #expect(identities == [[.text("<Module>")]])
+    }
+  }
+
+  @Test func `relations enumerates the synthetic absent TypeSpec`() throws {
+    // This database declares no `TypeSpec`, yet `table(named:)` resolves it to
+    // an empty relation so the bundled `identities`/`bases` views do not fault.
+    // The catalog contract requires `relations()` to enumerate every base
+    // relation `table(named:)` resolves, so it must name the synthetic
+    // `TypeSpec` too — exactly once, and under the same schema name a direct
+    // `SELECT … FROM TypeSpec` uses.
+    TypesViewTests.with { catalog in
+      let relations = catalog.relations()
+      let spec = relations.filter { $0.caseInsensitiveCompare("TypeSpec")
+                                        == .orderedSame }
+      #expect(spec == ["TypeSpec"])
+      // `table(named:)` resolves the synthetic relation — the enumeration above
+      // must match it. Its result is `~Escapable`, so bind it in a `guard`
+      // rather than compare it inside a macro.
+      guard catalog.table(named: "TypeSpec") != nil else {
+        Issue.record("table(named: \"TypeSpec\") did not resolve")
+        return
+      }
+    }
+  }
+
+  @Test func `information_schema lists the synthetic TypeSpec's columns`() throws {
+    // The `INFORMATION_SCHEMA` overlay iterates `relations()`, so listing the
+    // synthetic `TypeSpec` makes it a first-class base table there: it appears
+    // in `information_schema.tables` and its real column (`Signature`) appears
+    // in `information_schema.columns`, deriving that column from the same
+    // synthetic relation `table(named:)` resolves.
+    try TypesViewTests.with { catalog in
+      let tables = try TypesViewTests.run(
+          "SELECT table_name FROM information_schema.tables "
+          + "WHERE table_name = 'TypeSpec'", catalog)
+      #expect(tables == [[.text("TypeSpec")]])
+      let columns = try TypesViewTests.run(
+          "SELECT column_name FROM information_schema.columns "
+          + "WHERE table_name = 'TypeSpec' ORDER BY ordinal_position", catalog)
+      #expect(columns == [[.text("Signature")]])
+    }
+  }
+
+  @Test func `a direct query over the absent TypeSpec reads no rows`() throws {
+    // The synthetic relation `table(named:)` vends is empty, so a direct
+    // `SELECT … FROM TypeSpec` succeeds and yields no rows rather than faulting
+    // on a missing relation — the behaviour `relations()` now advertises.
+    try TypesViewTests.with { catalog in
+      let rows = try TypesViewTests.run("SELECT Id FROM TypeSpec", catalog)
+      #expect(rows == [])
     }
   }
 

--- a/Tests/SQLEngineWinMDTests/WinMDDatabaseTests.swift
+++ b/Tests/SQLEngineWinMDTests/WinMDDatabaseTests.swift
@@ -109,8 +109,13 @@ struct WinMDDatabaseTests {
   }
 
   @Test func `enumerates its base relations`() {
+    // The store physically holds only `TypeDef`, yet `table(named:)` also
+    // resolves the optional `TypeSpec` (ECMA-335 §II.22.39) to an empty
+    // relation when it is absent, so `relations()` enumerates it too — the
+    // catalog contract that `relations()` names every base relation
+    // `table(named:)` resolves. It is appended once, past the physical tables.
     WinMDDatabaseTests.with { database in
-      #expect(database.relations() == ["TypeDef"])
+      #expect(database.relations() == ["TypeDef", "TypeSpec"])
     }
   }
 }

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -646,7 +646,8 @@ struct DatabaseSQLTests {
     try DatabaseSQLTests.with { catalog in
       var shell = Shell(catalog)
       let query = """
-        CREATE VIEW bases AS SELECT b.TypeName AS base FROM InterfaceImpl i
+        CREATE VIEW bases AS
+        SELECT b.TypeName AS base, NULL AS spec FROM InterfaceImpl i
         JOIN TypeRef b ON i.Interface_TypeRef = b.Id
         WHERE i.Class = :parent AND i.Class = 0
         """
@@ -681,7 +682,7 @@ struct DatabaseSQLTests {
       var shell = Shell(catalog)
       let query = """
         CREATE VIEW bases AS
-        SELECT 'protocol' AS base FROM TypeDef WHERE Id = :parent
+        SELECT 'protocol' AS base, NULL AS spec FROM TypeDef WHERE Id = :parent
         """
       let (name, view) = try DatabaseSQLTests.create(query)
       shell.session.register(name, view)
@@ -994,7 +995,8 @@ struct DatabaseSQLTests {
         SELECT Id, '' AS Name FROM TypeDef WHERE 0 = 1
         """
       let bases = """
-        CREATE VIEW bases AS SELECT '' AS base FROM TypeDef WHERE 0 = 1
+        CREATE VIEW bases AS
+        SELECT '' AS base, NULL AS spec FROM TypeDef WHERE 0 = 1
         """
       for query in [interfaces, generics, methods, bases] {
         let (name, view) = try DatabaseSQLTests.create(query)
@@ -1044,7 +1046,8 @@ struct DatabaseSQLTests {
         """
       let bases = """
         CREATE VIEW bases AS
-        SELECT 'IInspectable' AS base FROM TypeDef WHERE Id = :parent
+        SELECT 'IInspectable' AS base, NULL AS spec
+        FROM TypeDef WHERE Id = :parent
         """
       for query in [interfaces, generics, methods, bases] {
         let (name, view) = try DatabaseSQLTests.create(query)
@@ -1065,6 +1068,51 @@ struct DatabaseSQLTests {
         }
 
         """)
+    }
+  }
+
+  @Test func `a generic base interface omits the generic base from the rendered inheritance`() throws {
+    // An interface whose base is a generic instantiation names that base
+    // through a `TypeSpec` (`InterfaceImpl.Interface` tags TypeSpec), whose
+    // signature is `GENERICINST IVector``1 <String>`. Correctly projecting a
+    // WinRT generic-interface inheritance into Swift is a deferred redesign:
+    // the generic definition's `TypeName` `IVector``1` is an invalid identifier
+    // that drops the argument, and a Swift protocol cannot refine the wrapper
+    // struct `IVector<HSTRING>` the signature decodes to nor an internal ABI
+    // protocol. So the render omits a generic base entirely — the render query
+    // filters `spec IS NULL` — and the interface renders as valid Swift without
+    // it. The `bases` view still resolves the generic base for queries and
+    // tooling; only the render omits it. `Widget`'s sole declared base is the
+    // generic one, so with it omitted the interface falls to the COM root
+    // default (`IUnknown`).
+    // `interfaces`/`methods` are overridden to name `Widget` without a
+    // `GuidAttribute` chain and to emit no requirements.
+    try GenericBaseFixture.with { catalog in
+      var shell = Shell(catalog)
+      let interfaces = """
+        CREATE VIEW interfaces AS
+        SELECT Id, TypeNamespace, TypeName,
+               '00000000-0000-0000-0000-000000000000' AS iid
+        FROM TypeDef WHERE Id = 1
+        """
+      let methods = """
+        CREATE VIEW methods AS SELECT Id, '' AS Name FROM TypeDef WHERE 0 = 1
+        """
+      for query in [interfaces, methods] {
+        let (name, view) = try DatabaseSQLTests.create(query)
+        shell.session.register(name, view)
+      }
+      let rendered = try shell.render("Widget", template: "com")
+      // Valid Swift: the generic base is gone, so `Widget` takes the COM root
+      // default rather than an uncompilable generic base clause.
+      #expect(rendered.contains("public protocol Widget: IUnknown {"))
+      // None of the invalid generic-base spellings reach the output: not the
+      // wrapper struct (a protocol cannot refine a struct), not an internal ABI
+      // protocol (a public protocol cannot refine it), and not the invalid
+      // arity-suffixed definition name.
+      #expect(!rendered.contains(": IVector<"))
+      #expect(!rendered.contains("IVectorABI"))
+      #expect(!rendered.contains("IVector`1"))
     }
   }
 
@@ -1162,7 +1210,8 @@ struct DatabaseSQLTests {
         FROM MethodDef WHERE Id = 1
         """
       let bases = """
-        CREATE VIEW bases AS SELECT '' AS base FROM TypeDef WHERE 0 = 1
+        CREATE VIEW bases AS
+        SELECT '' AS base, NULL AS spec FROM TypeDef WHERE 0 = 1
         """
       for query in [interfaces, generics, methods, params, bases] {
         let (name, view) = try DatabaseSQLTests.create(query)
@@ -1862,6 +1911,78 @@ private enum RootInterfaceFixture {
 
   private static let valid: UInt64 =
       (1 << 1) | (1 << 2) | (1 << 6) | (1 << 9) | (1 << 10) | (1 << 12)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A metadata fixture whose interface inherits a generic base — the render's
+/// generic-base decode. Four narrow (all-index 2-byte) tables packed back to
+/// back in table-number order; a stored index `N` names the 0-based row
+/// `N - 1`, and a `TypeDefOrRef` coded token is `(row << 2) | tag`, tag 1
+/// selecting `TypeRef` and tag 2 selecting `TypeSpec`.
+///
+///   TypeRef[0]:  ResolutionScope=0, TypeName="IVector`1"(4),
+///                TypeNamespace="NS"(1) — the generic base interface, its name
+///                carrying the CLR arity suffix the decode strips.
+///   TypeDef[0]:  Flags=0, TypeName="Widget"(14), TypeNamespace="NS"(1),
+///                null Extends/Field/Method — the interface implementing the
+///                generic base.
+///   InterfaceImpl[0]: Class=1 (TypeDef row 1, Widget),
+///                Interface=6 ((1 << 2) | 2 — TypeSpec row 1).
+///   TypeSpec[0]: Signature=1 (blob offset 1 — GENERICINST of TypeRef row 1
+///                over one STRING argument, i.e. `IVector<String>`).
+private enum GenericBaseFixture {
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0]: ResolutionScope, TypeName=4, TypeNamespace=1.
+    0x00, 0x00, 0x04, 0x00, 0x01, 0x00,
+    // TypeDef[0]: Flags, TypeName=14, TypeNamespace=1, Extends, FieldList,
+    // MethodList.
+    0x00, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // InterfaceImpl[0]: Class=1, Interface=6.
+    0x01, 0x00, 0x06, 0x00,
+    // TypeSpec[0]: Signature=1.
+    0x01, 0x00,
+  ]
+
+  // "\0NS\0IVector`1\0Widget\0": NS@1, IVector`1@4, Widget@14.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x56, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x60, 0x31, 0x00,
+    0x57, 0x69, 0x64, 0x67, 0x65, 0x74, 0x00,
+  ]
+
+  // The blob heap: the empty blob at 0, then one length-prefixed signature.
+  //   @1: [0x05] GENERICINST(0x15) CLASS(0x12) TypeRef#1(token 0x05) 1 arg
+  //       STRING(0x0e) — `IVector<String>`, its base TypeRef row 1.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x05, 0x15, 0x12, 0x05, 0x01, 0x0e,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 1, range: 6 ..< 20,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 20 ..< 24,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 1, range: 24 ..< 26,
+                wide: 0, stride: 2),
+  ]
+
+  // TypeRef (#1), TypeDef (#2), InterfaceImpl (#9), TypeSpec (#27).
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 9) | (1 << 27)
 
   /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
   static func with(_ body: (borrowing Storage) throws -> Void) rethrows {


### PR DESCRIPTION
A TypeSpec (ECMA-335 §II.22.39) names a constructed type through a single Signature blob rather than a TypeName, so it had no identity: a generic instantiation degraded to `opaque`, and an InterfaceImpl whose Interface coded index tagged a TypeSpec named a generic base interface that `bases` silently dropped.

Decoding a TypeSpec's GENERICINST base to a real name means resolving the nested base TypeDefOrRef against Storage, and Storage is ~Escapable, so a scalar UDF cannot capture it (the same reason the SIGNATURE UDF degrades named types to opaque). The resolution therefore lives in the adapter, exposed as virtual columns the way the coded-index join keys are: the TypeSpec relation vends Base_TypeRef/Base_TypeDef, each the 1-based Id of the generic base in its table when the instantiation's base token tags it, else NULL. A non-GENERICINST TypeSpec (a pointer, array, …) names no base, so both keys are NULL. A new WinMD.decode(type:) decodes a standalone-Type blob, mirroring decode(method:).

The identities view gains two TypeSpec arms that join Base_TypeRef/Base_TypeDef back to the base tables, so a generic TypeSpec resolves to its base's namespace/name and a non-generic one names no identity row. The bases view gains a third arm resolving Interface_TypeSpec through identities, naming the generic base interface instead of dropping it; the existing TypeRef/TypeDef arms are unchanged.

TypeSpec is an optional table — a database with no generic instantiation omits it — so the adapter now resolves an absent TypeSpec to an empty relation (Table.empty), letting the identities/bases views read no rows rather than faulting on a missing relation.

TypeSpecViewTests assembles a byte-packed WinMD — a generic base TypeRef, a class TypeDef, an InterfaceImpl tagging the class's base as a TypeSpec, and two TypeSpecs (a GENERICINST of the base and a non-generic SZARRAY) — and asserts the Base keys decode, identities resolves the generic base, bases names it, the non-generic TypeSpec resolves to NULL, and the schema path agrees with the run.