### PR TITLE
SQLEngine: fault incomparable-type comparisons (ISO 42804)

### DIFF
--- a/Sources/SQLEngine/Adapter.swift
+++ b/Sources/SQLEngine/Adapter.swift
@@ -144,6 +144,21 @@ public enum Value: Hashable, Sendable {
 }
 
 extension Value {
+  /// The value kind of a non-NULL value, or `nil` for NULL — the kind the
+  /// comparability classifier reads off a lowered constant. NULL has no kind of
+  /// its own (a NULL comparison is UNKNOWN, never an incomparability fault), so
+  /// it is `nil` rather than a nominal placeholder.
+  internal var kind: ValueType? {
+    switch self {
+    case .null: nil
+    case .integer: .integer
+    case .double: .double
+    case .text: .text
+    case .boolean: .boolean
+    case .blob: .blob
+    }
+  }
+
   /// This value coerced to `type` — the widening a `CASE` (or a defined
   /// function body) applies so a selected branch's raw value matches the
   /// unified result type the schema advertises.

--- a/Sources/SQLEngine/Decorrelation.swift
+++ b/Sources/SQLEngine/Decorrelation.swift
@@ -231,6 +231,14 @@ extension Catalog where Self: ~Escapable {
     // combined slot space), `inner` the equi conjunct's body slot.
     let correlate = (outer: outer, inner: inner)
 
+    // The correlation equality is hoisted to a straddling `.match` — the hash
+    // key the physical join buckets each side by — so decorrelate only when its
+    // two columns' declared types unify; a cross-kind pair would hash into
+    // disjoint buckets and silently match nothing. Bail otherwise, leaving the
+    // apply correlated so the equality routes through `matches` and faults.
+    guard comparable(correlating: correlate.outer, in: left,
+                     to: correlate.inner, scanning: name, scanOrdinals,
+                     context) else { return nil }
     // The scan is relaid after the left, so the body's 0-based scan slots shift
     // by `base` into the combined space. The correlation equality becomes a
     // `.match` (folded to the join key), and the residual `p_R` shifts
@@ -482,6 +490,13 @@ extension Catalog where Self: ~Escapable {
     }
     guard let inner else { return nil }
 
+    // The correlation equality becomes the semijoin's straddling `.match` hash
+    // key, so decorrelate only when its two columns' declared types unify; a
+    // cross-kind pair would hash into disjoint buckets and match nothing,
+    // dropping every left row silently. Bail otherwise, leaving the correlated
+    // `EXISTS`/`IN` select so its equality routes through `matches` and faults.
+    guard comparable(correlating: outer, in: left, to: inner, scanning: name,
+                     scanOrdinals, context) else { return nil }
     // The scan is relaid after the left, so the body's 0-based scan slots shift
     // by `base` into the combined space. The correlation equality becomes a
     // straddling `.match` (the executor's hash key), and the residual `p_R`
@@ -647,6 +662,14 @@ extension Catalog where Self: ~Escapable {
         scanOrdinals[inner] == table.width,
         table.virtuals.first?.lowercased() == "id" else { return nil }
 
+    // The correlation equality becomes the join's straddling `.match` hash key
+    // (its inner side the unique `Id`, an integer row index), so decorrelate
+    // only when the outer column's declared type unifies with the inner's; a
+    // cross-kind pair would hash into disjoint buckets and match nothing. Bail
+    // otherwise, leaving the correlated scalar so its equality routes through
+    // `matches` and faults.
+    guard comparable(correlating: outer, in: left, to: inner, scanning: name,
+                     scanOrdinals, context) else { return nil }
     // The scan is relaid after the left, so the body's 0-based scan slots shift
     // by `base` into the combined space. The correlation equality becomes a
     // straddling `.match` (the executor's hash key), and the residual `p_R`
@@ -661,6 +684,104 @@ extension Catalog where Self: ~Escapable {
     // lands at `base + vSlot` in the combined `left ++ scan` space.
     return (.outer(left, scan, on: on, kind: .left), base + vSlot)
   }
+
+  /// Whether the correlation key `outer = inner` is a comparable pair — the
+  /// straddling `.match` this pass hoists is the physical join key `nest`, the
+  /// bucketed outer join, and the semijoin fast path all hash on, so a
+  /// cross-kind pair (an integer outer against a text inner) hashes the two
+  /// sides into disjoint buckets, compares no candidate row, and would silently
+  /// return no matches — the same silent non-match `Scope.on` guards for a
+  /// `column = column` join key. The inner-body lowering cannot fault it (the
+  /// outer column is an untyped `:parameter` in the body scope), so gate the
+  /// hoist here: decorrelate only when the outer slot's declared type unifies
+  /// with the inner column's (`ValueType.unified`, the notion `Scope.on`, the
+  /// run's `matches`, and `check`'s `comparable` all share). When it does not
+  /// unify — or either type cannot be resolved from the plans — bail: the
+  /// correlated `.apply`/`.select` is left in place, routing the equality
+  /// through the nested-loop `matches`, which faults 42804 on the cross-kind
+  /// pair. A missed decorrelation is a perf loss; a wrong one is data
+  /// corruption, so an unresolved type bails.
+  ///
+  /// `outer` addresses `left`'s combined slot space; `inner` is the body scan's
+  /// slot, reading the base relation `name`'s column `scanOrdinals[inner]`.
+  private borrowing func comparable(correlating outer: Int, in left: Plan,
+                                    to inner: Int, scanning name: String,
+                                    _ scanOrdinals: Array<Int>,
+                                    _ context: Context) -> Bool {
+    guard let l = type(of: left, at: outer, context),
+        let r = type(of: .scan(name: name, ordinals: scanOrdinals,
+                                     seek: nil), at: inner, context),
+        l.unified(with: r) != nil else { return false }
+    return true
+  }
+
+  /// The declared type of the base-relation column the combined `slot` of
+  /// `plan` reads, or `nil` when it traces to none — a computed column, a
+  /// grouped/set-operation/apply slot, or a shape this resolver does not walk.
+  /// It mirrors `Plan.slots`' combined-space arithmetic to descend to the leaf
+  /// scan the slot belongs to, then reads that column's type exactly as
+  /// `Scope.type(at:)` does: a real column's `types` entry (a CTE/store
+  /// overlay binding's, else the base table's), and a virtual ordinal (`Id`,
+  /// an owner foreign key) or an out-of-range one `.integer`, the index type.
+  /// A `nil` result bails the decorrelation gate above (conservatively, never a
+  /// wrong rewrite).
+  private borrowing func type(of plan: Plan, at slot: Int,
+                                    _ context: Context) -> ValueType? {
+    switch plan {
+    case let .scan(name, ordinals, _):
+      guard slot >= 0, slot < ordinals.count else { return nil }
+      return type(of: name, at: ordinals[slot], context)
+    case let .select(_, source):
+      return type(of: source, at: slot, context)
+    case let .distinct(source):
+      return type(of: source, at: slot, context)
+    case let .limit(_, _, source):
+      return type(of: source, at: slot, context)
+    case let .sort(_, source):
+      return type(of: source, at: slot, context)
+    case let .semijoin(left, _, _, _):
+      return type(of: left, at: slot, context)
+    case let .project(terms, source):
+      guard slot >= 0, slot < terms.count,
+          case let .slot(inner) = terms[slot] else { return nil }
+      return type(of: source, at: inner, context)
+    case let .product(left, right):
+      guard let boundary = left.slots else { return nil }
+      return slot < boundary
+          ? type(of: left, at: slot, context)
+          : type(of: right, at: slot - boundary, context)
+    case let .outer(left, right, _, _):
+      guard let boundary = left.slots else { return nil }
+      return slot < boundary
+          ? type(of: left, at: slot, context)
+          : type(of: right, at: slot - boundary, context)
+    case let .join(outer, name, ordinals, base, _, _, _):
+      if slot < base { return type(of: outer, at: slot, context) }
+      let inner = slot - base
+      guard inner >= 0, inner < ordinals.count else { return nil }
+      return type(of: name, at: ordinals[inner], context)
+    default:
+      // A `.derived` view leaf, a `.apply`, an `.aggregate`, a `.setop`, or a
+      // `.single`/`.empty` slot has no single base column this resolver reads —
+      // bail (the gate leaves the apply correlated, a perf loss, never wrong).
+      return nil
+    }
+  }
+
+  /// The declared type of relation `name`'s column at `ordinal` — the CTE/store
+  /// overlay binding's `types` entry when the name binds one, else the base
+  /// table's — mirroring `Scope.type(at:)`: a real column carries its type, a
+  /// virtual (`Id`, owner) or out-of-range ordinal is `.integer`. `nil` only
+  /// when the name resolves to no base relation at all (the caller then bails).
+  private borrowing func type(of name: String, at ordinal: Int,
+                                    _ context: Context) -> ValueType? {
+    if let instance = context.relations[name.lowercased()] {
+      return ordinal < instance.types.count ? instance.types[ordinal]
+                                            : .integer
+    }
+    guard let table = table(named: name) else { return nil }
+    return ordinal < table.types.count ? table.types[ordinal] : .integer
+  }
 }
 
 /// The inner-key slot of an equi correlation conjunct `slot = :parameter` (in
@@ -669,7 +790,16 @@ extension Catalog where Self: ~Escapable {
 /// non-`=` comparison (a non-equi correlation), a compound operand, or a
 /// different parameter is not an equi correlation key and leaves the conjunct
 /// to the residual test (which bails on it as a parameterised non-equi term).
+///
+/// The equi correlation compares a slot to the opaque-kind `:parameter`, so it
+/// is stamped `Filter.incomparable` at lowering; unwrap that stamp to read the
+/// underlying equi shape. The stamp keeps the correlation predicate an
+/// always-evaluated residual on the un-decorrelated path (the run its authority
+/// for the per-run kind); recognising the equi shape here lets the decorrelator
+/// hoist it to the straddling `.match`, where its comparability is decided.
 private func equated(_ conjunct: Filter, to parameter: String) -> Int? {
+  var conjunct = conjunct
+  if case let .incomparable(inner) = conjunct { conjunct = inner }
   guard case let .compare(lhs, .equal, rhs) = conjunct else { return nil }
   switch (lhs, rhs) {
   case let (.slot(slot), .parameter(name)) where name == parameter:

--- a/Sources/SQLEngine/Evaluation.swift
+++ b/Sources/SQLEngine/Evaluation.swift
@@ -132,9 +132,17 @@ extension Comparison {
 /// strings, two booleans (`false < true`), or two blobs (byte equality,
 /// lexicographic order). An integer against a double is numeric too — both
 /// sides are numbers — so the integer promotes to `Double` and they compare by
-/// magnitude (`1 = 1.0` is true); only a cross-*kind* pair (a number against a
-/// string) never matches.
-internal func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool? {
+/// magnitude (`1 = 1.0` is true).
+///
+/// Every remaining pair is cross-*kind* (a number against a string, a boolean
+/// against a blob): ISO 9075 requires a comparison's operands to be of
+/// comparable types, so an incomparable pair is a data-type mismatch
+/// (`SQLError.state` `42804`), not a definite FALSE row. The fault matches the
+/// type-check `Scope.check` raises statically, so the run and `columns(of:
+/// validate:)` agree — an ill-typed comparison faults either way rather than
+/// silently dropping every row.
+internal func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value)
+    throws(SQLError) -> Bool? {
   switch (lhs, rhs) {
   case (.null, _), (_, .null): nil
   case let (.integer(lhs), .integer(rhs)): op.apply(lhs, rhs)
@@ -151,22 +159,57 @@ internal func matches(_ lhs: Value, _ op: Comparison, _ rhs: Value) -> Bool? {
   // `Array` is not `Comparable`, so `=`/`<>` is byte equality and the ordering
   // relations are lexicographic (memcmp) order over the bytes.
   case let (.blob(lhs), .blob(rhs)): op.apply(lhs, rhs)
-  default: false
+  default:
+    throw .state("42804",
+                 "cannot compare \(domain(of: lhs)) with \(domain(of: rhs))")
+  }
+}
+
+/// The ISO domain spelling of a value's type, for a comparability fault
+/// message. NULL never reaches here (`matches` handles it as UNKNOWN before the
+/// incomparable arm).
+private func domain(of value: Value) -> String {
+  switch value {
+  case .null: "null"
+  case .integer: ValueType.integer.domain
+  case .double: ValueType.double.domain
+  case .text: ValueType.text.domain
+  case .boolean: ValueType.boolean.domain
+  case .blob: ValueType.blob.domain
   }
 }
 
 /// Whether two typed values differ under ISO `IS DISTINCT FROM` — the null-safe
 /// comparison, treating NULL as a comparable value. Unlike `matches`, it is
-/// two-valued (never UNKNOWN): two NULLs are the same (not DISTINCT), exactly
-/// one NULL is DISTINCT, and two non-NULLs are DISTINCT unless they are equal —
-/// a cross-kind pair being DISTINCT, as `matches` yields FALSE (`== true` is
-/// false) for cross-kind equality. `IS DISTINCT FROM` returns this; `IS NOT
-/// DISTINCT FROM` (null-safe equality) negates it.
+/// two-valued (never UNKNOWN) AND total (never a fault): two NULLs are the same
+/// (not DISTINCT), exactly one NULL is DISTINCT, and two non-NULLs are DISTINCT
+/// unless they are equal — a cross-kind pair being DISTINCT, where a bare
+/// comparison faults `42804`. `IS DISTINCT FROM` returns this; `IS NOT DISTINCT
+/// FROM` (null-safe equality) negates it.
 internal func distinct(_ lhs: Value, _ rhs: Value) -> Bool {
   switch (lhs, rhs) {
   case (.null, .null): false
   case (.null, _), (_, .null): true
-  case let (lhs, rhs): matches(lhs, .equal, rhs) != true
+  case let (lhs, rhs): !identical(lhs, rhs)
+  }
+}
+
+/// Whether two non-NULL values compare equal, a cross-kind pair reading as
+/// unequal (never a fault) — the equality kernel `IS DISTINCT FROM` folds. It
+/// is kept separate from `matches` so the null-safe comparison stays total
+/// where a bare comparison faults an incomparable pair; the numeric
+/// integer/double promotion still equates by magnitude (`1` is not distinct
+/// from `1.0`).
+private func identical(_ lhs: Value, _ rhs: Value) -> Bool {
+  switch (lhs, rhs) {
+  case let (.integer(lhs), .integer(rhs)): lhs == rhs
+  case let (.double(lhs), .double(rhs)): lhs == rhs
+  case let (.integer(lhs), .double(rhs)): Double(lhs) == rhs
+  case let (.double(lhs), .integer(rhs)): lhs == Double(rhs)
+  case let (.text(lhs), .text(rhs)): lhs == rhs
+  case let (.boolean(lhs), .boolean(rhs)): lhs == rhs
+  case let (.blob(lhs), .blob(rhs)): lhs == rhs
+  default: false
   }
 }
 
@@ -184,19 +227,30 @@ internal func distinct(_ lhs: Value, _ rhs: Value) -> Bool {
 /// by the componentwise equality. A NULL component makes a componentwise test
 /// UNKNOWN, propagated through the Kleene fold.
 internal func relate(_ l: Array<Value>, _ op: Comparison,
-                     _ r: Array<Value>) -> Bool? {
+                     _ r: Array<Value>) throws(SQLError) -> Bool? {
+  // A row comparison is ill-typed — and `Scope.check` rejects it — when any
+  // component pair is of incomparable types, regardless of the values, so the
+  // run must fault the same way rather than let an earlier decisive (or NULL)
+  // component short-circuit the fold past a later incomparable pair: `(N, S) =
+  // (999, N)` over `N != 999` is FALSE at the first component, but the
+  // incomparable `S`/`N` pair still makes the whole comparison a data-type
+  // mismatch. Preflight every component's comparability through `matches` (the
+  // same notion the fold uses — same-kind or numeric integer/double, a NULL
+  // pair exempt) before the short-circuiting Boolean fold; a comparable row
+  // then folds byte-for-byte as before, same result and same short-circuit.
+  for index in l.indices { _ = try matches(l[index], .equal, r[index]) }
   switch op {
   case .equal:
     var truth: Bool? = true
     for index in l.indices {
-      truth = and(truth, matches(l[index], .equal, r[index]))
+      truth = try and(truth, matches(l[index], .equal, r[index]))
       if truth == false { break }
     }
     return truth
   case .unequal:
     var truth: Bool? = true
     for index in l.indices {
-      truth = and(truth, matches(l[index], .equal, r[index]))
+      truth = try and(truth, matches(l[index], .equal, r[index]))
       if truth == false { break }
     }
     return truth.map { !$0 }
@@ -205,9 +259,9 @@ internal func relate(_ l: Array<Value>, _ op: Comparison,
     var cascade: Bool? = nil
     for index in stride(from: l.count - 1, through: 0, by: -1) {
       let last = index == l.count - 1
-      let step = matches(l[index], last ? op : strict, r[index])
+      let step = try matches(l[index], last ? op : strict, r[index])
       if let tail = cascade {
-        let equal = matches(l[index], .equal, r[index])
+        let equal = try matches(l[index], .equal, r[index])
         cascade = or(step, and(equal, tail))
       } else {
         cascade = step
@@ -295,7 +349,7 @@ extension Catalog where Self: ~Escapable {
         nil
       }
     case let .match(left, right):
-      matches(row[left], .equal, row[right])
+      try matches(row[left], .equal, row[right])
     case let .null(term, negated):
       try (evaluate(row, term, context) == .null) != negated
     case let .membership(operand, elements, negated):
@@ -361,6 +415,13 @@ extension Catalog where Self: ~Escapable {
       }
     case let .not(operand):
       try evaluate(row, operand, context).map { !$0 }
+    case let .incomparable(inner):
+      // The stamp is a compile-time reordering barrier only; evaluating it is
+      // evaluating the comparison it wraps, which faults `42804` at run through
+      // `matches`/`relate`/`like` for a non-NULL cross-kind pair (a NULL
+      // operand is UNKNOWN, as any comparison is). The wrapper never changes
+      // the three-valued result — it kept the leaf here to be evaluated at all.
+      try evaluate(row, inner, context)
     }
   }
 
@@ -382,7 +443,7 @@ extension Catalog where Self: ~Escapable {
     var truth: Bool? = false
     for element in elements {
       let element = try evaluate(row, element, context)
-      truth = or(truth, matches(value, .equal, element))
+      truth = try or(truth, matches(value, .equal, element))
       if truth == true { break }
     }
     return negated ? truth.map { !$0 } : truth
@@ -406,7 +467,7 @@ extension Catalog where Self: ~Escapable {
     var r = Array<Value>()
     r.reserveCapacity(rhs.count)
     for term in rhs { try r.append(evaluate(row, term, context)) }
-    return relate(l, op, r)
+    return try relate(l, op, r)
   }
 
   /// Evaluates a lowered `(l…) [NOT] IN ((r…), …)` row-value membership against
@@ -432,7 +493,7 @@ extension Catalog where Self: ~Escapable {
       var r = Array<Value>()
       r.reserveCapacity(element.count)
       for term in element { try r.append(evaluate(row, term, context)) }
-      truth = or(truth, relate(l, .equal, r))
+      truth = try or(truth, relate(l, .equal, r))
       if truth == true { break }
     }
     return negated ? truth.map { !$0 } : truth
@@ -461,7 +522,7 @@ extension Catalog where Self: ~Escapable {
     for term in lhs { try l.append(evaluate(row, term, context)) }
     var truth: Bool? = false
     for element in tuples {
-      truth = or(truth, relate(l, .equal, element))
+      truth = try or(truth, relate(l, .equal, element))
       if truth == true { break }
     }
     return negated ? truth.map { !$0 } : truth
@@ -491,7 +552,7 @@ extension Catalog where Self: ~Escapable {
     for term in lhs { try l.append(evaluate(row, term, context)) }
     var truth: Bool? = quantifier == .any ? false : true
     for element in tuples {
-      let matched = relate(l, op, element)
+      let matched = try relate(l, op, element)
       switch quantifier {
       case .any:
         truth = or(truth, matched)
@@ -509,16 +570,16 @@ extension Catalog where Self: ~Escapable {
   /// The `test` term is evaluated once per row — an `AND`/`OR` of two
   /// comparisons would re-evaluate a non-idempotent test once per bound — then
   /// the two bounds fold against that same value under Kleene logic as `test >=
-  /// lower AND test <= upper`. `NOT BETWEEN` is the negation of that same
-  /// truth, NOT the `test < lower OR test > upper` expansion: with a cross-kind
-  /// bound `matches` yields FALSE for every ordering operator (so `test <
-  /// lower` is not the complement of `test >= lower`), and the expansion would
-  /// diverge from `NOT (test BETWEEN lower AND upper)` — e.g. `K NOT BETWEEN
-  /// 'a' AND 10` must KEEP the row (the cross-kind `K >= 'a'` is FALSE, so
-  /// BETWEEN is FALSE and its negation TRUE), which the expansion's two FALSE
-  /// ordering checks would wrongly reject. A NULL `test`, `lower`, or `upper`
-  /// makes a bound UNKNOWN (`matches` yields `nil`), so the row is excluded —
-  /// the ISO three-valued range semantics.
+  /// lower AND test <= upper`. `NOT BETWEEN` is the negation of that truth, not
+  /// the `test < lower OR test > upper` expansion: the two spellings diverge on
+  /// a NULL bound (`test >= lower` UNKNOWN is not the complement of `test <
+  /// lower`), so `NOT BETWEEN` negates the single `BETWEEN` truth to stay
+  /// consistent. A cross-kind bound (`test >= 'a'` against a numeric `test`) is
+  /// a data-type mismatch that `matches` faults `42804`, not a FALSE — the ISO
+  /// comparability rule — so `K BETWEEN 'a' AND 10` faults rather than dropping
+  /// the row. A NULL `test`, `lower`, or `upper` makes a bound UNKNOWN
+  /// (`matches` yields `nil`), so the row is excluded — the ISO three-valued
+  /// range semantics.
   ///
   /// The `upper` bound is evaluated ONLY when the lower does not already settle
   /// the truth: a definitely-FALSE `test >= lower` makes BETWEEN FALSE (and NOT
@@ -538,10 +599,10 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Bool? {
     let value = try evaluate(row, test, context)
     let low = try evaluate(row, lower, context)
-    let above = matches(value, .geq, low)
+    let above = try matches(value, .geq, low)
     if above == false { return negated }
     let high = try evaluate(row, upper, context)
-    let within = and(above, matches(value, .leq, high))
+    let within = try and(above, matches(value, .leq, high))
     return negated ? within.map { !$0 } : within
   }
 
@@ -586,10 +647,11 @@ extension Catalog where Self: ~Escapable {
   /// silently swallowed by a NULL escape. Only once all three have evaluated is
   /// the result decided: a non-NULL escape that is not a single character is
   /// `SQLError.argument` (the ISO rule); a NULL operand, pattern, or escape is
-  /// UNKNOWN (`nil`), the row excluded; a non-text operand or pattern is a
-  /// definite non-match (FALSE), mirroring the engine's cross-kind comparison
-  /// rule (`Row.matches`) rather than faulting. Otherwise the pattern runs
-  /// against the operand through the `%`/`_` matcher. The pattern and escape
+  /// UNKNOWN (`nil`), the row excluded; a non-NULL non-character operand or
+  /// pattern is a data-type mismatch — ISO `LIKE` requires character operands —
+  /// so it faults `SQLError.state` `42804`, mirroring the engine's cross-kind
+  /// rule (`matches`) and the type-check `Scope.check`. Otherwise the pattern
+  /// runs against the operand through the `%`/`_` matcher. The escape
   /// may be a `:parameter` resolved from the bindings. `NOT LIKE` negates the
   /// result (UNKNOWN maps to itself).
   private borrowing func like(_ row: borrowing some Row & ~Escapable,
@@ -621,16 +683,19 @@ extension Catalog where Self: ~Escapable {
       throw .argument("LIKE ESCAPE must be a single character")
     }
 
-    let truth: Bool? = switch (subject, template, separator) {
+    let truth: Bool?
+    switch (subject, template, separator) {
     // A NULL operand, pattern, or escape is UNKNOWN.
     case (.null, _, _), (_, .null, _), (_, _, .some(.null)):
-      nil
+      truth = nil
     case let (.text(subject), .text(template), _):
-      matches(subject, template, escape: character)
-    // A non-text operand or pattern never matches — the engine's cross-kind
-    // comparison rule — so the run is a definite non-match, not a fault.
+      truth = matches(subject, template, escape: character)
+    // A non-NULL, non-character operand or pattern is a data-type mismatch: ISO
+    // `LIKE` requires character operands, so the run faults `42804` (matching
+    // the engine's cross-kind comparison rule and `Scope.check`), not a silent
+    // FALSE row.
     default:
-      false
+      throw .state("42804", "LIKE requires character operands")
     }
     return negated ? truth.map { !$0 } : truth
   }

--- a/Sources/SQLEngine/Filter.swift
+++ b/Sources/SQLEngine/Filter.swift
@@ -74,9 +74,9 @@ internal indirect enum Filter: Equatable, Sendable {
   /// LIKE`. The runtime reads the operand and pattern text and runs the `%`/`_`
   /// matcher (a linear two-pointer match, `%` matching any run and `_` exactly
   /// one character, an escape character taking the next character literally); a
-  /// NULL operand, pattern, or escape is UNKNOWN and a non-text operand or
-  /// pattern is a definite non-match (the engine's cross-kind rule), with `NOT
-  /// LIKE` negating the three-valued result (UNKNOWN maps to itself).
+  /// NULL operand, pattern, or escape is UNKNOWN and a non-NULL non-character
+  /// operand or pattern faults `42804` (ISO `LIKE` wants character operands),
+  /// with `NOT LIKE` negating the three-valued result (UNKNOWN maps to itself).
   case like(Term, pattern: Operand, escape: Operand?, negated: Bool)
   /// `x [NOT] BETWEEN a AND b` — the lowered form of the AST's `between`. The
   /// test term `x` is held once, the two bounds `a` and `b` beside it — each an
@@ -93,9 +93,9 @@ internal indirect enum Filter: Equatable, Sendable {
   /// predicate) and `negated` marks the `IS NOT DISTINCT FROM` (null-safe
   /// equality) spelling. Evaluating it is two-valued — never UNKNOWN — treating
   /// NULL as a comparable value: the two are the same iff both are NULL, or
-  /// both non-NULL and equal (a cross-kind pair is DISTINCT, matching
-  /// `matches`'s cross-kind FALSE equality), and `IS DISTINCT FROM` is TRUE
-  /// when they differ, `IS NOT DISTINCT FROM` when they are the same.
+  /// both non-NULL and equal (a cross-kind pair is DISTINCT, never a fault —
+  /// the null-safe comparison is total where a bare comparison faults), and `IS
+  /// DISTINCT FROM` is TRUE when they differ, `IS NOT DISTINCT FROM` when same.
   case distinct(Term, Term, negated: Bool)
   /// `[NOT] EXISTS (Q)` — the lowered form of the AST's `exists`. The subquery
   /// occurrence is carried as its cache `Subkey` (its resolution scope composed
@@ -157,6 +157,22 @@ internal indirect enum Filter: Equatable, Sendable {
   case or(Filter, Filter)
   /// `NOT operand`.
   case not(Filter)
+  /// A throwable comparison leaf the typed scope proved incomparable under the
+  /// ISO 9075 comparability rule — a cross-kind `compare`/`comparison`/
+  /// `membership`/`memberships`/`between`, or a non-character `LIKE` — wrapping
+  /// the same leaf it classifies (never a connective). The classification is
+  /// computed once at lowering (`stamped`, where `Scope`/`Schema` know the
+  /// operand types) and carried into the untyped physical layer, so `safe`
+  /// reports the leaf throws `42804` (as an ill-typed divide does) without the
+  /// optimiser recomputing type information it does not have. Because the
+  /// wrapper sits below the `and` above the leaf, `conjuncts` still splits into
+  /// individual conjuncts and the optimiser reads one unsafe conjunct;
+  /// `remapped` re-wraps the remapped inner (slot renumbering does not change
+  /// comparability), and every other traversal recurses into the inner.
+  /// Evaluating it evaluates the inner, which faults `42804` at run exactly as
+  /// the un-optimised plan does — never dropped over an emptied seek, never
+  /// pushed past a row-dropping operator.
+  case incomparable(Filter)
 
   /// The lowered pattern or escape operand of a `Filter.like`: a `Term`
   /// evaluated per row, or a run-time `:parameter` resolved from the engine's
@@ -574,6 +590,19 @@ extension Filter.Operand {
     }
   }
 
+  /// Whether this `LIKE` pattern or escape operand is a constant NULL — the run
+  /// reads it as UNKNOWN (`Row.like`'s `(_, _, .some(.null))` / NULL-pattern
+  /// arm) before any character-type or single-character check, so it never
+  /// faults, and the whole `LIKE` is UNKNOWN. The NULL-first rule the
+  /// comparability stamp (`vanishes`) and `Scope.check` follow, lifted here for
+  /// `Filter.safe`. A `:parameter` is per-run and not NULL-determined (it may
+  /// bind a non-NULL cross-kind value, or a bad-length escape, the run faults
+  /// on), so it does not vanish — matching the stamp's parameter rule.
+  internal var vanishes: Bool {
+    if case .term(.constant(.null)) = self { return true }
+    return false
+  }
+
   /// Whether this operand reads a run-time `:parameter` — a `.parameter` is one
   /// (it may be unbound or bound to NULL, so a `LIKE` over it is UNKNOWN), and
   /// a `.term` is one when its `Term` itself carries a correlated
@@ -653,6 +682,11 @@ extension Filter {
       .or(lhs.remapped(through: slot), rhs.remapped(through: slot))
     case let .not(operand):
       .not(operand.remapped(through: slot))
+    case let .incomparable(inner):
+      // Slot renumbering never changes comparability, so re-wrap the remapped
+      // inner rather than reclassifying — the carried bit travels verbatim
+      // through the combined-space remap the optimiser applies.
+      .incomparable(inner.remapped(through: slot))
     }
   }
 
@@ -726,17 +760,24 @@ extension Filter {
       lhs.allSatisfy(\.safe) && rows.allSatisfy { $0.allSatisfy(\.safe) }
     case let .like(operand, pattern, escape, _):
       // An escape makes the predicate unsafe unless it is statically a valid
-      // single-character escape: `Row.like` faults (`SQLError.argument`) on any
-      // escape that does not evaluate to a one-character text — a throw
-      // independent of whether a pair matches, so it must not ride below a seek
-      // or join and fire on an empty product (or be dropped by a hash key). A
-      // non-constant escape (a slot or call) or a constant that is NULL,
-      // non-text, or the wrong length is unsafe; only a `.constant` text of
-      // exactly one character (`escape.escape`) is safe. Plain LIKE (no escape)
-      // stays safe — the matcher itself never throws, a non-text operand or
-      // pattern being a definite non-match and a NULL UNKNOWN.
+      // single-character escape, or a constant NULL: `Row.like` faults
+      // (`SQLError.argument`) on any non-NULL escape that does not evaluate to
+      // a one-character text — a throw independent of whether a pair matches,
+      // so it must not ride below a seek or join and fire on an empty product
+      // (or be dropped by a hash key). A non-constant escape (a slot or call)
+      // or a constant that is non-text or the wrong length is unsafe; a
+      // `.constant` text of exactly one character (`escape.escape`) is safe. A
+      // constant-NULL escape is the one non-single-character escape also safe
+      // (`vanishes`):
+      // `Row.like` reads it as UNKNOWN before the single-character check, so it
+      // never faults — the NULL-first rule the comparability stamp follows, and
+      // why a `K LIKE 'x' ESCAPE NULL` hoists its sibling equi key. A
+      // `:parameter` escape stays unsafe (it may bind a bad length at run).
+      // Plain LIKE (no escape) stays safe — the matcher itself never throws, a
+      // non-text operand or pattern being a definite non-match and a NULL
+      // UNKNOWN.
       operand.safe && pattern.safe
-          && (escape.map(\.escape) ?? true)
+          && (escape.map { $0.escape || $0.vanishes } ?? true)
     case let .between(test, lower, upper, _):
       test.safe && lower.safe && upper.safe
     case let .distinct(lhs, rhs, _): lhs.safe && rhs.safe
@@ -755,6 +796,13 @@ extension Filter {
     case let .and(lhs, rhs): lhs.safe && rhs.safe
     case let .or(lhs, rhs): lhs.safe && rhs.safe
     case let .not(operand): operand.safe
+    // A leaf the typed scope proved cross-kind faults `42804` at run through
+    // `matches`/`relate`/`like` — as throwing as a divide — so it is not safe
+    // to bypass: `seek` must keep it an always-evaluated residual rather than
+    // drop it over an emptied range, and pushdown must not ride it past a
+    // row-dropping operator. This carried classification is the one place the
+    // physical layer learns a comparison's type-derived hazard.
+    case .incomparable: false
     }
   }
 
@@ -803,6 +851,10 @@ extension Filter {
     case let .and(lhs, rhs): lhs.contingent || rhs.contingent
     case let .or(lhs, rhs): lhs.contingent || rhs.contingent
     case let .not(operand): operand.contingent
+    // A stamped leaf wraps a scalar/row comparison that reads its components'
+    // slots, so it is never slotless-UNKNOWN — derive from the inner, which is
+    // false for every case `incomparable` wraps.
+    case let .incomparable(inner): inner.contingent
     }
   }
 
@@ -852,6 +904,8 @@ extension Filter {
     case let .and(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .or(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .not(operand): operand.parameterised
+    // A stamped leaf is parameterised exactly when the comparison it wraps is.
+    case let .incomparable(inner): inner.parameterised
     }
   }
 
@@ -888,8 +942,10 @@ extension Filter {
       // Both operands are constants: evaluate through the engine's own
       // three-valued `matches`. A NULL on either side is UNKNOWN (`nil`) — not
       // provably true and not provably false — so a NULL-bearing compare is
-      // never folded.
-      matches(lhs, op, rhs)
+      // never folded. An incomparable cross-kind pair is left unfolded (`nil`)
+      // too, so the optimiser keeps the compare and its `42804` fault surfaces
+      // at run rather than folding to a constant.
+      (try? matches(lhs, op, rhs)) ?? nil
     // A comparison against a non-constant term reads a slot or `:parameter`;
     // its truth is not statically known. A row comparison and row `IN` are not
     // statically folded — conservative, matching `.membership`/`.between`.
@@ -917,6 +973,11 @@ extension Filter {
       // `IS <truth>` is a definite two-valued test, but only when the inner's
       // value is itself statically decided; an undecidable inner leaves `nil`.
       inner.constant == nil ? nil : tested(inner.constant, value, negated)
+    case let .incomparable(inner):
+      // A provably cross-kind comparison is undecidable (`nil`, from the inner)
+      // — never folded to a constant, so the optimiser keeps it and its `42804`
+      // fault surfaces at run rather than folding to true/false.
+      inner.constant
     }
   }
 }
@@ -1408,7 +1469,7 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Value {
     let va = try evaluate(row, lhs, context)
     let vb = try evaluate(row, rhs, context)
-    return matches(va, .equal, vb) == true ? .null : va
+    return try matches(va, .equal, vb) == true ? .null : va
   }
 
   /// Evaluates a lowered `CASE` — its `branches` and optional `otherwise`

--- a/Sources/SQLEngine/Grouped.swift
+++ b/Sources/SQLEngine/Grouped.swift
@@ -610,6 +610,8 @@ extension Filter {
       rhs.references(into: &ordinals)
     case let .not(operand):
       operand.references(into: &ordinals)
+    case let .incomparable(inner):
+      inner.references(into: &ordinals)
     }
   }
 }

--- a/Sources/SQLEngine/Interpreter.swift
+++ b/Sources/SQLEngine/Interpreter.swift
@@ -1099,7 +1099,7 @@ extension Catalog where Self: ~Escapable {
             try evaluate(right, filter, context) != true { continue }
         inner.append(right)
       }
-      return joined(outer, inner, base, keys)
+      return try joined(outer, inner, base, keys)
     }
     guard let inner = table(named: name) else { throw .relation(name) }
     guard inner.seekable(column) else {
@@ -1130,7 +1130,7 @@ extension Catalog where Self: ~Escapable {
         // Equal by the same rule the predicate uses — integer/integer exact,
         // mixed integer/double promoted — so a seek that scanned wide still
         // pairs exactly.
-        if matches(value, .equal, right[slot]) == true {
+        if try matches(value, .equal, right[slot]) == true {
           records.append(left.merged(with: right))
         }
       }
@@ -1204,7 +1204,7 @@ extension Table where Self: ~Escapable {
       // share a `Double` bucket), so the residual check keeps integer/integer
       // exact.
       for right in buckets[bucket(value)] ?? []
-          where matches(value, .equal, right[slot]) == true {
+          where try matches(value, .equal, right[slot]) == true {
         records.append(left.merged(with: right))
       }
     }
@@ -1218,15 +1218,16 @@ extension Table where Self: ~Escapable {
 /// equals it, the pair concatenated. The plain nested-loop a CTE inner takes.
 private func joined(_ outer: Array<Record>, _ inner: Array<Record>,
                     _ base: Int, _ keys: (left: Int, right: Int))
-    -> Array<Record> {
+    throws(SQLError) -> Array<Record> {
   let slot = keys.right - base
   var records = Array<Record>()
   for left in outer {
     let value = left[keys.left]
     if case .null = value { continue }
     // The same exact/promoted equality the predicate and the other join paths
-    // use — integer/integer exact, mixed integer/double promoted.
-    for right in inner where matches(value, .equal, right[slot]) == true {
+    // use — integer/integer exact, mixed integer/double promoted, an
+    // incomparable cross-kind key faulting `42804` (the comparability rule).
+    for right in inner where try matches(value, .equal, right[slot]) == true {
       records.append(left.merged(with: right))
     }
   }

--- a/Sources/SQLEngine/Optimisation.swift
+++ b/Sources/SQLEngine/Optimisation.swift
@@ -355,17 +355,26 @@ extension Catalog where Self: ~Escapable {
 /// non-comparison does not qualify, and the relation scans.
 private func comparison(_ filter: Filter, _ bindings: Bindings)
     -> (Int, Comparison, Int)? {
+  // A `slot op :parameter` (`bound`) is stamped `Filter.incomparable` at
+  // lowering — its parameter side is opaque — so unwrap that stamp to read the
+  // seekable shape. The seek stays comparability-safe on its own: a parameter
+  // seeks only when it resolves to an integer against the sort key here, so a
+  // cross-kind binding never seeks (it scans, and the residual — carrying the
+  // stamp — faults `42804` at run), while the stamp still bars a sibling from
+  // seeking past this conjunct through `Filter.safe`.
+  var filter = filter
+  if case let .incomparable(inner) = filter { filter = inner }
   switch filter {
   case let .compare(.slot(slot), op, .constant(.integer(value))):
-    (slot, op, value)
+    return (slot, op, value)
   case let .bound(.slot(slot), op, parameter):
     if case let .integer(value)? = bindings[parameter] {
-      (slot, op, value)
+      return (slot, op, value)
     } else {
-      nil
+      return nil
     }
   default:
-    nil
+    return nil
   }
 }
 
@@ -381,6 +390,13 @@ private func comparison(_ filter: Filter, _ bindings: Bindings)
 /// unbound or non-integer parameter) does not qualify, and the relation scans
 /// under the residual `between`.
 private func range(_ filter: Filter, _ bindings: Bindings) -> (Int, Int, Int)? {
+  // A parameterised `x BETWEEN :lo AND :hi` is stamped `Filter.incomparable` at
+  // lowering (an opaque `:parameter` bound); unwrap to read the seekable range.
+  // The seek is binding-guarded — a bound seeks only when it resolves to an
+  // integer against the sort key — so a cross-kind binding scans and the
+  // stamped residual faults `42804`, as `comparison` does for a `bound`.
+  var filter = filter
+  if case let .incomparable(inner) = filter { filter = inner }
   guard case let .between(.slot(slot), lower, upper, negated: false) = filter,
       let low = integer(lower, bindings),
       let high = integer(upper, bindings) else {

--- a/Sources/SQLEngine/Parser+Predicate.swift
+++ b/Sources/SQLEngine/Parser+Predicate.swift
@@ -194,11 +194,11 @@ extension Parser {
     guard let op = try comparator() else {
       // No comparison operator or other predicate tail follows, so `left`
       // stands alone as an ISO `<boolean predicand>`: bridge it as the
-      // comparison `left = TRUE`, whose three-valued truth IS `left`'s
-      // boolean value (a NULL `left` reading UNKNOWN), the same desugar `x IS
-      // TRUE` uses. A non-boolean `left` compares cross-kind against the
-      // boolean literal, which the engine reads as a definite non-match
-      // exactly as the explicit `left = TRUE` does.
+      // comparison `left = TRUE`, whose three-valued truth IS `left`'s boolean
+      // value (a NULL `left` reading UNKNOWN), the same desugar `x IS TRUE`
+      // uses. A non-boolean `left` compares incomparably against the boolean
+      // literal, so — like the explicit `left = TRUE` — it faults `42804` (the
+      // ISO comparability rule), a genuine BOOLEAN predicand alone passing.
       return .comparison(left: left, op: .equal,
                          right: .literal(.boolean(true)))
     }

--- a/Sources/SQLEngine/Resolution.swift
+++ b/Sources/SQLEngine/Resolution.swift
@@ -1299,6 +1299,333 @@ internal func lower(_ predicate: Predicate,
   }
 }
 
+/// Stamps `filter` with the ISO 9075 comparability classification the typed
+/// resolution surface can see, wrapping each throwable leaf a run can fault
+/// `42804` on in `Filter.incomparable`.
+///
+/// This is the single locus of the comparability rule for the physical plan:
+/// the classification is computed once here, at lowering, from the static
+/// operand kinds `typeAt` resolves (a slot's declared type in the caller's own
+/// slot space — a base relation's ordinal, a join chain's combined ordinal),
+/// and carried by the wrapper into the untyped physical layer, where `seek`,
+/// pushdown, and decorrelation read it through `Filter.safe` without
+/// recomputing type information they do not have. `Scope.on` reads the same
+/// carried bit (its conjuncts are lowered through here), so the join-key hoist
+/// and the physical-plan reorderings cannot drift.
+///
+/// The rule mirrors the run's throwability, `matches`/`relate`/`like` faulting
+/// `42804` exactly when a reachable operand pair is a non-NULL cross-kind one:
+/// a leaf is wrapped when some reachable operand pair can be non-NULL and
+/// incomparable. `reconcile` classifies a pair from the three-way
+/// `Comparability` of its operands — a constant NULL (`.null`: a NULL
+/// comparison is UNKNOWN, never `42804`, so it is safe against anything), a
+/// statically-known non-NULL kind (`.known`: two known kinds are safe iff they
+/// unify), and a run-time value of undecidable kind (`.opaque`: a `:parameter`
+/// or a computed/subquery term, which may carry a non-NULL incomparable value,
+/// so the run can fault). This is the fix for the two soundness holes and the
+/// one over-strictness the earlier `ValueType?`-based classifier carried:
+///
+///   - An `.opaque` operand is unsafe, not deferred. The old `nil` kind
+///     conflated a constant NULL (genuinely safe) with a `:parameter`/computed
+///     term (which the run can fault on), and `reconcile(nil, _)` admitted
+///     both. A `left op :parameter` (`.bound`) and a `BETWEEN`/`LIKE`/`IN` with
+///     a `:parameter` bound therefore hoisted a sibling equi-key that discarded
+///     rows before the throwing residual ran, silently returning empty where
+///     the run must fault. `.bound` is classified here beside the others rather
+///     than passing through unconditionally: its parameter side is `.opaque`,
+///     so it is safe only when the term side is a constant NULL.
+///
+///   - A `membership`/`memberships` honours the run's reachable prefix rather
+///     than checking every element. The run's Kleene-OR `member` fold stops at
+///     the first definite match, so an element after one is never compared and
+///     cannot fault — `1 IN (1, 'x')` never reaches `'x'`. The walk stops at
+///     the same prefix `Scope.check`/the finder use: a reflexive element equal
+///     to a stable operand (`K IN (K, …)`) or a constant match (`operand =
+///     element` folds TRUE through the shared `Filter.constant`/`relate`), so
+///     only a reachable cross-kind element makes it unsafe. A row `IN`
+///     (`memberships`) takes only the constant-match stop, not the reflexive
+///     one — a partially-NULL left row can still reach a later element's
+///     non-null component and fault it.
+///
+///   - A `between` honours the run's lower-bound short-circuit. `ranged`
+///     evaluates `test >= lower` first, and a statically-FALSE lower settles
+///     the whole truth (BETWEEN FALSE), leaving the upper bound unreachable and
+///     unable to fault. So the lower is always reconciled, but the upper only
+///     when the lower does not `settled`-short-circuit — the same `settled`
+///     gate `Scope.check`'s `.between` reads, off the one shared
+///     `Filter.constant` fold. `0 BETWEEN 1 AND 'x'` therefore stays safe.
+///
+///   - A `like` honours the run's NULL-first ordering. `like` reads a NULL
+///     pattern, escape, or subject as UNKNOWN before its non-character
+///     fallback, so a NULL-determined operand makes the whole predicate
+///     UNKNOWN and unable to fault, whatever the subject's type. So a
+///     constant-NULL pattern or escape (`vanishes`), or a constant-NULL
+///     subject, is safe without the character check — the same ordering
+///     `Scope.check`'s `.like` reads through its `vanishes`/constant-NULL gate
+///     — while a non-NULL pattern over a non-character subject still faults.
+///     `A.n LIKE NULL` therefore stays safe. A `:parameter` pattern/escape
+///     stays unsafe (it is not NULL-determined — it may bind a non-character
+///     value the run faults on).
+///
+/// `match`/`null`/`distinct` and the subquery predicates never fault `42804`,
+/// so each passes through (a subquery predicate is already `unsafe` through
+/// `Filter.safe`); the connectives recurse.
+internal func stamped(_ filter: Filter,
+                      _ typeAt: (Int) -> ValueType) -> Filter {
+  switch filter {
+  case let .compare(lhs, _, rhs):
+    return reconcile(kind(of: lhs, typeAt), kind(of: rhs, typeAt))
+        ? filter : .incomparable(filter)
+  case let .comparison(lhs, _, rhs):
+    return zip(lhs, rhs).allSatisfy { reconcile(kind(of: $0, typeAt),
+                                                 kind(of: $1, typeAt)) }
+        ? filter : .incomparable(filter)
+  case let .bound(term, _, _):
+    // `term op :parameter`: the parameter side is a per-run `.opaque` value, so
+    // the comparison is safe only when the term side is a constant NULL — else
+    // the run can fault `42804` on a non-NULL incomparable binding.
+    return reconcile(kind(of: term, typeAt), .opaque)
+        ? filter : .incomparable(filter)
+  case let .membership(operand, elements, _):
+    let operandKind = kind(of: operand, typeAt)
+    var comparable = true
+    for element in elements {
+      if !reconcile(operandKind, kind(of: element, typeAt)) {
+        comparable = false
+        break
+      }
+      // Stop where the run's Kleene-OR fold does — a reflexive element equal to
+      // a stable operand, or a constant match — so a later element is
+      // unreachable and cannot fault.
+      if element == operand && stable(operand) { break }
+      if Filter(compare: operand, .equal, element).constant == true { break }
+    }
+    return comparable ? filter : .incomparable(filter)
+  case let .memberships(lhs, rows, _):
+    let left = constants(lhs)
+    var comparable = true
+    search: for row in rows {
+      for (l, r) in zip(lhs, row) {
+        if !reconcile(kind(of: l, typeAt), kind(of: r, typeAt)) {
+          comparable = false
+          break search
+        }
+      }
+      // The row `IN` fold stops at a row-independent constant match, as the
+      // scalar `.membership` does; it takes no reflexive shortcut.
+      if let left, let right = constants(row), left.count == right.count,
+          (try? relate(left, .equal, right)) == true {
+        break
+      }
+    }
+    return comparable ? filter : .incomparable(filter)
+  case let .between(test, lower, upper, _):
+    // `x BETWEEN a AND b` compares `x` against both bounds, honouring the run's
+    // short-circuit exactly as `Scope.check`'s `.between` does: `ranged`
+    // evaluates `x >= a` first, and a statically-FALSE lower settles the whole
+    // truth (BETWEEN FALSE), leaving `upper` unreachable and unable to fault.
+    // So the lower is always reconciled, but the upper only when the lower does
+    // not `settled`-short-circuit — mirroring the `settled` gate `check` reads,
+    // off the one shared `Filter.constant` fold. `0 BETWEEN 1 AND 'x'` thus
+    // stays safe (the `0 >= 1` lower is FALSE, the `'x'` upper unreachable),
+    // while `5 BETWEEN 1 AND 'x'` (lower does not settle) reconciles the upper
+    // and is stamped incomparable.
+    let testKind = kind(of: test, typeAt)
+    guard reconcile(testKind, kind(of: lower, typeAt)) else {
+      return .incomparable(filter)
+    }
+    if settled(test, lower) { return filter }
+    return reconcile(testKind, kind(of: upper, typeAt))
+        ? filter : .incomparable(filter)
+  case let .like(operand, pattern, escape, _):
+    // `x LIKE p ESCAPE e` reads a NULL — pattern, escape, or subject — as
+    // UNKNOWN before its non-character fallback, so a NULL-determined operand
+    // makes the whole predicate UNKNOWN and it can never fault, exactly as
+    // `Scope.check`'s `.like` orders `vanishes`/constant-NULL-subject ahead of
+    // the character check. Mirror that NULL-first ordering off the same
+    // constant-fold notion: a constant-NULL pattern or escape (`vanishes`), or
+    // a constant-NULL subject, is safe without enforcing the subject's or
+    // pattern's character type. Only a non-NULL pattern/escape reaches the
+    // character check — and there a `:parameter` (a per-run value that is not
+    // NULL-determined, may bind non-character) stays unsafe through
+    // `character`, the prior round's parameter rule. The escape was previously
+    // ignored here.
+    if vanishes(pattern, typeAt) || vanishes(escape, typeAt) { return filter }
+    if case .null = kind(of: operand, typeAt) { return filter }
+    return character(kind(of: operand, typeAt))
+        && character(kind(of: pattern, typeAt))
+        ? filter : .incomparable(filter)
+  case .match, .null, .distinct, .exists, .within, .quantified:
+    return filter
+  case let .truth(inner, value, negated):
+    return .truth(stamped(inner, typeAt), value, negated: negated)
+  case let .and(lhs, rhs):
+    return .and(stamped(lhs, typeAt), stamped(rhs, typeAt))
+  case let .or(lhs, rhs):
+    return .or(stamped(lhs, typeAt), stamped(rhs, typeAt))
+  case let .not(operand):
+    return .not(stamped(operand, typeAt))
+  case .incomparable:
+    // Idempotent: a filter already stamped is not re-classified.
+    return filter
+  }
+}
+
+/// The static comparability class of a lowered comparison operand — the input
+/// `reconcile` folds into a per-pair verdict. It refines the former
+/// `ValueType?`, whose `nil` conflated two opposite cases: a constant NULL
+/// (safe) and a run-time value of undecidable kind (unsafe).
+private enum Comparability {
+  /// A statically-known non-NULL value kind — a slot's declared type, a
+  /// non-NULL constant, a `GROUPING` integer. Two known kinds are comparable
+  /// iff they unify (`ValueType.unified`).
+  case known(ValueType)
+  /// A constant NULL. A comparison with a NULL operand is UNKNOWN, never a
+  /// `42804` fault, so it is comparable against anything.
+  case null
+  /// A value whose kind is not decidable at compile — a `:parameter`, or a
+  /// computed term (`apply`/`binary`/`case`/`cast`/`coalesce`/`nullif`/
+  /// `subquery`). It may carry a non-NULL incomparable value, so the run can
+  /// fault `42804`; the optimiser must not reorder past it.
+  case opaque
+}
+
+/// The `Comparability` of a lowered `term` — its declared kind when known, a
+/// constant NULL as `.null`, and a `:parameter` or any computed/subquery term
+/// as `.opaque` (a per-run value the run stays the authority for). A slot's
+/// kind is its declared type in `typeAt`'s slot space (always known).
+private func kind(of term: Term,
+                  _ typeAt: (Int) -> ValueType) -> Comparability {
+  switch term {
+  case let .slot(ordinal): .known(typeAt(ordinal))
+  case let .constant(value): value.kind.map(Comparability.known) ?? .null
+  case .grouping: .known(.integer)
+  case .parameter, .apply, .binary, .case, .cast, .coalesce, .nullif,
+       .subquery:
+    .opaque
+  }
+}
+
+/// The `Comparability` of a lowered `LIKE`/`BETWEEN` operand — a `.term`'s
+/// `kind(of:)`, and `.opaque` for a run-time `:parameter`.
+private func kind(of operand: Filter.Operand,
+                  _ typeAt: (Int) -> ValueType) -> Comparability {
+  switch operand {
+  case let .term(term): kind(of: term, typeAt)
+  case .parameter: .opaque
+  }
+}
+
+/// Whether a comparison of operands of these classes cannot fault `42804` — the
+/// throwability rule `stamped` shares with the run's `matches`/`relate` and
+/// `Scope.check`. A NULL-involved pair is UNKNOWN, never a fault (safe); two
+/// known kinds are safe iff they unify; an `.opaque` operand against a non-NULL
+/// operand may be a non-NULL incomparable pair the run faults on (unsafe).
+private func reconcile(_ lhs: Comparability, _ rhs: Comparability) -> Bool {
+  switch (lhs, rhs) {
+  case (.null, _), (_, .null):
+    true
+  case let (.known(l), .known(r)):
+    l.unified(with: r) != nil
+  case (.known, .opaque), (.opaque, .known), (.opaque, .opaque):
+    false
+  }
+}
+
+/// Whether a `LIKE` character operand of this class cannot fault `42804` — a
+/// constant NULL is UNKNOWN (safe), a known `text` is a valid character
+/// operand, and any other known kind or an `.opaque` operand (a `:parameter` or
+/// computed term that may be a non-NULL non-character value) can fault.
+private func character(_ kind: Comparability) -> Bool {
+  switch kind {
+  case .null: true
+  case let .known(type): type == .text
+  case .opaque: false
+  }
+}
+
+/// Whether a `BETWEEN`'s lower comparison `test >= lower` folds statically
+/// FALSE — the short-circuit the run's `ranged` makes and `Scope.check`'s
+/// `.between` follows through its own `settled`: a definitely-FALSE lower
+/// settles the whole truth (BETWEEN FALSE), leaving the upper bound
+/// unreachable and unable to fault, so `stamped` must not reconcile it. It
+/// reads the very `Filter.constant` fold `stamped`'s `.membership` already uses
+/// for a reflexive or constant match — `Filter(compare: test, .geq,
+/// low).constant` runs the same `matches` `ranged` evaluates, so the two paths
+/// cannot drift. A non-constant `test` or `lower` (a slot, a `:parameter`, a
+/// computed term) does not fold, so it is not settled and the upper is
+/// reconciled, matching `check`.
+private func settled(_ test: Term, _ lower: Filter.Operand) -> Bool {
+  guard case let .term(low) = lower else { return false }
+  return Filter(compare: test, .geq, low).constant == false
+}
+
+/// Whether a `LIKE` pattern or escape `operand` is NULL-determined — a constant
+/// NULL the run reads as UNKNOWN before its non-character fallback, so the
+/// whole predicate is UNKNOWN and cannot fault `42804` regardless of the
+/// subject's type. The Filter/Term analogue of the constant-NULL arm of
+/// `Scope.check`'s `vanishes`, off the same `kind(of:)` NULL classification the
+/// rest of `stamped` reads. Unlike `check`'s `vanishes` it does not admit a
+/// `:parameter`: `check` defers a parameter to the run because the run is the
+/// authority on its per-run kind, but `stamped` governs the physical-plan
+/// reorderings, and a parameter can bind a non-NULL non-character value the run
+/// faults on — so a parameter pattern/escape is not NULL-determined and stays
+/// unsafe through `character`, the prior round's parameter rule. The two
+/// functions therefore agree on the run's verdict (a non-NULL cross-kind
+/// parameter faults) while answering their two different questions.
+private func vanishes(_ operand: Filter.Operand?,
+                      _ typeAt: (Int) -> ValueType) -> Bool {
+  switch operand {
+  case .none, .some(.parameter):
+    return false
+  case let .some(.term(term)):
+    if case .null = kind(of: term, typeAt) { return true }
+    return false
+  }
+}
+
+/// Whether a lowered `term` yields the same value at every occurrence within a
+/// single row's evaluation — the stability the reflexive membership shortcut in
+/// `stamped`'s `.membership` walk relies on, the `Term` analogue of
+/// `Scope.stable(_ expression:)`. A slot reads the same cell, a constant and a
+/// `GROUPING` are fixed, and a `:parameter` is fixed per run; arithmetic, a
+/// `CAST`, a `COALESCE`, or a `NULLIF` over stable sub-terms stays stable. A
+/// scalar call is stable only over a deterministic routine — which `stamped`
+/// has no `Routines` to check — and a `CASE` guards on `Filter`s this walk does
+/// not test, so both, and a subquery, are conservatively unstable: no reflexive
+/// prune, which is safe (the walk keeps checking later elements).
+private func stable(_ term: Term) -> Bool {
+  switch term {
+  case .slot, .parameter, .constant, .grouping:
+    true
+  case let .binary(_, lhs, rhs):
+    stable(lhs) && stable(rhs)
+  case let .cast(operand, _):
+    stable(operand)
+  case let .coalesce(elements, _):
+    elements.allSatisfy { stable($0) }
+  case let .nullif(lhs, rhs):
+    stable(lhs) && stable(rhs)
+  case .apply, .case, .subquery:
+    false
+  }
+}
+
+/// The constant values of `terms` when every one is a compile-time `.constant`,
+/// else `nil` — the row-independent fold the row `IN` constant-match shortcut
+/// reads. Conservative: a term that is not a bare constant (arithmetic over
+/// constants, a slot) leaves the row undecided, so no false short-circuit
+/// prunes a reachable element.
+private func constants(_ terms: Array<Term>) -> Array<Value>? {
+  var values = Array<Value>()
+  values.reserveCapacity(terms.count)
+  for term in terms {
+    guard case let .constant(value) = term else { return nil }
+    values.append(value)
+  }
+  return values
+}
+
 /// Lowers `x [NOT] IN (v, …)` — the operand already lowered to `left` — to a
 /// first-class `Filter.membership(left, [v0, v1, …], negated:)`, each value
 /// lowered through `term`.

--- a/Sources/SQLEngine/Scope.swift
+++ b/Sources/SQLEngine/Scope.swift
@@ -219,9 +219,23 @@ extension Schema {
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Filter {
-    try SQLEngine.lower(predicate, term: { expression throws(SQLError) in
-      try term(expression, in: relation, routines, subquery: subquery)
-    }, subquery: subquery)
+    let filter =
+        try SQLEngine.lower(predicate, term: { expression throws(SQLError) in
+          try term(expression, in: relation, routines, subquery: subquery)
+        }, subquery: subquery)
+    // Stamp the comparability classification onto every throwable leaf from
+    // this single relation's own ordinal space, so a single-table WHERE's
+    // cross-kind conjunct is carried as unsafe into the physical plan and its
+    // seek/pushdown cannot bypass the `42804` fault (see `stamped`).
+    return stamped(filter) { type(at: $0) }
+  }
+
+  /// The declared value type of the column at `ordinal` in this schema — a real
+  /// column its own `types` entry, a virtual ordinal (`Id`, a foreign key) the
+  /// integral `.integer`, mirroring `Scope.type(at:)` for a single relation so
+  /// the comparability stamp reads the same kinds either resolution path does.
+  private func type(at ordinal: Int) -> ValueType {
+    ordinal < width ? types[ordinal] : .integer
   }
 }
 
@@ -954,17 +968,17 @@ internal struct Scope {
   }
 
   /// The result type of `NULLIF(v1, v2)`, validating both operands as a run
-  /// would fault. The result is either `v1` or NULL, so the column takes `v1`'s
-  /// type; `v2` need not unify with it (a run compares them under `matches`,
-  /// which yields FALSE across kinds without faulting), so it is validated for
-  /// its own errors (an unknown column, a bad call) but does not shape the
-  /// type.
+  /// would fault. `NULLIF(v1, v2)` is `CASE WHEN v1 = v2 THEN NULL ELSE v1`, so
+  /// the two must be comparable — an incomparable pair faults 42804, the fault
+  /// the run's `nullif` raises through `matches`. The result is either `v1` or
+  /// NULL, so the column takes `v1`'s type; `v2` does not shape it.
   private func nullif(validate lhs: Expression, _ rhs: Expression,
                       _ routines: Routines,
                       subquery: SubqueryCheck = .unsupported)
       throws(SQLError) -> ValueType {
     let type = try validate(lhs, routines, subquery: subquery)
-    _ = try validate(rhs, routines, subquery: subquery)
+    let other = try validate(rhs, routines, subquery: subquery)
+    try comparable(lhs, type, rhs, other, routines)
     return type
   }
 
@@ -1332,8 +1346,14 @@ internal struct Scope {
       throws(SQLError) {
     switch predicate {
     case let .comparison(left, _, right):
-      _ = try validate(left, routines, subquery: subquery)
-      _ = try validate(right, routines, subquery: subquery)
+      let l = try validate(left, routines, subquery: subquery)
+      let r = try validate(right, routines, subquery: subquery)
+      // The ISO comparability rule: an incomparable operand pair (a number
+      // against a string) is a data-type mismatch (42804), not a FALSE row —
+      // the fault the run's `matches` raises, so the two agree. A bare boolean
+      // predicand (`WHERE Age`) reaches here as its `Age = TRUE` desugar, so a
+      // non-boolean one faults exactly as an explicit `Age = TRUE` does.
+      try comparable(left, l, right, r, routines)
     case let .exists(query, _):
       // Validate the inner uncorrelated query as the run's lowering does — it
       // resolves and type-checks against the enclosing catalog, so a bad column
@@ -1348,10 +1368,13 @@ internal struct Scope {
       // schema validation matches execution — the recurring lesson that the
       // two must not diverge. Reached in the `valued` role (its rows are read),
       // so the deferred phase validates the original query. A cross-kind
-      // component is NOT rejected — the run's `relate`/`matches` yields FALSE
-      // across kinds without faulting, as an `IN` element does — so the schema
-      // accepts what the run accepts; an irreconcilable set-operation subquery
-      // still faults through its own union type fold.
+      // component now faults at run through `relate` (the ISO comparability
+      // rule), but the static comparability check is not applied against a
+      // subquery operand here: its single-column type may be a nominal-NULL
+      // placeholder (a `SELECT NULL` body types `.integer`), which would
+      // mis-reject a query the run keeps — so the run stays the authority for a
+      // subquery operand, while an irreconcilable set-operation subquery still
+      // faults through its own union type fold.
       for expression in lhs {
         _ = try validate(expression, routines, subquery: subquery)
       }
@@ -1363,7 +1386,9 @@ internal struct Scope {
       // enforce the row-arity-equals-subquery-width rule the lowering does
       // (`SQLError.arity`), so schema validation matches execution. Reached
       // `valued` (its rows are read), so the deferred phase validates the
-      // original query.
+      // original query. A cross-kind operand faults at run through `relate`;
+      // the static comparability check defers to the run for a subquery
+      // operand, as `within` does.
       for expression in lhs {
         _ = try validate(expression, routines, subquery: subquery)
       }
@@ -1380,19 +1405,46 @@ internal struct Scope {
     case let .membership(operand, values, _):
       // `x IN (v, …)` lowers to `x = v OR …`, so type it as those comparisons:
       // validate the operand and each value for real errors (unknown column,
-      // bad arity, …). A cross-kind element (text in an integer list) is NOT
-      // rejected: the lowered `operand = element` comparison yields FALSE at
-      // runtime via `Row.matches` without faulting, so a row still runs (and
-      // may match a like-kind element), and the schema check must accept what
-      // the run accepts — rejecting it here would diverge from the run.
+      // bad arity, …) AND check each reached element is comparable to the
+      // operand — an incomparable element (text in an integer list) is a
+      // data-type mismatch (42804), the fault the run's `member` raises, so the
+      // schema check faults exactly where the run does.
       //
-      // The OR-chain short-circuits: a definite constant match (`x = v` folds
-      // TRUE, both row-independent constants) makes the whole `IN` TRUE and
-      // leaves every later element unreachable, so validation stops there —
-      // `1 IN (1 + 0, Name + 1)` type-checks, the run matching `1 = 1 + 0`
-      // before ever reaching `Name + 1`, while `2 IN (1 + 0, Name + 1)` (no
-      // definite match) still validates `Name + 1` and faults.
-      // `matched(operand, value, routines)` is the fold's own primitive.
+      // The OR-chain short-circuits: a definite match makes the whole `IN` TRUE
+      // and leaves later elements unreachable, so validation stops there. Two
+      // element shapes are a definite match:
+      //   - A row-independent constant match (`x = v` folds TRUE, both
+      //     constants) — `1 IN (1 + 0, Name + 1)` type-checks, the run matching
+      //     `1 = 1 + 0` before ever reaching `Name + 1`, while `2 IN (1 + 0,
+      //     Name + 1)` (no definite match) still validates `Name + 1` and
+      //     faults. `matched(operand, value, routines)` is that primitive. A
+      //     constant match folds only over a non-NULL operand (a NULL folds
+      //     UNKNOWN), so the run genuinely short-circuits.
+      //   - A reflexive element structurally equal to a stable operand (`K IN
+      //     (K, …)`) is a per-row match — but a short-circuit only over
+      //     a provably non-NULL operand (`defined`): `operand = operand` is
+      //     TRUE, so the run's membership Kleene-OR stops there and every later
+      //     element is unreachable, none validated or compared. A nullable
+      //     operand makes it UNKNOWN, so a NULL row runs on and evaluates every
+      //     later element: its comparison to the NULL operand is UNKNOWN (never
+      //     42804), so the comparability check still stops here, but its own
+      //     evaluation is reached — a `1 / 0` faults — so the evaluation check
+      //     continues. So `K IN (K, 'x')` type-checks whether or not `K` is
+      //     provably non-NULL (the reached `'x'` is compared to a NULL `K`,
+      //     UNKNOWN), while `K IN (K, 1 / 0)` type-checks only when `K` is
+      //     provably non-NULL — a nullable `K` reaches and faults the `1 / 0`.
+      //     `K IN ('x', K)` still faults (the reached `'x'` is compared to a
+      //     non-NULL `K` before the reflexive one) and `K IN (1, 'x')` still
+      //     faults (`1` is comparable but not a match). The stability gate
+      //     (`stable`) is load-bearing: it fires only for an operand whose two
+      //     evaluations always agree, since the run evaluates the operand and
+      //     the element independently — a deterministic `K + 1` is stable, a
+      //     non-deterministic `tick()` is not, so `tick() IN (tick(), 'x')`
+      //     reaches the `'x'`. The reflexive recognition is scoped to
+      //     the comparability walk: it must not leak into the `matched`
+      //     reachability fold `constant(_ predicate:)` shares, since `K IN
+      //     (K, …)` is UNKNOWN (not constant-TRUE) for a NULL operand and the
+      //     optimiser must not fold it away.
       //
       // An empty list has no OR-chain and cannot be lowered (`lower` would have
       // no seed), so reject it here too — the parser rejects `IN ()`, but a
@@ -1401,34 +1453,77 @@ internal struct Scope {
       if values.isEmpty {
         throw .state("42601", "IN requires a non-empty value list")
       }
-      _ = try validate(operand, routines, subquery: subquery)
-      _ = try membership(of: values, each: { value throws(SQLError) in
-        _ = try validate(value, routines, subquery: subquery)
-      }, equality: { value throws(SQLError) in
-        matched(operand, value, routines)
-      })
+      let type = try validate(operand, routines, subquery: subquery)
+      // `x IN (…)` lowers to `x = v OR …`. Every element the run reaches is
+      // validated for its own evaluation errors (a `1 / 0`); and until the
+      // OR-chain short-circuits it is also checked comparable to the operand —
+      // an incomparable element faults 42804, the fault the run's `member`
+      // raises. A constant-TRUE element, or a reflexive element equal to a
+      // stable operand (`operand IN (operand, …)`), short-circuits the chain.
+      // `1 IN (1, 'a')` type-checks while `1 IN ('a', 1)` faults.
+      //
+      // A reflexive element short-circuits definitely only over a provably
+      // non-NULL operand (`defined`): `operand = operand` is TRUE, so every
+      // later element is unreachable and neither validated nor compared. A
+      // nullable operand makes it UNKNOWN, so a NULL row runs on and evaluates
+      // every later element — those still fault on their own evaluation, though
+      // their comparison to the NULL operand is UNKNOWN, never 42804 — so the
+      // comparability check stops at the reflexive element while the evaluation
+      // check continues. A non-deterministic operand is not stable, so it
+      // never short-circuits (`tick() IN (tick(), 'x')` reaches the `'x'`).
+      var comparing = true
+      for value in values {
+        let element = try validate(value, routines, subquery: subquery)
+        guard comparing else { continue }
+        try comparable(operand, type, value, element, routines)
+        if value == operand && stable(operand, routines) {
+          if defined(operand) { break }
+          comparing = false
+        } else if matched(operand, value, routines) == true {
+          break
+        }
+      }
     case let .rows(lhs, _, rhs):
       // `(l…) <op> (r…)` lowers to a componentwise comparison, so type each
       // component of both rows for real errors (unknown column, bad arity, …),
       // and enforce the equal-arity rule the lowering does (`SQLError.arity`)
-      // so schema validation matches execution. A cross-kind component is NOT
-      // rejected — the run's `matches` yields FALSE across kinds without
-      // faulting, as an `IN` element does — so the schema accepts what the run
-      // accepts.
+      // so schema validation matches execution.
       guard lhs.count == rhs.count else {
         throw .arity(lhs.count, rhs.count)
       }
+      // Validate both rows in the run's evaluation order — every left, then
+      // every right component — before the componentwise comparability pass,
+      // because that is the order `Filter.comparison` runs: it evaluates the
+      // whole left row into a `[Value]`, then the whole right, and only then
+      // does `relate` preflight every component pair's comparability. A
+      // component's own evaluation fault the run raises while building a row
+      // therefore surfaces ahead of any 42804 — `(1, 1 / 0) = ('x', 2)` divides
+      // by zero building the left row before the incomparable `1`/`'x'` pair is
+      // compared, so the type-check must fault the divide, not the 42804, to
+      // match the run. Interleaving the comparability check per component would
+      // fault the first pair's 42804 before the later faulting left component.
+      var l = Array<ValueType>()
+      l.reserveCapacity(lhs.count)
       for expression in lhs {
-        _ = try validate(expression, routines, subquery: subquery)
+        try l.append(validate(expression, routines, subquery: subquery))
       }
+      var r = Array<ValueType>()
+      r.reserveCapacity(rhs.count)
       for expression in rhs {
-        _ = try validate(expression, routines, subquery: subquery)
+        try r.append(validate(expression, routines, subquery: subquery))
+      }
+      // Each component pair must be comparable — `(l…) <op> (r…)` folds through
+      // the componentwise `relate`, which faults 42804 on an incomparable pair
+      // (`(1, 'a') = (1, 2)`), so the type-check faults the same pair.
+      for index in lhs.indices {
+        try comparable(lhs[index], l[index], rhs[index], r[index], routines)
       }
     case let .among(lhs, rows, _):
       // `(l…) [NOT] IN ((r…), …)` lowers to a disjunction of row equalities, so
-      // type the left row and each element row for real errors, and enforce the
-      // non-empty list and per-row equal-arity rules the lowering does. A
-      // cross-kind component is NOT rejected, as an `IN` element is not.
+      // type the left row and each reached element row for real errors, enforce
+      // the non-empty list and per-row equal-arity rules the lowering does, and
+      // check each reached component pair is comparable — an incomparable one
+      // faults 42804, the fault the run's row `member` fold raises.
       //
       // The OR-chain short-circuits exactly as the scalar `.membership` does: a
       // definite constant match (both the left row and an element row fold to
@@ -1443,39 +1538,87 @@ internal struct Scope {
       if rows.isEmpty {
         throw .state("42601", "IN requires a non-empty value list")
       }
+      var types = Array<ValueType>()
+      types.reserveCapacity(lhs.count)
       for expression in lhs {
-        _ = try validate(expression, routines, subquery: subquery)
+        try types.append(validate(expression, routines, subquery: subquery))
       }
       let l = constants(lhs, routines)
       _ = try membership(of: rows, each: { element throws(SQLError) in
         guard element.count == lhs.count else {
           throw .arity(lhs.count, element.count)
         }
+        // Each element row folds through the componentwise `relate`, which
+        // faults 42804 on an incomparable component — so type-check each
+        // component pair. Short-circuit aware: a prior constant-TRUE element
+        // row leaves a later one unvisited, matching the run's `member` fold.
+        //
+        // Validate the whole element row in the run's evaluation order —
+        // `member` builds every component into a `[Value]` before `relate`
+        // preflights their comparability — then the comparability pass, so a
+        // component's own evaluation fault surfaces ahead of a later pair's
+        // 42804: `(N) IN ((1 / 0))` over integer `N` divides before comparing,
+        // and `(N, M) IN (('x', 1 / 0))` divides building the element row, not
+        // faulting the incomparable `N`/`'x'` pair, matching the run.
+        var r = Array<ValueType>()
+        r.reserveCapacity(element.count)
         for expression in element {
-          _ = try validate(expression, routines, subquery: subquery)
+          try r.append(validate(expression, routines, subquery: subquery))
+        }
+        for index in element.indices {
+          try comparable(lhs[index], types[index], element[index], r[index],
+                         routines)
         }
       }, equality: { element throws(SQLError) in
         guard let l, let r = constants(element, routines) else { return nil }
-        return relate(l, .equal, r)
+        // The short-circuit fold is a pure reachability decision — an
+        // incomparable pair is undecided here (`nil`), its 42804 fault raised
+        // by the comparability check in the `each` walk above, not this fold.
+        return (try? relate(l, .equal, r)) ?? nil
       })
     case let .like(operand, pattern, escape, _):
-      // Validate the operand, pattern, and optional escape for REAL errors
-      // (unknown column, bad arity, …); a non-text operand or pattern is NOT
-      // rejected — the run yields a definite FALSE via `Row.like` without
-      // faulting (the cross-kind rule), and the schema check must accept what
-      // the run accepts, as the `IN` cross-kind element does.
-      _ = try validate(operand, routines, subquery: subquery)
+      // Validate the operand, pattern, and optional escape for real errors
+      // (unknown column, bad arity, …). The operand and pattern must be
+      // character strings (ISO): a non-text, non-NULL operand or pattern faults
+      // 42804, the same non-character fault the run's `like` raises, so the
+      // type-check and the run agree.
+      let type = try validate(operand, routines, subquery: subquery)
       try validate(pattern, routines, subquery: subquery)
       if let escape {
         try validate(escape, routines, subquery: subquery)
         try reject(escape, routines)
       }
+      // The run reads a NULL — or a possibly-NULL, per-run — pattern or escape
+      // as UNKNOWN before its non-character fallback, so the whole predicate is
+      // UNKNOWN regardless of the subject's type. A constant-NULL pattern or
+      // escape (`K LIKE NULL`, `K LIKE 'x' ESCAPE NULL`, integer `K`) and a
+      // `:parameter` one (`K LIKE :p`, its value arriving from the bindings)
+      // both run and select nothing — they do not fault 42804 — so `vanishes`
+      // defers each. Mirror that NULL-first ordering: when the pattern or the
+      // escape vanishes, admit the predicate without enforcing the character
+      // type of the subject (or the pattern), matching the run; only a
+      // non-NULL, non-parameter pattern/escape reaches the character check the
+      // run's non-character fallback faults.
+      guard !vanishes(pattern, routines), !vanishes(escape, routines) else {
+        break
+      }
+      // A constant-NULL subject makes the run's `like` return UNKNOWN from its
+      // `(.null, _, _)` arm before it inspects the pattern's type, so neither
+      // the subject nor the pattern character type is enforced — `NULL LIKE 1`
+      // runs and selects nothing, it does not fault. The pattern is already
+      // validated above for the faults it can raise; only its character type is
+      // skipped. Symmetric to the constant-NULL pattern `vanishes` exemption.
+      if constant(operand, routines) == .null { break }
+      try character(operand, type, routines)
+      if case let .expression(pattern) = pattern {
+        try character(pattern, try validate(pattern, routines,
+                                            subquery: subquery), routines)
+      }
     case let .between(test, lower, upper, _):
       // `x [NOT] BETWEEN a AND b` compares `x` against both bounds, so validate
-      // the three operands for real errors (an unknown column, a bad call). A
-      // cross-kind bound is NOT rejected: the run's `matches` yields FALSE
-      // across kinds without faulting (as an `IN` element does), so the schema
-      // check accepts what the run accepts.
+      // the three operands for real errors (an unknown column, a bad call) and
+      // check each reached bound is comparable to `x` — an incomparable bound
+      // faults 42804, the fault the run's `ranged` raises.
       //
       // It respects the executor's short-circuit — the same one `ranged`
       // evaluates with: a definitely-FALSE lower comparison (`x >= a`) settles
@@ -1485,16 +1628,32 @@ internal struct Scope {
       // validated — `0 BETWEEN 1 AND (1 / 0)` type-checks, the lower `0 >= 1`
       // FALSE settling the row before the `1 / 0` upper is reached, exactly as
       // an `AND`'s constant-false left leaves its right unchecked.
-      _ = try validate(test, routines, subquery: subquery)
+      let type = try validate(test, routines, subquery: subquery)
       try validate(lower, routines, subquery: subquery)
+      // `x BETWEEN a AND b` compares `x` against both bounds, so each bound
+      // must be comparable to `x` — an incomparable one faults 42804, the fault
+      // the run's `ranged` raises. The lower is always compared; the upper only
+      // when the lower does not settle the truth (the same short-circuit
+      // `ranged` makes), so `0 BETWEEN 1 AND 'z'` faults only if `0 >= 1` does
+      // not settle it first.
+      if case let .expression(low) = lower {
+        let bound = try validate(low, routines, subquery: subquery)
+        try comparable(test, type, low, bound, routines)
+      }
       let settled = {
         guard let value = constant(test, routines),
             let low = constant(lower, routines) else {
           return false
         }
-        return matches(value, .geq, low) == false
+        return ((try? matches(value, .geq, low)) ?? nil) == false
       }()
-      if !settled { try validate(upper, routines, subquery: subquery) }
+      if !settled {
+        try validate(upper, routines, subquery: subquery)
+        if case let .expression(high) = upper {
+          let bound = try validate(high, routines, subquery: subquery)
+          try comparable(test, type, high, bound, routines)
+        }
+      }
     case let .distinct(lhs, rhs, _):
       // `a IS [NOT] DISTINCT FROM b` compares both operands, so validate the
       // two for real errors (an unknown column, a bad call). both are always
@@ -1523,6 +1682,75 @@ internal struct Scope {
     case let .not(operand):
       try check(operand, routines, subquery: subquery)
     }
+  }
+
+  /// Faults `SQLError.state` `42804` when the two comparison operands have
+  /// incomparable declared types — the ISO 9075 comparability rule a
+  /// `<comparison predicate>` (and `BETWEEN`, `IN`, quantified, and row
+  /// comparison) requires of its operands. A numeric integer/double pair and
+  /// any like-kind pair unify and are comparable; every other cross-kind pair
+  /// (a number against a string, a boolean against a blob) is a data-type
+  /// mismatch, faulted here exactly where the run's `matches`/`relate` faults
+  /// it, so `run ≡ columns(of: validate:)`.
+  ///
+  /// An operand that folds to a constant NULL, or is a subquery, is exempt: the
+  /// run reads a NULL comparison as UNKNOWN (never a fault, so a `text = NULL`
+  /// must not be rejected here even though a bare `NULL` types nominally
+  /// `.integer`), and a subquery operand's static single-column type may itself
+  /// be a nominal-NULL placeholder — so the run, which faults per cross-kind
+  /// row through `relate`, stays the authority for a subquery operand.
+  private func comparable(_ lhs: Expression, _ l: ValueType,
+                          _ rhs: Expression, _ r: ValueType,
+                          _ routines: Routines) throws(SQLError) {
+    guard !exempt(lhs, routines), !exempt(rhs, routines) else { return }
+    guard l.unified(with: r) != nil else {
+      throw .state("42804", "cannot compare \(l.domain) with \(r.domain)")
+    }
+  }
+
+  /// Faults `SQLError.state` `42804` when `expression` (of derived type `type`)
+  /// is not a character operand — the ISO rule a `LIKE` operand and pattern are
+  /// character strings, the same non-text fault the run's `like` raises. A
+  /// constant-NULL or subquery operand is exempt (the run reads NULL as UNKNOWN
+  /// and defers a subquery to `relate`), matching `comparable`.
+  private func character(_ expression: Expression, _ type: ValueType,
+                         _ routines: Routines) throws(SQLError) {
+    guard !exempt(expression, routines), type != .text else { return }
+    throw .state("42804", "LIKE requires character operands")
+  }
+
+  /// Whether a `LIKE` pattern or escape `operand` reads as NULL — or may read
+  /// as NULL, or be unbound — at run, so the whole predicate is UNKNOWN before
+  /// the run's non-character fallback and neither the subject's nor the
+  /// pattern's character type is enforced. It is `true` for a constant-NULL
+  /// `.expression` (`K LIKE NULL`, `K LIKE 'x' ESCAPE NULL`, integer `K`, run
+  /// and select nothing) and for a `.parameter` (its value arrives from the
+  /// bindings, possibly NULL or unbound, so the run stays the authority for its
+  /// per-run kind — an unbound or NULL one selects nothing, a non-character
+  /// bound one faults 42804 at run, exactly as `Predicate.bound` defers a
+  /// comparison to the run). A `nil` escape, or any non-NULL, non-parameter
+  /// expression is not NULL, so the character check still applies. It is the
+  /// same deferral `exempt` reads for a comparison operand, widened by the
+  /// per-run `.parameter` kind LIKE carries.
+  private func vanishes(_ operand: Predicate.Operand?,
+                        _ routines: Routines) -> Bool {
+    switch operand {
+    case .none:
+      return false
+    case .some(.parameter):
+      return true
+    case let .some(.expression(expression)):
+      return constant(expression, routines) == .null
+    }
+  }
+
+  /// Whether `expression` is exempt from the comparability check — a subquery
+  /// (whose static single-column type may be a nominal-NULL placeholder) or an
+  /// expression that folds to a constant NULL (read as UNKNOWN by the run,
+  /// never a fault).
+  private func exempt(_ expression: Expression, _ routines: Routines) -> Bool {
+    if case .subquery = expression { return true }
+    return constant(expression, routines) == .null
   }
 
   /// Type-checks a `LIKE` pattern or escape `operand` for the side effect of
@@ -1573,7 +1801,159 @@ internal struct Scope {
         let rhs = constant(value, routines) else {
       return nil
     }
-    return matches(lhs, .equal, rhs)
+    // A pure reachability fold: an incomparable constant pair is undecided
+    // (`nil`) here, its 42804 fault raised by the comparability `check`.
+    return (try? matches(lhs, .equal, rhs)) ?? nil
+  }
+
+  /// Whether `expression` yields the same value at every one of its textual
+  /// occurrences within a single row's (or group's) evaluation — the stability
+  /// the reflexive membership shortcut in `check`'s `.membership` walk relies
+  /// on. That walk treats an element structurally equal to the `IN` operand
+  /// (`K IN (K, …)`) as a definite per-row match that stops the walk, but the
+  /// run evaluates the operand and that element independently, so the shortcut
+  /// is sound only when both evaluations always agree. This differs from
+  /// `constant(_ expression:)`: a column is not row-independent (it does not
+  /// fold to a `Value`) yet it is stable — reading the same cell twice — so a
+  /// stability test, not constancy, is what the shortcut needs.
+  ///
+  /// A column reads the same cell, a literal is fixed, and GROUPING lowers to a
+  /// per-arm compile-time integer constant, so each is stable. Arithmetic, a
+  /// `CAST`, a `COALESCE`, a `NULLIF`, and a `CASE` over stable sub-expressions
+  /// stay stable, so `K + 1 IN (K + 1, 'x')` still short-circuits. A scalar
+  /// `call` is re-evaluated per occurrence, so it is stable only when the
+  /// routine is deterministic and every argument is stable — a non-
+  /// deterministic (or unregistered) routine, or a non-stable argument, lets
+  /// two calls disagree, so `tick() IN (tick(), 'x')` must reach the cross-kind
+  /// `'x'`. An aggregate is stable when its aggregand and `FILTER` are (a non-
+  /// deterministic aggregand two occurrences fold over the group to values that
+  /// can disagree). A subquery is conservatively not stable — no reflexive
+  /// shortcut over a subquery operand, which is safe: the walk keeps
+  /// considering later elements, never wrongly pruning one.
+  private func stable(_ expression: Expression, _ routines: Routines) -> Bool {
+    switch expression {
+    case .column, .literal, .grouping:
+      true
+    case let .call(name, arguments):
+      routines[name]?.deterministic == true
+          && arguments.allSatisfy { stable($0, routines) }
+    case let .binary(_, lhs, rhs):
+      stable(lhs, routines) && stable(rhs, routines)
+    case let .aggregate(_, aggregand, _, filter):
+      stable(aggregand, routines)
+          && (filter.map { stable($0, routines) } ?? true)
+    case let .case(whens, otherwise):
+      whens.allSatisfy {
+        stable($0.when, routines) && stable($0.then, routines)
+      } && (otherwise.map { stable($0, routines) } ?? true)
+    case let .cast(operand, _):
+      stable(operand, routines)
+    case let .coalesce(arguments):
+      arguments.allSatisfy { stable($0, routines) }
+    case let .nullif(lhs, rhs):
+      stable(lhs, routines) && stable(rhs, routines)
+    case .subquery:
+      false
+    }
+  }
+
+  /// An aggregand is stable when its expression is (`COUNT(*)` names no
+  /// expression, so it is trivially stable).
+  private func stable(_ aggregand: Aggregand, _ routines: Routines) -> Bool {
+    switch aggregand {
+    case .star:
+      true
+    case let .expression(expression):
+      stable(expression, routines)
+    }
+  }
+
+  /// Whether `operand` (a `LIKE`/`BETWEEN` operand) is stable: an expression
+  /// defers to the expression rule, a `:parameter` is fixed for the whole run.
+  private func stable(_ operand: Predicate.Operand, _ routines: Routines)
+      -> Bool {
+    switch operand {
+    case let .expression(expression):
+      stable(expression, routines)
+    case .parameter:
+      true
+    }
+  }
+
+  /// Whether `predicate` yields the same truth at every occurrence within one
+  /// evaluation — the stability rule extended to a `CASE` guard or an aggregate
+  /// `FILTER`. A `:parameter` is fixed per run; a subquery predicate
+  /// (`EXISTS`/`IN (Q)`/quantified) is conservatively not stable.
+  private func stable(_ predicate: Predicate, _ routines: Routines) -> Bool {
+    switch predicate {
+    case let .comparison(left, _, right):
+      stable(left, routines) && stable(right, routines)
+    case let .bound(left, _, _):
+      stable(left, routines)
+    case let .null(operand, _):
+      stable(operand, routines)
+    case let .membership(operand, values, _):
+      stable(operand, routines) && values.allSatisfy { stable($0, routines) }
+    case let .rows(lhs, _, rhs):
+      lhs.allSatisfy { stable($0, routines) }
+          && rhs.allSatisfy { stable($0, routines) }
+    case let .among(lhs, rows, _):
+      lhs.allSatisfy { stable($0, routines) }
+          && rows.allSatisfy { row in row.allSatisfy { stable($0, routines) } }
+    case let .like(operand, pattern, escape, _):
+      stable(operand, routines) && stable(pattern, routines)
+          && (escape.map { stable($0, routines) } ?? true)
+    case let .between(test, lower, upper, _):
+      stable(test, routines) && stable(lower, routines)
+          && stable(upper, routines)
+    case let .distinct(lhs, rhs, _):
+      stable(lhs, routines) && stable(rhs, routines)
+    case let .truth(inner, _, _):
+      stable(inner, routines)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      stable(lhs, routines) && stable(rhs, routines)
+    case let .not(operand):
+      stable(operand, routines)
+    case .exists, .within, .quantified:
+      false
+    }
+  }
+
+  /// Whether `expression` is provably non-NULL — it yields a value on every
+  /// row, never NULL. Conservative: an undecidable case is treated as nullable
+  /// (`false`), so a caller pruning on non-nullness never prunes a row a NULL
+  /// could reach. The reflexive membership shortcut reads it: `operand IN
+  /// (operand, …)` short-circuits at `operand = operand` only when the operand
+  /// is non-NULL (a NULL makes it UNKNOWN, so the run reaches the later
+  /// elements), so only a provably non-NULL operand may prune them.
+  ///
+  /// A non-NULL literal is non-NULL, and a `GROUPING` is a settled non-NULL
+  /// integer. Arithmetic and a `CAST` over non-NULL operands stay non-NULL — a
+  /// fault throws rather than yielding NULL. A `COALESCE` is non-NULL when any
+  /// argument is, since it returns the first non-NULL one. A `CASE` is non-NULL
+  /// when it has an `ELSE` and every result arm (each `THEN` and the `ELSE`) is
+  /// non-NULL — a no-match `CASE` without `ELSE` yields NULL. Everything else
+  /// is treated as nullable: a `column` carries no NOT NULL schema flag (the
+  /// engine does not track column nullability), a `NULLIF` yields NULL on an
+  /// equal pair, and a `call`, `aggregate`, or `subquery` can yield NULL.
+  private func defined(_ expression: Expression) -> Bool {
+    switch expression {
+    case let .literal(literal):
+      if case .null = literal { false } else { true }
+    case .grouping:
+      true
+    case let .binary(_, lhs, rhs):
+      defined(lhs) && defined(rhs)
+    case let .cast(operand, _):
+      defined(operand)
+    case let .coalesce(arguments):
+      arguments.contains { defined($0) }
+    case let .case(whens, otherwise):
+      (otherwise.map { defined($0) } ?? false)
+          && whens.allSatisfy { defined($0.then) }
+    case .column, .call, .aggregate, .nullif, .subquery:
+      false
+    }
   }
 
   /// The constant `Value` `expression` folds to when it is ROW-independent —
@@ -1675,7 +2055,12 @@ internal struct Scope {
           let vb = constant(rhs, routines) else {
         return nil
       }
-      return matches(va, .equal, vb) == true ? .null : va
+      // An incomparable `v1 = v2` is a would-be `42804` fault, so leave the
+      // fold undecided (`nil`) rather than deciding it is `va` — a soundness
+      // guard matching the divide/overflow collapse, so the reachability walk
+      // never prunes a branch the run would fault.
+      guard let equal = try? matches(va, .equal, vb) else { return nil }
+      return equal == true ? .null : va
     case .column, .aggregate, .subquery, .grouping:
       // A `subquery` is row-independent but is materialised at run (this
       // compile-time fold has no cache), so it is not statically foldable —
@@ -1869,7 +2254,9 @@ internal struct Scope {
           let rhs = constant(right, routines) else {
         return nil
       }
-      return matches(lhs, op, rhs)
+      // A pure reachability fold: an incomparable pair is undecided (`nil`)
+      // here, its 42804 fault raised by the comparability check in `check`.
+      return (try? matches(lhs, op, rhs)) ?? nil
     case let .and(lhs, rhs):
       // `constant` is a pure fold with no side effect, so both arms evaluate.
       return and(constant(lhs, routines), constant(rhs, routines))
@@ -1924,10 +2311,10 @@ internal struct Scope {
           let low = constant(lower, routines) else {
         return nil
       }
-      let above = matches(value, .geq, low)
+      let above = (try? matches(value, .geq, low)) ?? nil
       if above == false { return negated }
       guard let high = constant(upper, routines) else { return nil }
-      let within = and(above, matches(value, .leq, high))
+      let within = and(above, (try? matches(value, .leq, high)) ?? nil)
       return negated ? within.map { !$0 } : within
     case let .distinct(lhs, rhs, negated):
       // Fold `a IS [NOT] DISTINCT FROM b` as `differs` evaluates it: the
@@ -1977,7 +2364,7 @@ internal struct Scope {
           let r = constants(rhs, routines) else {
         return nil
       }
-      return relate(l, op, r)
+      return (try? relate(l, op, r)) ?? nil
     case let .among(lhs, rows, negated):
       // Fold `(l…) [NOT] IN ((r…), …)` exactly as the scalar `.membership`
       // folds — the left row folds through `constant(_ expression:)`, then the
@@ -1992,7 +2379,7 @@ internal struct Scope {
       guard let l = constants(lhs, routines) else { return nil }
       let truth = membership(of: rows) { element in
         guard let r = constants(element, routines) else { return nil }
-        return relate(l, .equal, r)
+        return (try? relate(l, .equal, r)) ?? nil
       }
       return negated ? truth.map { !$0 } : truth
     case .exists, .within, .quantified:
@@ -2386,7 +2773,7 @@ internal struct Scope {
       // else the folded `v1`.
       let va = try empty(lhs, routines)
       let vb = try empty(rhs, routines)
-      return matches(va, .equal, vb) == true ? .null : va
+      return try matches(va, .equal, vb) == true ? .null : va
     case .column, .subquery:
       // A bare column cannot appear over an empty group (a grouping error
       // `compile` rejected). A scalar `subquery` is materialised at run (this
@@ -2435,7 +2822,7 @@ internal struct Scope {
       throws(SQLError) -> Bool? {
     switch predicate {
     case let .comparison(left, op, right):
-      return matches(try empty(left, routines), op, try empty(right, routines))
+      return try matches(empty(left, routines), op, empty(right, routines))
     case .bound:
       return nil
     case let .null(operand, negated):
@@ -2461,7 +2848,7 @@ internal struct Scope {
       }
       let lhs = try empty(operand, routines)
       let truth = try membership(of: values) { value throws(SQLError) in
-        matches(lhs, .equal, try empty(value, routines))
+        try matches(lhs, .equal, empty(value, routines))
       }
       return negated ? truth.map { !$0 } : truth
     case let .rows(lhs, op, rhs):
@@ -2480,7 +2867,7 @@ internal struct Scope {
       var r = Array<Value>()
       r.reserveCapacity(rhs.count)
       for expression in rhs { try r.append(empty(expression, routines)) }
-      return relate(l, op, r)
+      return try relate(l, op, r)
     case let .among(lhs, rows, negated):
       // Fold `(l…) [NOT] IN ((r…), …)` over the empty group as
       // `Filter.memberships` evaluates it: the left row folds once, then
@@ -2501,7 +2888,7 @@ internal struct Scope {
         var r = Array<Value>()
         r.reserveCapacity(element.count)
         for expression in element { try r.append(empty(expression, routines)) }
-        truth = or(truth, relate(l, .equal, r))
+        truth = try or(truth, relate(l, .equal, r))
         if truth == true { break }
       }
       return negated ? truth.map { !$0 } : truth
@@ -2510,10 +2897,11 @@ internal struct Scope {
       // operand, pattern, and optional escape are each folded once, IN ORDER,
       // before the result is decided (so a faulting reached operand surfaces
       // its throw rather than being swallowed by a NULL escape). Then a NULL
-      // operand, pattern, or escape is UNKNOWN, a non-text operand or pattern a
-      // definite non-match, else the `%`/`_` matcher decides; a non-NULL escape
-      // that is not a single character faults `SQLError.argument`, as the run
-      // does. `NOT LIKE` negates.
+      // operand, pattern, or escape is UNKNOWN, a non-NULL non-character
+      // operand or pattern a `42804` data-type mismatch (ISO `LIKE` requires
+      // character operands), else the `%`/`_` matcher decides; a non-NULL
+      // escape that is not a single character faults `SQLError.argument`, as
+      // the run does. `NOT LIKE` negates.
       let subject = try empty(operand, routines)
       let template = try empty(pattern, routines)
       let separator: Value? =
@@ -2527,13 +2915,14 @@ internal struct Scope {
       default:
         throw .argument("LIKE ESCAPE must be a single character")
       }
-      let truth: Bool? = switch (subject, template, separator) {
+      let truth: Bool?
+      switch (subject, template, separator) {
       case (.null, _, _), (_, .null, _), (_, _, .some(.null)):
-        nil
+        truth = nil
       case let (.text(subject), .text(template), _):
-        matches(subject, template, escape: character)
+        truth = matches(subject, template, escape: character)
       default:
-        false
+        throw .state("42804", "LIKE requires character operands")
       }
       return negated ? truth.map { !$0 } : truth
     case let .between(test, lower, upper, negated):
@@ -2547,9 +2936,10 @@ internal struct Scope {
       // fault, exactly as the run does.
       let value = try empty(test, routines)
       let low = try empty(lower, routines)
-      let above = matches(value, .geq, low)
+      let above = try matches(value, .geq, low)
       if above == false { return negated }
-      let within = and(above, matches(value, .leq, try empty(upper, routines)))
+      let within =
+          try and(above, matches(value, .leq, empty(upper, routines)))
       return negated ? within.map { !$0 } : within
     case let .distinct(lhs, rhs, negated):
       // Fold `a IS [NOT] DISTINCT FROM b` over the empty group as `differs`
@@ -2932,7 +3322,26 @@ internal struct Scope {
     // both skips a NULL pair before a later unsafe conjunct runs and drops a
     // non-match before an earlier one does — either suppressing the throw the
     // whole-ON residual owes. Lower the entire conjunction as one residual.
-    guard lowered.allSatisfy(\.safe) else { return lowered.conjunction! }
+    //
+    // A comparison whose operands' declared types do not reconcile now faults
+    // 42804 through the nested-loop `matches`/`relate`/`like`, so it is as
+    // throwing as a divide — and equally unsafe to bypass. A hoisted key drops
+    // every non-matching pair before that residual is reached, so a `ON L.n =
+    // R.t AND L.n = R.m` (`n`/`m` integer, `t` text) that hashes the comparable
+    // `n = m` key would let a run with no `n = m` pair silently return no rows
+    // rather than fault the cross-kind `n = t` residual — a run the validate
+    // path (`check`) already faults 42804. `lower` stamps a provably-cross-kind
+    // conjunct `Filter.incomparable`, so `safe` already reports it unsafe (the
+    // same carried classification `seek`/pushdown read — computed once, no
+    // separate recompute here): the whole `ON` stays one always-evaluated
+    // residual `nest` runs nested-loop, faulting the cross-kind pair exactly as
+    // validation does. A conjunct whose comparability the static types cannot
+    // decide — a `:parameter`/subquery operand, a constant NULL — was left
+    // unstamped (the run stays the authority for its per-run kind, as `check`
+    // defers those too), so a plain equi `ON` still hash-joins.
+    guard lowered.allSatisfy(\.safe) else {
+      return lowered.conjunction!
+    }
     // Read the equi-join key off the already-lowered term rather than
     // re-resolving the AST: a key is a `compare(.slot, .equal, .slot)` whose
     // both operands are columns of the join prefix. A conjunct that lowered to
@@ -2940,8 +3349,24 @@ internal struct Scope {
     // NOT a column = column key, so it stays the residual `ON` filter — a
     // re-resolution of its AST would consult only the prefix and fault
     // `SQLError.column` on the outer column already lowered correctly.
+    //
+    // Hoist the key only when the two columns' declared types are comparable
+    // (`ValueType.unified`, the same notion `check`'s `comparable` and the
+    // run's `matches` share) — a like-kind or numeric integer/double pair. A
+    // `.match` is the sole shape every physical join keys on (`nest`'s hash
+    // seek, the `.outer`/semijoin bucketed fast paths through `equikey`), and
+    // it never funnels through `matches`: `nest` buckets each side by its own
+    // key value, so an incomparable `A.n = B.s` (an integer against a string)
+    // hashes the two sides to disjoint buckets and no pair is ever compared —
+    // the join would silently drop every row rather than fault, whereas the
+    // validate path (`check`) already faults it 42804. Leaving an incomparable
+    // equality as the residual `compare(.slot, .equal, .slot)` routes it
+    // through the nested-loop `matches`, which faults 42804 on the cross-kind
+    // pair, so run ≡ validate. A comparable key still hoists and hashes exactly
+    // as before.
     let filters = lowered.map { residual -> Filter in
-      if case let .compare(.slot(left), .equal, .slot(right)) = residual {
+      if case let .compare(.slot(left), .equal, .slot(right)) = residual,
+          type(at: left).unified(with: type(at: right)) != nil {
         return Filter(match: left, right)
       }
       return residual
@@ -2950,13 +3375,19 @@ internal struct Scope {
   }
 
   /// Lowers the name-addressed AST `predicate` to the engine's `Filter`, each
-  /// column reference resolved to a combined ordinal across the chain.
+  /// column reference resolved to a combined ordinal across the chain, then
+  /// stamps the comparability classification onto every throwable leaf (see
+  /// `stamped`) from this scope's combined-space `type(at:)` — so the untyped
+  /// physical layer reads a cross-kind comparison's `42804` hazard through
+  /// `Filter.safe` and cannot seek/push past it.
   internal func lower(_ predicate: Predicate,
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Filter {
-    try SQLEngine.lower(predicate, term: { expression throws(SQLError) in
-      try term(expression, routines, subquery: subquery)
-    }, subquery: subquery)
+    let filter =
+        try SQLEngine.lower(predicate, term: { expression throws(SQLError) in
+          try term(expression, routines, subquery: subquery)
+        }, subquery: subquery)
+    return stamped(filter) { type(at: $0) }
   }
 }

--- a/Tests/SQLTests/Expressions/BetweenTests.swift
+++ b/Tests/SQLTests/Expressions/BetweenTests.swift
@@ -100,37 +100,36 @@ struct BetweenEvaluationTests {
   }
 }
 
-// MARK: - Cross-kind negation
+// MARK: - Cross-kind comparability
+
+/// The incomparable-type fault an integer/text bound raises.
+private let mismatch =
+    SQLError.state("42804", "cannot compare integer with character varying")
 
 struct BetweenCrossKindTests {
-  @Test func `NOT BETWEEN is the negation of BETWEEN across kinds`() throws {
-    // The parser and validator accept a cross-kind bound, so both spellings
-    // are reachable and must agree. With integer `K` and the text lower bound
-    // `'a'`, `matches` yields FALSE for every ordering operator, so `K >= 'a'`
-    // is FALSE — making BETWEEN FALSE and NOT BETWEEN TRUE. `K NOT BETWEEN 'a'
-    // AND 10` must therefore equal `NOT (K BETWEEN 'a' AND 10)`, NOT the
-    // `K < 'a' OR K > 10` expansion whose two FALSE ordering checks would
-    // wrongly reject the row.
-    try things().expect(
-        "SELECT Id FROM T WHERE K NOT BETWEEN 'a' AND 10",
-        equals: "SELECT Id FROM T WHERE NOT (K BETWEEN 'a' AND 10)")
-  }
-
-  @Test func `a cross-kind NOT BETWEEN keeps every non-NULL row`() throws {
-    // BETWEEN is FALSE for every non-NULL `K` (the cross-kind `K >= 'a'` is
-    // FALSE), so its negation keeps rows 1, 2, 3, 5; row 4's NULL `K` is
-    // UNKNOWN and stays excluded, as NOT of UNKNOWN is UNKNOWN.
+  @Test func `a cross-kind lower bound faults run and validate`() throws {
+    // `K` is integer and the lower bound `'a'` text: `K >= 'a'` is a data-type
+    // mismatch (42804), not a silent FALSE — the ISO comparability rule — so
+    // both the run (`ranged`) and the schema check fault, rather than the old
+    // FALSE that kept the row under NOT BETWEEN.
+    let query = try parse(query: "SELECT Id FROM T WHERE K BETWEEN 'a' AND 10")
+    #expect(throws: mismatch) { try things().columns(of: query) }
+    try things().expect("SELECT Id FROM T WHERE K BETWEEN 'a' AND 10",
+                        fails: mismatch)
+    // `NOT BETWEEN` reaches the same lower comparison, so it faults the same.
     try things().expect("SELECT Id FROM T WHERE K NOT BETWEEN 'a' AND 10",
-                        yields: [[1], [2], [3], [5]])
+                        fails: mismatch)
   }
 
-  @Test func `a cross-kind upper bound negates equivalently`() throws {
-    // The divergence is not lower-bound-specific: with the text upper bound
-    // `'z'`, `K <= 'z'` is FALSE, so BETWEEN is FALSE and the two spellings
-    // still agree.
-    try things().expect(
-        "SELECT Id FROM T WHERE K NOT BETWEEN 1 AND 'z'",
-        equals: "SELECT Id FROM T WHERE NOT (K BETWEEN 1 AND 'z')")
+  @Test func `a cross-kind upper bound faults when the lower does not settle`()
+      throws {
+    // With a comparable lower `1` and a text upper `'z'`, the lower does not
+    // settle the truth (a row with `K >= 1` reaches the upper), so `K <= 'z'`
+    // faults 42804 at run and validate — the upper bound is reached, not cut.
+    let query = try parse(query: "SELECT Id FROM T WHERE K BETWEEN 1 AND 'z'")
+    #expect(throws: mismatch) { try things().columns(of: query) }
+    try things().expect("SELECT Id FROM T WHERE K BETWEEN 1 AND 'z'",
+                        fails: mismatch)
   }
 }
 

--- a/Tests/SQLTests/Expressions/BooleanPredicandTests.swift
+++ b/Tests/SQLTests/Expressions/BooleanPredicandTests.swift
@@ -145,14 +145,16 @@ struct BareBooleanPredicandEvaluationTests {
     try flags().empty("SELECT Id FROM T GROUP BY Id HAVING NULL")
   }
 
-  @Test func `a non-boolean bare predicand does not fault, matching = TRUE`()
-      throws {
-    // A non-boolean operand does not fault: the engine compares it cross-kind
-    // against the boolean literal, a definite non-match, exactly as the
-    // explicit `Age = TRUE` does — so both select no rows and agree.
-    try flags().empty("SELECT Id FROM T WHERE Age")
-    try flags().expect("SELECT Id FROM T WHERE Age",
-                       equals: "SELECT Id FROM T WHERE Age = TRUE")
+  @Test func `a non-boolean bare predicand faults run and validate`() throws {
+    // `Age` is an integer, so the bare predicand desugars to `Age = TRUE` — an
+    // incomparable integer/boolean comparison (42804), not a silent non-match —
+    // so both the run and the schema check fault, exactly as an explicit `Age =
+    // TRUE` does. A genuine boolean predicand (`WHERE Flag`) still passes.
+    let error = SQLError.state("42804", "cannot compare integer with boolean")
+    let query = try parse(query: "SELECT Id FROM T WHERE Age")
+    #expect(throws: error) { try flags().columns(of: query) }
+    try flags().expect("SELECT Id FROM T WHERE Age", fails: error)
+    try flags().expect("SELECT Id FROM T WHERE Age = TRUE", fails: error)
   }
 
   @Test func `the run and schema paths agree on a bare predicand`() throws {

--- a/Tests/SQLTests/Expressions/ComparabilityTests.swift
+++ b/Tests/SQLTests/Expressions/ComparabilityTests.swift
@@ -1,0 +1,669 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixture
+
+/// A relation carrying one column of each comparable kind — an integer `N`, a
+/// text `S`, a boolean `B`, and a double `D` — beside a text relation `U` a
+/// subquery reads, so a comparison mixing any two kinds is expressible.
+private func mixed() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "N": .integer, "S": .text,
+                   "B": .boolean, "D": .double]) {
+      Row(1, 10, "x", true, 1.0)
+      Row(2, 20, "y", false, 2.5)
+    }
+    Relation("U", ["Label": .text]) {
+      Row("a")
+      Row("b")
+    }
+  }
+}
+
+/// The incomparable-type faults this fixture's cross-kind pairs raise.
+private let intVsText =
+    SQLError.state("42804", "cannot compare integer with character varying")
+private let textVsInt =
+    SQLError.state("42804", "cannot compare character varying with integer")
+private let intVsBoolean =
+    SQLError.state("42804", "cannot compare integer with boolean")
+
+// MARK: - Scalar comparison
+
+/// A cross-kind scalar comparison is a data-type mismatch, faulting on both the
+/// run and the `validate: true` schema path with the same SQLSTATE — the
+/// run ≡ validate parity the ISO comparability rule demands.
+struct ScalarComparabilityTests {
+  @Test func `a cross-kind equality faults run and validate`() throws {
+    let query = try parse(query: "SELECT Id FROM T WHERE N = S")
+    #expect(throws: intVsText) { try mixed().columns(of: query) }
+    try mixed().expect("SELECT Id FROM T WHERE N = S", fails: intVsText)
+  }
+
+  @Test func `a cross-kind inequality faults run and validate`() throws {
+    let query = try parse(query: "SELECT Id FROM T WHERE N <> S")
+    #expect(throws: intVsText) { try mixed().columns(of: query) }
+    try mixed().expect("SELECT Id FROM T WHERE N <> S", fails: intVsText)
+  }
+
+  @Test func `a cross-kind ordering faults run and validate`() throws {
+    let query = try parse(query: "SELECT Id FROM T WHERE N < S")
+    #expect(throws: intVsText) { try mixed().columns(of: query) }
+    try mixed().expect("SELECT Id FROM T WHERE N < S", fails: intVsText)
+  }
+
+  @Test func `a boolean against a number faults`() throws {
+    let query = try parse(query: "SELECT Id FROM T WHERE N = B")
+    #expect(throws: intVsBoolean) { try mixed().columns(of: query) }
+    try mixed().expect("SELECT Id FROM T WHERE N = B", fails: intVsBoolean)
+  }
+}
+
+// MARK: - Row comparison
+
+/// A row comparison folds componentwise, so an incomparable component pair
+/// faults — the same fault on run and validate.
+struct RowComparabilityTests {
+  @Test func `a cross-kind component faults run and validate`() throws {
+    let query = try parse(query: "SELECT Id FROM T WHERE (N, S) = (S, N)")
+    #expect(throws: intVsText) { try mixed().columns(of: query) }
+    try mixed().expect("SELECT Id FROM T WHERE (N, S) = (S, N)",
+                       fails: intVsText)
+  }
+
+  @Test func `a like-kind row comparison still compares`() throws {
+    // Every component pair is comparable, so the row comparison runs.
+    try mixed().expect("SELECT Id FROM T WHERE (N, S) = (10, 'x')",
+                       yields: [[1]])
+  }
+
+  @Test func `a short-circuited incomparable component faults`() throws {
+    // `(N, S) = (999, N)`: the integer first component decides FALSE (no `N` is
+    // 999), which used to short-circuit the fold before the incomparable
+    // `S`/`N` second was reached — a silent FALSE at run where `Scope.check`
+    // already rejected it. The run now preflights every component's
+    // comparability, so it faults the same reachable pair validate does.
+    let sql = "SELECT Id FROM T WHERE (N, S) = (999, N)"
+    let query = try parse(query: sql)
+    #expect(throws: textVsInt) { try mixed().columns(of: query) }
+    try mixed().expect(sql, fails: textVsInt)
+  }
+
+  @Test func `an incomparable ordering component faults past a decisive one`()
+      throws {
+    // The lexicographic cascade `(N, S) < (999, N)`: the integer first
+    // component (`N < 999`) is decisive, yet the incomparable `S`/`N` second
+    // still makes the whole row comparison ill-typed — it faults on both the
+    // run and validate, the same reachable pair.
+    let sql = "SELECT Id FROM T WHERE (N, S) < (999, N)"
+    let query = try parse(query: sql)
+    #expect(throws: textVsInt) { try mixed().columns(of: query) }
+    try mixed().expect(sql, fails: textVsInt)
+  }
+
+  @Test func `a comparable short-circuit still yields the right rows`() throws {
+    // The preflight leaves a fully-comparable row byte-for-byte: `(N, S) =
+    // (999, 'x')` short-circuits FALSE at the first component (no `N` is 999)
+    // and selects nothing, without a fault — the short-circuit is intact.
+    try mixed().empty("SELECT Id FROM T WHERE (N, S) = (999, 'x')")
+  }
+}
+
+// MARK: - Row membership
+
+/// The value-list row `IN` and the row-subquery `IN` paths fold the same
+/// componentwise `relate`, so they inherit the preflight: an incomparable
+/// component faults even when an earlier one would short-circuit the equality.
+struct RowMembershipComparabilityTests {
+  @Test func `a cross-kind row IN-list component faults run and validate`()
+      throws {
+    // `(N, S) IN ((999, N))`: the integer first component decides no-match, but
+    // the incomparable `S`/`N` second faults — on the run through `relate` and
+    // on validate, which types each element pair (`.among`).
+    let sql = "SELECT Id FROM T WHERE (N, S) IN ((999, N))"
+    let query = try parse(query: sql)
+    #expect(throws: textVsInt) { try mixed().columns(of: query) }
+    try mixed().expect(sql, fails: textVsInt)
+  }
+
+  @Test func `a cross-kind row IN subquery component faults at run`() throws {
+    // `(N, S) IN (SELECT 999, Id FROM T)`: the integer first component is FALSE
+    // for every subquery row (no `N` is 999), short-circuiting the equality
+    // before the incomparable `S`/`Id` second — yet the row subquery folds the
+    // same `relate`, so the preflight faults it at run. The static check defers
+    // a subquery operand to the run, so it admits it.
+    let sql = "SELECT Id FROM T WHERE (N, S) IN (SELECT 999, Id FROM T)"
+    try mixed().expect(sql, fails: textVsInt)
+    let query = try parse(query: sql)
+    _ = try mixed().columns(of: query)
+  }
+}
+
+// MARK: - Reflexive membership
+
+/// A relation with a nullable integer `N`, to exercise the reflexive
+/// short-circuit's NULL-operand exemption on the run.
+private func nullable() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "N": .integer, "S": .text]) {
+      Row(1, 10, "x")
+      Row(2, nil, "y")
+      Row(3, 30, "z")
+    }
+  }
+}
+
+/// A stateful counter backing a non-deterministic `tick()` routine, so a
+/// reflexive `tick()` operand reads a different value at each call.
+private final class Counter: @unchecked Sendable {
+  private var count = 0
+
+  /// Returns the sequence `1, 2, 3, …` across successive calls — two calls
+  /// never agree, so a `tick() = tick()` comparison is FALSE.
+  func next() -> Int {
+    count += 1
+    return count
+  }
+}
+
+/// A scalar `IN`-list whose reached prefix ends at a reflexive element — the
+/// operand itself (`K IN (K, …)`) — never faults the comparability check on a
+/// later element, because the run's membership Kleene-OR never faults one: a
+/// non-null operand makes `operand = operand` TRUE and short-circuits before a
+/// later element is evaluated, and a NULL operand makes every element (this one
+/// and each later one) a NULL comparison, UNKNOWN and exempt. So the validate
+/// walk stops at the reflexive element, matching the run — while respecting
+/// element order, so a cross-kind element reached first still faults.
+struct ReflexiveMembershipComparabilityTests {
+  @Test func `a reflexive element short-circuits a later cross-kind element`()
+      throws {
+    // `N IN (N, 'x')`: a non-null `N` matches the reflexive `N` and never
+    // reaches the cross-kind `'x'`; a NULL `N` reaches it but compares UNKNOWN
+    // (`NULL = 'x'`), never a 42804. So `'x'` is only ever compared to a
+    // possibly-NULL `N` — no fault on run or validate, whether or not `N` is
+    // provably non-NULL. Every non-null row matches `N = N`, so the run selects
+    // them all.
+    let sql = "SELECT Id FROM T WHERE N IN (N, 'x')"
+    let query = try parse(query: sql)
+    _ = try mixed().columns(of: query)
+    try mixed().expect(sql, yields: [[1], [2]])
+  }
+
+  @Test func `a cross-kind element before the reflexive one still faults`()
+      throws {
+    // `N IN ('x', N)`: the cross-kind `'x'` is reached first — a non-null `N`
+    // faults `N = 'x'` before the reflexive `N`, so it faults 42804 on both
+    // the run and validate. The reflexive recognition respects element order.
+    let sql = "SELECT Id FROM T WHERE N IN ('x', N)"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try mixed().columns(of: query) }
+    try mixed().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a comparable non-match before a cross-kind element still faults`()
+      throws {
+    // `N IN (1, 'x')`: `1` is comparable to `N` but not a definite match (no
+    // `N` is 1), so the walk reaches the cross-kind `'x'` and faults — the
+    // reflexive fix must not over-admit a merely-comparable earlier element.
+    let sql = "SELECT Id FROM T WHERE N IN (1, 'x')"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try mixed().columns(of: query) }
+    try mixed().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a NULL operand exempts a later cross-kind element on the run`()
+      throws {
+    // The soundness crux: a NULL operand makes `NULL IN (NULL, 'x')` UNKNOWN
+    // (never a fault), so `N IN (N, 'x')` runs cleanly even over a NULL-`N` row
+    // — the row is simply not selected. Only the non-null rows match `N = N`,
+    // confirming the reflexive short-circuit never hides a run fault.
+    try nullable().expect("SELECT Id FROM T WHERE N IN (N, 'x')",
+                          yields: [[1], [3]])
+  }
+
+  @Test func `a non-deterministic operand no longer short-circuits, faulting`()
+      throws {
+    // `tick() IN (tick(), 'x')`: the operand is a non-deterministic routine, so
+    // the run evaluates the two `tick()` calls independently — here they
+    // disagree (1 then 2), so the reflexive `tick() = tick()` is FALSE and the
+    // run reaches the cross-kind `tick() = 'x'` and faults 42804. The stability
+    // gate withholds the reflexive short-circuit (a non-deterministic operand
+    // is not stable), so the validate walk reaches the same `'x'` and faults
+    // too — the run ≡ validate parity the earlier structural-equality shortcut
+    // broke by pruning `'x'` while the run faulted on it.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    let sql = "SELECT Id FROM T WHERE tick() IN (tick(), 'x')"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) {
+      try mixed().columns(of: query, routines: routines)
+    }
+    try mixed().expect(sql, fails: intVsText, routines: routines)
+  }
+
+  @Test func `a deterministic non-column operand still short-circuits`()
+      throws {
+    // `N + 1 IN (N + 1, 'x')`: the operand is deterministic though not a bare
+    // column, so its two evaluations always agree and the reflexive `N + 1`
+    // matches per row — the comparability walk stops there, so the cross-kind
+    // `'x'` is only ever compared to a possibly-NULL `N + 1` (UNKNOWN, never
+    // 42804) and it type-checks on both paths, every row matching `N + 1 = N +
+    // 1`. The gate is stability, not column-only: a column-only gate would
+    // wrongly reach and fault `'x'`.
+    let sql = "SELECT Id FROM T WHERE N + 1 IN (N + 1, 'x')"
+    let query = try parse(query: sql)
+    _ = try mixed().columns(of: query)
+    try mixed().expect(sql, yields: [[1], [2]])
+  }
+
+  @Test func `a nullable reflexive operand no longer prunes a later element`()
+      throws {
+    // `N IN (N, 1 / 0)` over a nullable `N`: a non-null row short-circuits at
+    // the reflexive `N` and never evaluates `1 / 0`, but a NULL row runs past
+    // the UNKNOWN `N = N` and evaluates `1 / 0`, which faults. The reflexive
+    // short-circuit is only a comparability stop for a not-provably-non-NULL
+    // operand, so validate keeps validating the later element and faults the
+    // `1 / 0` too — matching the run, which faults on the NULL-`N` row 2. This
+    // is the nullable-operand guard: the prune suppressed the divide the
+    // run raises.
+    let sql = "SELECT Id FROM T WHERE N IN (N, 1 / 0)"
+    let query = try parse(query: sql)
+    #expect(throws: SQLError.divide) { try nullable().columns(of: query) }
+    try nullable().expect(sql, fails: .divide)
+  }
+
+  @Test func `a provably non-null reflexive operand still prunes fully`()
+      throws {
+    // `COALESCE(N, 0) IN (COALESCE(N, 0), 1 / 0)`: the operand is provably
+    // non-NULL — `COALESCE(N, 0)` never yields NULL — so `operand = operand` is
+    // TRUE on every row and the run short-circuits at the reflexive element,
+    // never evaluating `1 / 0`. The `defined` gate recognises this, so validate
+    // prunes the whole tail (the `1 / 0` is not validated) and type-checks,
+    // matching the run — the optimisation is preserved for a non-NULL operand.
+    // Every row matches, so the run selects them all.
+    let sql =
+        "SELECT Id FROM T WHERE COALESCE(N, 0) IN (COALESCE(N, 0), 1 / 0)"
+    let query = try parse(query: sql)
+    _ = try nullable().columns(of: query)
+    try nullable().expect(sql, yields: [[1], [2], [3]])
+  }
+
+  @Test func `a provably non-null reflexive operand prunes a cross-kind tail`()
+      throws {
+    // `COALESCE(N, 0) IN (COALESCE(N, 0), 'x')`: the provably non-NULL operand
+    // short-circuits the reflexive match, so the `'x'` is unreachable
+    // — no fault on run or validate, every row matching.
+    let sql = "SELECT Id FROM T WHERE COALESCE(N, 0) IN (COALESCE(N, 0), 'x')"
+    let query = try parse(query: sql)
+    _ = try nullable().columns(of: query)
+    try nullable().expect(sql, yields: [[1], [2], [3]])
+  }
+}
+
+// MARK: - Subquery operands
+
+/// A cross-kind `IN (Q)` or quantified comparison faults at run through
+/// `relate`. The static schema check defers to the run for a subquery operand
+/// (its single-column type may be a nominal-NULL placeholder), so it does not
+/// fault `columns(of:)` — a deliberate soundness choice keeping the run the
+/// authority there.
+struct SubqueryComparabilityTests {
+  @Test func `a cross-kind IN subquery faults at run`() throws {
+    try mixed().expect("SELECT Id FROM T WHERE N IN (SELECT Label FROM U)",
+                       fails: intVsText)
+  }
+
+  @Test func `a cross-kind IN subquery is admitted by the schema check`()
+      throws {
+    // The static comparability check defers to the run for a subquery operand,
+    // so `columns(of:)` resolves the shape without faulting (run stays the
+    // authority — no false reject of a `SELECT NULL`-typed subquery).
+    let query =
+        try parse(query: "SELECT Id FROM T WHERE N IN (SELECT Label FROM U)")
+    _ = try mixed().columns(of: query)
+  }
+
+  @Test func `a cross-kind quantified comparison faults at run`() throws {
+    try mixed().expect("SELECT Id FROM T WHERE N = ANY (SELECT Label FROM U)",
+                       fails: intVsText)
+  }
+}
+
+// MARK: - Join keys
+
+/// Two relations sharing a join column of each kind — `L.N`/`R.M` an integer
+/// pair, `L.N`/`R.T` an integer against text (an incomparable cross-kind key),
+/// and `R.D` a double (numeric-promotable against `L.N`). Neither relation
+/// carries a sort key, so a join over it hashes/buckets rather than seeks —
+/// exercising the very fast paths a cross-kind key must still fault through.
+private func joinable() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("L", ["Id": .integer, "N": .integer, "S": .text]) {
+      Row(1, 10, "x")
+      Row(2, 20, "y")
+    }
+    Relation("R", ["Id": .integer, "M": .integer, "T": .text, "D": .double]) {
+      Row(1, 10, "10", 20.0)
+      Row(2, 99, "z", 10.0)
+    }
+  }
+}
+
+/// A cross-kind equi-join key must fault 42804 at run, not silently drop every
+/// row. The optimiser hoists a `col = col` ON equality into a hash/bucket key
+/// keyed by each side's value, so an incomparable pair (`L.N = R.T`, an integer
+/// against text) hashes to disjoint buckets and no candidate is ever compared —
+/// the key is therefore hoisted only when the two columns are comparable, and
+/// an incomparable one stays a residual the nested loop evaluates through
+/// `matches`, which faults 42804. The schema path (`validate: true`) already
+/// faults it, so this restores run ≡ validate on the join key too.
+struct JoinComparabilityTests {
+  @Test func `a cross-kind inner hash-join key faults run and validate`()
+      throws {
+    let sql = "SELECT L.Id FROM L JOIN R ON L.N = R.T"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try joinable().columns(of: query) }
+    try joinable().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a cross-kind LEFT bucketed join key faults at run`() throws {
+    // The `.left`/`.full` outer join buckets the right side by its key, so a
+    // cross-kind key would bucket the two sides apart and NULL-extend every
+    // left row silently; leaving it a residual routes it through the nested
+    // loop's per-pair `matches`, which faults.
+    try joinable().expect("SELECT L.Id FROM L LEFT JOIN R ON L.N = R.T",
+                          fails: intVsText)
+  }
+
+  @Test func `a cross-kind FULL bucketed join key faults at run`() throws {
+    try joinable().expect("SELECT L.Id FROM L FULL JOIN R ON L.N = R.T",
+                          fails: intVsText)
+  }
+
+  @Test func `a cross-kind RIGHT join key faults at run`() throws {
+    try joinable().expect("SELECT L.Id FROM L RIGHT JOIN R ON L.N = R.T",
+                          fails: intVsText)
+  }
+
+  @Test func `a same-kind inner hash join still matches`() throws {
+    // A comparable key is still hoisted and hashed — `L.N = R.M` pairs `L.N`
+    // 10 with `R.M` 10 (`L.Id` 1) and leaves `L.N` 20 unmatched.
+    try joinable().expect("SELECT L.Id FROM L JOIN R ON L.N = R.M",
+                          yields: [[1]])
+  }
+
+  @Test func `a numeric int-double hash join still matches by magnitude`()
+      throws {
+    // The hash bucket promotes an integer to its double magnitude, so `L.N =
+    // R.D` matches 10 to 10.0 and 20 to 20.0 — both left rows pair.
+    try joinable().expect("SELECT L.Id FROM L JOIN R ON L.N = R.D",
+                          yields: [[1], [2]])
+  }
+
+  @Test func `a same-kind LEFT bucketed join still preserves and matches`()
+      throws {
+    // The comparable-key bucketed fast path is intact: `L.N` 10 matches, `L.N`
+    // 20 has no `R.M` 20 and is NULL-extended — `L.Id` still emitted for both.
+    try joinable().expect("SELECT L.Id FROM L LEFT JOIN R ON L.N = R.M",
+                          yields: [[1], [2]])
+  }
+}
+
+// MARK: - Preserved behaviour
+
+/// The change touches only cross-kind non-null comparisons: NULL stays UNKNOWN,
+/// numeric integer/double promotion stays comparable, and `IS DISTINCT FROM`
+/// (the null-safe comparison) stays total — never a fault.
+struct ComparabilityPreservedTests {
+  @Test func `a comparison against NULL stays UNKNOWN, never a fault`()
+      throws {
+    // `S = NULL` is UNKNOWN for every row (a constant-NULL operand is exempt),
+    // so it selects no rows and faults neither the run nor the schema check.
+    let query = try parse(query: "SELECT Id FROM T WHERE S = NULL")
+    _ = try mixed().columns(of: query)
+    try mixed().empty("SELECT Id FROM T WHERE S = NULL")
+  }
+
+  @Test func `numeric integer and double promotion still compares`() throws {
+    // An integer against a double is numeric, not cross-kind, so it compares by
+    // magnitude — `N = D` and `N = 1.0` both run and type-check cleanly.
+    let query = try parse(query: "SELECT Id FROM T WHERE N = D")
+    _ = try mixed().columns(of: query)
+    try mixed().expect("SELECT Id FROM T WHERE N = 10.0", yields: [[1]])
+  }
+
+  @Test func `IS DISTINCT FROM stays total across kinds`() throws {
+    // The null-safe comparison treats a cross-kind pair as DISTINCT without
+    // faulting (unlike a bare comparison), so `N IS DISTINCT FROM S` keeps
+    // every row and faults neither the run nor the schema check.
+    let query = try parse(query: "SELECT Id FROM T WHERE N IS DISTINCT FROM S")
+    _ = try mixed().columns(of: query)
+    try mixed().expect("SELECT Id FROM T WHERE N IS DISTINCT FROM S",
+                       yields: [[1], [2]])
+  }
+
+  @Test func `a genuine boolean predicand still filters`() throws {
+    // `WHERE B` desugars to `B = TRUE` — a like-kind boolean comparison — so a
+    // genuine boolean predicand still works where a non-boolean one faults.
+    try mixed().expect("SELECT Id FROM T WHERE B", yields: [[1]])
+  }
+}
+
+// MARK: - Optimiser safety
+
+/// A two-relation join fixture for the ON-key-hoist hazard. `L.N` and `R.M` are
+/// comparable integers that share no value, so a hash key on `L.N = R.M` drops
+/// every candidate pair; `R.K` is an integer that matches `L.N` row for row
+/// (a comparable key that pairs both rows); and `R.T` is text — so `L.N = R.T`
+/// and `L.N LIKE R.T` are cross-kind. `L` and `R` are both non-empty, so the
+/// product `L × R` a barred key falls back to is non-empty and its residual is
+/// reached.
+private func bucketed() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("L", ["Id": .integer, "N": .integer]) {
+      Row(1, 1)
+      Row(2, 2)
+    }
+    Relation("R", ["M": .integer, "K": .integer, "T": .text]) {
+      Row(8, 1, "a")
+      Row(9, 2, "b")
+    }
+  }
+}
+
+/// The non-character `LIKE` fault, raised identically by the run's `like` and
+/// the validate path's `character`.
+private let likeNonText =
+    SQLError.state("42804", "LIKE requires character operands")
+
+/// Whether `plan` reaches a `.join` — a hash join formed when an `ON` yields an
+/// extractable equi key, the observable sign the safety gate hoisted a key.
+private func joins(_ plan: Plan) -> Bool {
+  switch plan {
+  case .join: true
+  case let .select(_, source): joins(source)
+  case let .project(_, source): joins(source)
+  case let .sort(_, source): joins(source)
+  case let .limit(_, _, source): joins(source)
+  case let .distinct(source): joins(source)
+  case let .aggregate(_, _, source): joins(source)
+  case let .derived(_, sub, _, _): joins(sub)
+  case let .product(left, right): joins(left) || joins(right)
+  case let .outer(left, right, _, _): joins(left) || joins(right)
+  case let .semijoin(left, right, _, _): joins(left) || joins(right)
+  case let .apply(left, _, _, _, _, _): joins(left)
+  case let .setop(_, left, right, _, _, _): joins(left) || joins(right)
+  case .single, .empty, .scan: false
+  }
+}
+
+/// Whether `plan` reaches a `.select` standing directly over a `.product` — the
+/// residual-product a join forms when the safety gate bars key extraction, so
+/// the whole `ON` is evaluated per pair.
+private func residual(_ plan: Plan) -> Bool {
+  switch plan {
+  case .select(_, .product): true
+  case let .select(_, source): residual(source)
+  case let .project(_, source): residual(source)
+  case let .sort(_, source): residual(source)
+  case let .limit(_, _, source): residual(source)
+  case let .distinct(source): residual(source)
+  case let .aggregate(_, _, source): residual(source)
+  case let .derived(_, sub, _, _): residual(sub)
+  case let .product(left, right): residual(left) || residual(right)
+  case let .join(outer, _, _, _, _, _, _): residual(outer)
+  case let .outer(left, right, _, _): residual(left) || residual(right)
+  case let .semijoin(left, right, _, _): residual(left) || residual(right)
+  case let .apply(left, _, _, _, _, _): residual(left)
+  case let .setop(_, left, right, _, _, _): residual(left) || residual(right)
+  case .single, .empty, .scan: false
+  }
+}
+
+/// A comparison that can fault 42804 must be classified unsafe for the
+/// optimiser, so a comparable equi key elsewhere in the same `ON` cannot be
+/// hoisted into a hash bucket that drops every candidate pair before the
+/// throwing residual is reached — the bypass would silently return no rows
+/// where both the nested-loop run and the validate path fault. The gate is
+/// type-aware: a provably-comparable `ON` still hash-joins.
+struct OptimiserComparabilitySafetyTests {
+  @Test
+  func `a cross-kind residual faults though a comparable key drops all pairs`()
+      throws {
+    // `ON L.N = R.T AND L.N = R.M`: `N = M` is a comparable integer key with no
+    // matching pair. Hoisting it would bucket every pair away before the
+    // cross-kind `N = T` residual ran, returning no rows; instead the whole ON
+    // stays a residual and `N = T` faults 42804 on both the run and validate.
+    let sql = "SELECT L.Id FROM L JOIN R ON L.N = R.T AND L.N = R.M"
+    let query = try parse(query: sql)
+    #expect(throws: intVsText) { try bucketed().columns(of: query) }
+    try bucketed().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a cross-kind ON conjunct bars key extraction`() throws {
+    // The plan-level consequence of the fix: no `.join` is formed and the level
+    // is a residual `.select` over the `.product`, so the whole `ON` runs per
+    // pair rather than a hash key dropping the pairs first.
+    let sql = "SELECT L.Id FROM L JOIN R ON L.N = R.T AND L.N = R.M"
+    let compiled = try bucketed().compile(parse(query: sql))
+    let plan = try bucketed().optimise(compiled.pushdown(), [:])
+    #expect(!joins(plan))
+    #expect(residual(plan))
+  }
+
+  @Test func `a cross-kind conjunct bars key extraction regardless of order`()
+      throws {
+    // The gate rejects the whole ON whichever conjunct comes first: with the
+    // comparable key ahead of the cross-kind residual, no `.join` is still
+    // formed. (The run's fault is then data-dependent — the definite-false
+    // integer `N = M` short-circuits the Kleene `AND` per pair before the
+    // cross-kind `N = T` is reached, exactly as the nested loop would, so only
+    // the conservative validate path faults here; the optimiser safety this
+    // test pins is order-independent.)
+    let sql = "SELECT L.Id FROM L JOIN R ON L.N = R.M AND L.N = R.T"
+    let compiled = try bucketed().compile(parse(query: sql))
+    let plan = try bucketed().optimise(compiled.pushdown(), [:])
+    #expect(!joins(plan))
+    #expect(residual(plan))
+    #expect(throws: intVsText) { try bucketed().columns(of: parse(query: sql)) }
+  }
+
+  @Test
+  func `a cross-kind LIKE residual faults though a comparable key drops pairs`()
+      throws {
+    // `ON L.N LIKE R.T AND L.N = R.M`: the integer-subject LIKE faults 42804,
+    // so it too must bar the comparable `N = M` key from bucketing pairs away.
+    let sql = "SELECT L.Id FROM L JOIN R ON L.N LIKE R.T AND L.N = R.M"
+    let query = try parse(query: sql)
+    #expect(throws: likeNonText) { try bucketed().columns(of: query) }
+    try bucketed().expect(sql, fails: likeNonText)
+  }
+
+  @Test func `a cross-kind LIKE ON conjunct bars key extraction`() throws {
+    let sql = "SELECT L.Id FROM L JOIN R ON L.N LIKE R.T AND L.N = R.M"
+    let compiled = try bucketed().compile(parse(query: sql))
+    let plan = try bucketed().optimise(compiled.pushdown(), [:])
+    #expect(!joins(plan))
+    #expect(residual(plan))
+  }
+
+  @Test func `a comparable equi-join still hash-joins and matches`() throws {
+    // Every operand is an integer, so the gate leaves the key hoistable: the
+    // plan reaches a `.join`, and `L.N = R.K` pairs each row (1↔1, 2↔2). A
+    // perf-defeating over-classification would force a nested-loop residual.
+    let sql = "SELECT L.Id FROM L JOIN R ON L.N = R.K"
+    let compiled = try bucketed().compile(parse(query: sql))
+    let plan = try bucketed().optimise(compiled.pushdown(), [:])
+    #expect(joins(plan))
+    #expect(!residual(plan))
+    try bucketed().expect(sql, yields: [[1], [2]])
+  }
+
+  @Test func `a comparable multi-conjunct ON still hoists a key`() throws {
+    // Two comparable conjuncts (`L.N = R.K AND L.N = R.M`, all integer): the
+    // gate classifies both comparable, so a key is still hoisted — the fix does
+    // not fall back to a nested-loop residual when nothing can fault.
+    let sql = "SELECT L.Id FROM L JOIN R ON L.N = R.K AND L.N = R.M"
+    let compiled = try bucketed().compile(parse(query: sql))
+    let plan = try bucketed().optimise(compiled.pushdown(), [:])
+    #expect(joins(plan))
+  }
+}
+
+// MARK: - Row-comparison evaluation order
+
+/// A row comparison and a row `IN` evaluate every component of a side before
+/// `relate` compares any pair, so a component's own evaluation fault surfaces
+/// ahead of an incomparable pair's 42804. The validate path validates both rows
+/// in that same order before its comparability pass, so run ≡ validate on which
+/// fault a mixed row raises first.
+struct RowOrderComparabilityTests {
+  @Test func `a left-row divide preempts the incomparable first pair`() throws {
+    // The run builds the whole left row `(1, 1 / 0)` before comparing, dividing
+    // by zero before the incomparable `1`/`'x'` pair is reached, so it faults
+    // the divide — and validate now matches, validating the left row through
+    // its `1 / 0` before the comparability pass rather than faulting 42804 on
+    // component 0.
+    let sql = "SELECT Id FROM T WHERE (1, 1 / 0) = ('x', 2)"
+    let query = try parse(query: sql)
+    #expect(throws: SQLError.divide) { try mixed().columns(of: query) }
+    try mixed().expect(sql, fails: .divide)
+  }
+
+  @Test func `a right-row divide preempts an incomparable first pair`() throws {
+    // The incomparable pair is at component 0, but the run evaluates the whole
+    // right row `(1, 1 / 0)` — dividing — before `relate` compares, faulting
+    // the divide. Validate validates all of the left row then all of the right,
+    // hitting the `1 / 0` before the comparability pass, matching the run.
+    let sql = "SELECT Id FROM T WHERE ('x', 2) = (1, 1 / 0)"
+    let query = try parse(query: sql)
+    #expect(throws: SQLError.divide) { try mixed().columns(of: query) }
+    try mixed().expect(sql, fails: .divide)
+  }
+
+  @Test func `a row-IN element divide preempts an incomparable pair`() throws {
+    // `(N, N) IN (('x', 1 / 0))`: the run builds the whole element row before
+    // `relate` compares it, dividing by zero before the incomparable `N`/`'x'`
+    // pair is reached. Validate validates every element component before its
+    // comparability pass, so it too faults the divide, not 42804.
+    let sql = "SELECT Id FROM T WHERE (N, N) IN (('x', 1 / 0))"
+    let query = try parse(query: sql)
+    #expect(throws: SQLError.divide) { try mixed().columns(of: query) }
+    try mixed().expect(sql, fails: .divide)
+  }
+
+  @Test func `a comparable mixed row still compares componentwise`() throws {
+    // The reorder does not change a comparable row's outcome: `(N, D) = (10,
+    // 1.0)` compares integer/integer and double/double, matching row 1.
+    try mixed().expect("SELECT Id FROM T WHERE (N, D) = (10, 1.0)",
+                       yields: [[1]])
+  }
+}

--- a/Tests/SQLTests/Expressions/LikeTests.swift
+++ b/Tests/SQLTests/Expressions/LikeTests.swift
@@ -199,26 +199,28 @@ struct LikeThreeValuedTests {
                        yields: [[3]])
   }
 
-  @Test func `a non-text operand is a definite non-match`() throws {
-    // `K` is an integer column, so `K LIKE '10'` is a cross-kind comparison —
-    // FALSE for every row via the engine's cross-kind rule, NOT a fault — so no
-    // row qualifies and NOT LIKE admits every row (a definite non-match, not
-    // UNKNOWN).
-    try names().empty("SELECT Id FROM T WHERE K LIKE '10'")
-    try names().expect("SELECT Id FROM T WHERE K NOT LIKE '10'",
-                       yields: [[1], [2], [3], [4]])
+  @Test func `a non-character operand faults the run`() throws {
+    // `K` is an integer column, so `K LIKE '10'` has a non-character operand:
+    // ISO `LIKE` requires character operands, so the run faults 42804 rather
+    // than the old silent FALSE (which admitted every row under `NOT LIKE`).
+    try names().expect("SELECT Id FROM T WHERE K LIKE '10'",
+                       fails: .state("42804",
+                                     "LIKE requires character operands"))
   }
 }
 
 // MARK: - Type checking
 
 struct LikeTypeCheckingTests {
-  @Test func `a non-text operand does not fault the schema check`() throws {
-    // `K` is an integer column, but `K LIKE '10'` does NOT fault the schema
-    // check: the run yields a definite FALSE without faulting (the cross-kind
-    // rule), so the check must accept what the run accepts.
+  @Test func `a non-character operand faults the schema check`() throws {
+    // `K` is an integer column: `K LIKE '10'` has a non-character operand, so
+    // the schema check faults 42804 (ISO `LIKE` requires character operands),
+    // matching the run — run ≡ validate.
     let query = try parse(query: "SELECT Id FROM T WHERE K LIKE '10'")
-    _ = try names().columns(of: query, validate: true)
+    #expect(throws: SQLError.state("42804",
+                                   "LIKE requires character operands")) {
+      try names().columns(of: query, validate: true)
+    }
   }
 
   @Test func `a bad operand expression faults the schema check`() throws {
@@ -231,6 +233,153 @@ struct LikeTypeCheckingTests {
     #expect(throws: SQLError.operand("operands must be numeric")) {
       try resolve()
     }
+  }
+}
+
+// MARK: - NULL pattern/escape parity
+
+/// A constant-NULL `LIKE` pattern or escape makes the run UNKNOWN before its
+/// non-character fallback, so validation must admit it without enforcing the
+/// subject's character type — `K LIKE NULL` (integer `K`) runs and selects
+/// nothing, it does not fault 42804. Only a non-NULL pattern over a
+/// non-character subject faults, on both paths.
+struct LikeNullOperandTests {
+  @Test func `a NULL pattern admits a non-character subject on both paths`()
+      throws {
+    // `K` is integer; a constant-NULL pattern reads UNKNOWN regardless of `K`,
+    // so the run selects nothing and validation admits it — no 42804, matching
+    // the run. adversarial: enforcing the subject type first faults validation.
+    let query = try parse(query: "SELECT Id FROM T WHERE K LIKE NULL")
+    _ = try names().columns(of: query, validate: true)
+    try names().empty("SELECT Id FROM T WHERE K LIKE NULL")
+  }
+
+  @Test func `a NULL escape admits a non-character subject on both paths`()
+      throws {
+    // A constant-NULL escape is UNKNOWN before the non-character fallback, so
+    // `K LIKE 'x' ESCAPE NULL` (integer `K`) admits at validation and selects
+    // no rows at run — the run ≡ validate parity the NULL-first ordering keeps.
+    let query =
+        try parse(query: "SELECT Id FROM T WHERE K LIKE 'x' ESCAPE NULL")
+    _ = try names().columns(of: query, validate: true)
+    try names().empty("SELECT Id FROM T WHERE K LIKE 'x' ESCAPE NULL")
+  }
+
+  @Test func `a non-NULL pattern still faults a non-character subject`()
+      throws {
+    // With a non-NULL pattern the run reaches its non-character fallback, so
+    // `K LIKE 'x'` (integer `K`) faults 42804 at run and validation — the NULL
+    // exemption does not weaken the ordinary character-type enforcement.
+    let fault = SQLError.state("42804", "LIKE requires character operands")
+    let query = try parse(query: "SELECT Id FROM T WHERE K LIKE 'x'")
+    #expect(throws: fault) { try names().columns(of: query, validate: true) }
+    try names().expect("SELECT Id FROM T WHERE K LIKE 'x'", fails: fault)
+  }
+
+  @Test func `a character subject with a NULL pattern stays UNKNOWN`() throws {
+    // A genuine character subject `Name LIKE NULL` admits at validation and is
+    // UNKNOWN for every row at run — the NULL-pattern short-circuit is not
+    // limited to a non-character subject.
+    let query = try parse(query: "SELECT Id FROM T WHERE Name LIKE NULL")
+    _ = try names().columns(of: query, validate: true)
+    try names().empty("SELECT Id FROM T WHERE Name LIKE NULL")
+  }
+}
+
+// MARK: - NULL subject parity
+
+/// A constant-NULL `LIKE` subject makes the run's `like` return UNKNOWN from
+/// its `(.null, _, _)` arm before it inspects the pattern's type, so neither
+/// the subject nor the pattern character type is enforced — `NULL LIKE 1` runs
+/// and selects nothing, it does not fault 42804. Symmetric to the constant-NULL
+/// pattern exemption `LikeNullOperandTests` covers; only a non-NULL
+/// non-character subject reaches the character check the run's non-character
+/// fallback faults.
+struct LikeNullSubjectTests {
+  @Test func `a NULL subject with a non-character pattern does not fault`()
+      throws {
+    // `NULL LIKE 1`: the NULL subject short-circuits the run to UNKNOWN before
+    // the integer pattern's type is inspected, so it selects nothing and does
+    // not fault — the strict validate path must agree. adversarial: enforcing
+    // the pattern's character type first faults validation.
+    let query = try parse(query: "SELECT Id FROM T WHERE NULL LIKE 1")
+    _ = try names().columns(of: query, validate: true)
+    try names().empty("SELECT Id FROM T WHERE NULL LIKE 1")
+  }
+
+  @Test func `a non-NULL non-character subject still faults`() throws {
+    // The skip is scoped to a NULL subject; a non-null integer subject `K` is a
+    // non-character operand the run's `like` faults, so `K LIKE 1` still faults
+    // 42804 on both paths — the exemption does not over-suppress.
+    let fault = SQLError.state("42804", "LIKE requires character operands")
+    let query = try parse(query: "SELECT Id FROM T WHERE K LIKE 1")
+    #expect(throws: fault) { try names().columns(of: query, validate: true) }
+    try names().expect("SELECT Id FROM T WHERE K LIKE 1", fails: fault)
+  }
+}
+
+// MARK: - Parameter pattern/escape parity
+
+/// A `:parameter` `LIKE` pattern or escape carries a per-run value from the
+/// bindings — possibly NULL or unbound — so the run reads it as UNKNOWN before
+/// its non-character fallback unless a non-NULL non-character value is bound.
+/// Validation cannot know the binding, so it defers the subject's (and
+/// pattern's) character type to the run exactly as it defers a constant-NULL
+/// pattern: `K LIKE :p` (integer `K`) does not fault at validation, and at run
+/// an unbound or NULL `:p` selects nothing while a non-character-bound one
+/// faults 42804 — the run is the authority for the per-run kind. The strict
+/// validator (commit 1) must agree without the comparison-finder.
+struct LikeParameterOperandTests {
+  @Test func `a parameter pattern admits a non-character subject at validate`()
+      throws {
+    // `K` is integer; a `:pattern` operand has no binding at validate time, so
+    // enforcing the subject's character type would reject `K LIKE :pattern` a
+    // run keeps. Validation admits it, deferring to the run — no 42804.
+    let query = try parse(query: "SELECT Id FROM T WHERE K LIKE :pattern")
+    _ = try names().columns(of: query, validate: true)
+  }
+
+  @Test func `an unbound parameter pattern selects nothing at run`() throws {
+    // An unbound `:pattern` resolves to NULL, so `K LIKE :pattern` is UNKNOWN
+    // for every row before the integer subject's type is inspected — the run
+    // selects nothing and does not fault, matching the admitting validation.
+    try names().empty("SELECT Id FROM T WHERE K LIKE :pattern")
+  }
+
+  @Test func `a parameter escape admits a non-character subject at validate`()
+      throws {
+    // A `:escape` operand likewise has no binding at validate time, so
+    // `K LIKE 'x' ESCAPE :escape` (integer `K`) admits without enforcing the
+    // subject's character type — deferred to the run.
+    let query =
+        try parse(query: "SELECT Id FROM T WHERE K LIKE 'x' ESCAPE :escape")
+    _ = try names().columns(of: query, validate: true)
+  }
+
+  @Test func `an unbound parameter escape selects nothing at run`() throws {
+    // An unbound `:escape` resolves to NULL, an UNKNOWN escape, so
+    // `K LIKE 'x' ESCAPE :escape` selects nothing at run before the integer
+    // subject's type is reached — no 42804, matching validation.
+    try names().empty("SELECT Id FROM T WHERE K LIKE 'x' ESCAPE :escape")
+  }
+
+  @Test func `a non-character bound parameter pattern faults the run`() throws {
+    // The run is the authority for the per-run kind: a `:pattern` bound to a
+    // non-null integer makes `K LIKE :pattern` reach the non-character fallback
+    // on the first row, faulting 42804 exactly as `K LIKE 1` does. Validation
+    // deferred it (the binding is unknown at compile), so the run decides.
+    let fault = SQLError.state("42804", "LIKE requires character operands")
+    try names().expect("SELECT Id FROM T WHERE K LIKE :pattern",
+                       fails: fault, bindings: ["pattern": .integer(1)])
+  }
+
+  @Test func `a text bound parameter pattern still matches`() throws {
+    // A `:pattern` bound to text runs as an ordinary pattern: `Name LIKE :p`
+    // with `:p` = `'ab%'` matches the two `ab`-prefixed rows — the deferral
+    // does not disturb a well-typed bound pattern.
+    try names().expect("SELECT Id FROM T WHERE Name LIKE :pattern",
+                       yields: [[1], [2]],
+                       bindings: ["pattern": .text("ab%")])
   }
 }
 

--- a/Tests/SQLTests/Expressions/MembershipTests.swift
+++ b/Tests/SQLTests/Expressions/MembershipTests.swift
@@ -113,19 +113,18 @@ struct MembershipEvaluationTests {
 // MARK: - Type checking
 
 struct MembershipTypeCheckingTests {
-  @Test func `a cross-kind element does not fault the schema check`() throws {
-    // `K` is an integer column and `'x'` is a text element, but the schema
-    // check does NOT reject it: the lowered `K = 'x'` comparison yields FALSE
-    // at runtime via `Row.matches` without faulting, so the row still runs and
-    // may match the like-kind `10` element. The check must accept what the run
-    // accepts — so `K IN (10, 'x')` types exactly as `K IN (10)`.
+  @Test func `a cross-kind element faults the schema check and the run`()
+      throws {
+    // `K` is an integer column and `'x'` a text element: the lowered `K = 'x'`
+    // comparison is a data-type mismatch (42804), not a silent FALSE — the ISO
+    // comparability rule — so both the schema check and the run fault. The
+    // like-kind `10` does not settle the truth for a column operand, so the
+    // cross-kind `'x'` element is reached (run ≡ validate).
+    let error = SQLError.state("42804",
+                               "cannot compare integer with character varying")
     let mixed = try parse(query: "SELECT Id FROM T WHERE K IN (10, 'x')")
-    let plain = try parse(query: "SELECT Id FROM T WHERE K IN (10)")
-    let columns = try members().columns(of: mixed)
-    #expect(columns == (try members().columns(of: plain)))
-    // The run keeps the `K = 10` row: the text arm silently non-matches.
-    try members().expect("SELECT Id FROM T WHERE K IN (10, 'x')",
-                         yields: [[1]])
+    #expect(throws: error) { try members().columns(of: mixed) }
+    try members().expect("SELECT Id FROM T WHERE K IN (10, 'x')", fails: error)
   }
 
   @Test func `a numeric element of the other numeric kind is admitted`() throws {

--- a/Tests/SQLTests/Expressions/ValueTypeTests.swift
+++ b/Tests/SQLTests/Expressions/ValueTypeTests.swift
@@ -24,36 +24,50 @@ private struct Cell: Row {
 }
 
 /// Evaluates `cell op constant` through the engine's three-valued comparison —
-/// `true`, `false`, or `nil` (UNKNOWN) — the path a real `WHERE` takes.
+/// `true`, `false`, or `nil` (UNKNOWN) — the path a real `WHERE` takes. An
+/// incomparable pair faults `42804`, so this is throwing.
 private func compare(_ cell: Value, _ op: Comparison,
-                     _ constant: Value) -> Bool? {
-  try! Cell(cell).evaluate(.compare(.slot(0), op, .constant(constant)),
-                           Routines(), [:])
+                     _ constant: Value) throws(SQLError) -> Bool? {
+  try Cell(cell).evaluate(.compare(.slot(0), op, .constant(constant)),
+                          Routines(), [:])
+}
+
+/// Whether evaluating `cell op constant` faults the ISO comparability error
+/// `42804` — an incomparable cross-kind pair.
+private func incomparable(_ cell: Value, _ op: Comparison,
+                          _ constant: Value) -> Bool {
+  do {
+    _ = try compare(cell, op, constant)
+    return false
+  } catch {
+    if case .state("42804", _) = error { return true }
+    return false
+  }
 }
 
 // MARK: - Boolean
 
 @Suite
 private struct BooleanValueTests {
-  @Test func `false orders before true`() {
-    #expect(compare(.boolean(false), .lt, .boolean(true)) == true)
-    #expect(compare(.boolean(true), .lt, .boolean(false)) == false)
-    #expect(compare(.boolean(false), .lt, .boolean(false)) == false)
-    #expect(compare(.boolean(true), .gt, .boolean(false)) == true)
+  @Test func `false orders before true`() throws {
+    #expect(try compare(.boolean(false), .lt, .boolean(true)) == true)
+    #expect(try compare(.boolean(true), .lt, .boolean(false)) == false)
+    #expect(try compare(.boolean(false), .lt, .boolean(false)) == false)
+    #expect(try compare(.boolean(true), .gt, .boolean(false)) == true)
   }
 
-  @Test func `like booleans compare equal`() {
-    #expect(compare(.boolean(true), .equal, .boolean(true)) == true)
-    #expect(compare(.boolean(true), .equal, .boolean(false)) == false)
-    #expect(compare(.boolean(false), .unequal, .boolean(true)) == true)
+  @Test func `like booleans compare equal`() throws {
+    #expect(try compare(.boolean(true), .equal, .boolean(true)) == true)
+    #expect(try compare(.boolean(true), .equal, .boolean(false)) == false)
+    #expect(try compare(.boolean(false), .unequal, .boolean(true)) == true)
   }
 
-  @Test func `the boundary relations follow the false < true order`() {
-    #expect(compare(.boolean(false), .leq, .boolean(false)) == true)
-    #expect(compare(.boolean(false), .leq, .boolean(true)) == true)
-    #expect(compare(.boolean(true), .leq, .boolean(false)) == false)
-    #expect(compare(.boolean(true), .geq, .boolean(true)) == true)
-    #expect(compare(.boolean(false), .geq, .boolean(true)) == false)
+  @Test func `the boundary relations follow the false < true order`() throws {
+    #expect(try compare(.boolean(false), .leq, .boolean(false)) == true)
+    #expect(try compare(.boolean(false), .leq, .boolean(true)) == true)
+    #expect(try compare(.boolean(true), .leq, .boolean(false)) == false)
+    #expect(try compare(.boolean(true), .geq, .boolean(true)) == true)
+    #expect(try compare(.boolean(false), .geq, .boolean(true)) == false)
   }
 }
 
@@ -61,32 +75,32 @@ private struct BooleanValueTests {
 
 @Suite
 private struct BlobValueTests {
-  @Test func `like blobs compare by byte equality`() {
-    #expect(compare(.blob([0x53, 0x51, 0x4c]), .equal,
-                    .blob([0x53, 0x51, 0x4c])) == true)
-    #expect(compare(.blob([0x53, 0x51, 0x4c]), .equal,
-                    .blob([0x53, 0x51])) == false)
-    #expect(compare(.blob([]), .equal, .blob([])) == true)
-    #expect(compare(.blob([0x00]), .unequal, .blob([])) == true)
+  @Test func `like blobs compare by byte equality`() throws {
+    #expect(try compare(.blob([0x53, 0x51, 0x4c]), .equal,
+                        .blob([0x53, 0x51, 0x4c])) == true)
+    #expect(try compare(.blob([0x53, 0x51, 0x4c]), .equal,
+                        .blob([0x53, 0x51])) == false)
+    #expect(try compare(.blob([]), .equal, .blob([])) == true)
+    #expect(try compare(.blob([0x00]), .unequal, .blob([])) == true)
   }
 
-  @Test func `blobs order lexicographically — memcmp over the bytes`() {
+  @Test func `blobs order lexicographically — memcmp over the bytes`() throws {
     // A byte difference decides: `0x01` < `0x02`.
-    #expect(compare(.blob([0x01]), .lt, .blob([0x02])) == true)
-    #expect(compare(.blob([0x02]), .lt, .blob([0x01])) == false)
+    #expect(try compare(.blob([0x01]), .lt, .blob([0x02])) == true)
+    #expect(try compare(.blob([0x02]), .lt, .blob([0x01])) == false)
     // A proper prefix orders before the longer string.
-    #expect(compare(.blob([0x01]), .lt, .blob([0x01, 0x00])) == true)
-    #expect(compare(.blob([]), .lt, .blob([0x00])) == true)
+    #expect(try compare(.blob([0x01]), .lt, .blob([0x01, 0x00])) == true)
+    #expect(try compare(.blob([]), .lt, .blob([0x00])) == true)
     // A high byte outweighs a longer tail.
-    #expect(compare(.blob([0x02]), .gt, .blob([0x01, 0xff])) == true)
+    #expect(try compare(.blob([0x02]), .gt, .blob([0x01, 0xff])) == true)
   }
 
-  @Test func `the boundary relations follow the lexicographic order`() {
-    #expect(compare(.blob([0x01]), .leq, .blob([0x01])) == true)
-    #expect(compare(.blob([0x01]), .leq, .blob([0x02])) == true)
-    #expect(compare(.blob([0x02]), .leq, .blob([0x01])) == false)
-    #expect(compare(.blob([0x02]), .geq, .blob([0x01])) == true)
-    #expect(compare(.blob([0x01]), .geq, .blob([0x02])) == false)
+  @Test func `the boundary relations follow the lexicographic order`() throws {
+    #expect(try compare(.blob([0x01]), .leq, .blob([0x01])) == true)
+    #expect(try compare(.blob([0x01]), .leq, .blob([0x02])) == true)
+    #expect(try compare(.blob([0x02]), .leq, .blob([0x01])) == false)
+    #expect(try compare(.blob([0x02]), .geq, .blob([0x01])) == true)
+    #expect(try compare(.blob([0x01]), .geq, .blob([0x02])) == false)
   }
 }
 
@@ -94,19 +108,29 @@ private struct BlobValueTests {
 
 @Suite
 private struct CrossTypeComparisonTests {
-  @Test func `unlike types never match — no coercion`() {
-    // Every non-null cross-type pair falls to the switch's `default: false`.
-    #expect(compare(.boolean(true), .equal, .integer(1)) == false)
-    #expect(compare(.integer(1), .equal, .boolean(true)) == false)
-    #expect(compare(.boolean(false), .equal, .integer(0)) == false)
-    #expect(compare(.blob([0x41]), .equal, .text("A")) == false)
-    #expect(compare(.text("A"), .equal, .blob([0x41])) == false)
-    #expect(compare(.blob([0x01]), .lt, .integer(2)) == false)
-    #expect(compare(.boolean(true), .lt, .text("z")) == false)
+  @Test func `unlike types fault — the ISO comparability rule`() {
+    // Every non-null cross-kind pair is a data-type mismatch (42804), not a
+    // silent FALSE — the ISO rule a comparison's operands must be comparable.
+    #expect(incomparable(.boolean(true), .equal, .integer(1)))
+    #expect(incomparable(.integer(1), .equal, .boolean(true)))
+    #expect(incomparable(.boolean(false), .equal, .integer(0)))
+    #expect(incomparable(.blob([0x41]), .equal, .text("A")))
+    #expect(incomparable(.text("A"), .equal, .blob([0x41])))
+    #expect(incomparable(.blob([0x01]), .lt, .integer(2)))
+    #expect(incomparable(.boolean(true), .lt, .text("z")))
   }
 
-  @Test func `a NULL operand is UNKNOWN, not false`() {
-    #expect(compare(.boolean(true), .equal, .null) == nil)
-    #expect(compare(.blob([0x01]), .lt, .null) == nil)
+  @Test func `the fault names both operand domains`() {
+    #expect(throws: SQLError.state("42804",
+                                   "cannot compare boolean with integer")) {
+      try compare(.boolean(true), .equal, .integer(1))
+    }
+  }
+
+  @Test func `a NULL operand is UNKNOWN, not a fault`() throws {
+    // NULL is comparable with anything — the comparison is UNKNOWN, never the
+    // cross-kind fault, so three-valued logic is unchanged.
+    #expect(try compare(.boolean(true), .equal, .null) == nil)
+    #expect(try compare(.blob([0x01]), .lt, .null) == nil)
   }
 }

--- a/Tests/SQLTests/Optimisation/DecorrelateTests.swift
+++ b/Tests/SQLTests/Optimisation/DecorrelateTests.swift
@@ -300,6 +300,10 @@ private func subquery(_ filter: Filter) -> Bool {
     return subquery(lhs) || subquery(rhs)
   case let .not(operand):
     return subquery(operand)
+  case let .incomparable(inner):
+    // A comparison whose subquery operand makes it provably throwable is
+    // wrapped, so see through the wrapper to the underlying operands.
+    return subquery(inner)
   default:
     return false
   }
@@ -2509,5 +2513,133 @@ struct DecorrelateScalarVirtualTests {
     #expect(outers(plan))                         // decorrelated
     #expect(!subquery(in: plan))                  // no residual scalar
     try catalog.expect(sql + " ORDER BY v", yields: [[100], [300]])
+  }
+}
+
+// MARK: - Correlated cross-kind comparability gate
+
+/// The soundness oracles for the decorrelation comparability gate. A correlated
+/// equi key `inner = :outer` is hoisted to a straddling hash `.match`, which
+/// buckets the two sides by the physical join key — so a cross-kind key (an
+/// integer inner against a text outer) hashes into disjoint buckets, compares
+/// no candidate row, and would silently return no rows. That is a run ≠
+/// validate break: the strict `columns(of: validate: true)` path faults 42804
+/// on the same key. The gate leaves such an apply/select/scalar correlated so
+/// the equality routes through the nested-loop `matches`, which faults, while a
+/// comparable key still decorrelates. Each case pins both the fault (a 42804,
+/// not a silent empty) and the plan shape (a cross-kind key is not lifted; a
+/// comparable one is), across the three `equated` users.
+///
+/// `T` carries an integer `int_key` and a text `text_key`; `S` carries an
+/// integer real column `n` and a text `label`, plus its 1-based virtual `Id`
+/// (at ordinal `== width`). Correlating `S.n`/`S.Id` against `T.text_key`
+/// crosses integer with text; against `T.int_key` stays like-kind.
+private func crossKindFixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["int_key": .integer, "text_key": .text]) {
+      Row(1, "x")
+      Row(2, "y")
+    }
+    Relation("S", ["n": .integer, "label": .text]) {
+      Row(1, "a")            // Id 1
+      Row(2, "c")            // Id 2
+    }
+  }
+}
+
+/// The incomparable-type fault the integer inner key against the text outer key
+/// raises through `matches` — the left operand is the integer inner column, the
+/// right the text outer value the correlation binds.
+private let intVsTextKey =
+    SQLError.state("42804", "cannot compare integer with character varying")
+
+/// A correlated `EXISTS` whose equi correlation key is cross-kind must NOT lift
+/// to a `.semijoin` (its hash `.match` would bucket the two sides apart); it
+/// stays a correlated `.exists` that faults 42804 through `matches`, matching
+/// the validate path. A like-kind key still lifts.
+struct DecorrelateExistsComparabilityTests {
+  @Test func `a cross-kind EXISTS key is not lifted and faults`() throws {
+    let sql =
+        "SELECT T.int_key FROM T WHERE EXISTS " +
+        "(SELECT 1 FROM S WHERE S.n = T.text_key)"
+    let plan = try crossKindFixture().optimised(sql)
+    #expect(!semijoins(plan))                     // NOT decorrelated
+    #expect(exists(in: plan))                     // stays a correlated EXISTS
+    try crossKindFixture().expect(sql, fails: intVsTextKey)
+    let query = try parse(query: sql)
+    #expect(throws: intVsTextKey) { try crossKindFixture().columns(of: query) }
+  }
+
+  @Test func `a like-kind EXISTS key still decorrelates and matches`() throws {
+    let sql =
+        "SELECT T.int_key FROM T WHERE EXISTS " +
+        "(SELECT 1 FROM S WHERE S.n = T.int_key)"
+    let plan = try crossKindFixture().optimised(sql)
+    #expect(semijoins(plan))                      // decorrelated to a semijoin
+    #expect(!exists(in: plan))                    // no residual EXISTS
+    // int_key 1 finds S.n 1, int_key 2 finds S.n 2 — both match.
+    try crossKindFixture().expect(sql + " ORDER BY T.int_key",
+                                  yields: [[1], [2]])
+  }
+}
+
+/// A correlated CROSS APPLY whose equi correlation key is cross-kind must NOT
+/// fold to a `.join`; it stays an `.apply` that faults 42804 through `matches`.
+/// A like-kind key still folds.
+struct DecorrelateApplyComparabilityTests {
+  @Test func `a cross-kind CROSS APPLY key stays an apply and faults`()
+      throws {
+    let sql =
+        "SELECT T.int_key, d.n FROM T " +
+        "JOIN LATERAL (SELECT S.n FROM S WHERE S.n = T.text_key) AS d ON 1 = 1"
+    let plan = try crossKindFixture().optimised(sql)
+    #expect(applies(plan))                        // NOT decorrelated
+    #expect(!joins(plan))
+    try crossKindFixture().expect(sql, fails: intVsTextKey)
+    let query = try parse(query: sql)
+    #expect(throws: intVsTextKey) { try crossKindFixture().columns(of: query) }
+  }
+
+  @Test func `a like-kind CROSS APPLY key still decorrelates and matches`()
+      throws {
+    let sql =
+        "SELECT T.int_key, d.n FROM T " +
+        "JOIN LATERAL (SELECT S.n FROM S WHERE S.n = T.int_key) AS d ON 1 = 1"
+    let plan = try crossKindFixture().optimised(sql)
+    #expect(!applies(plan))                       // decorrelated
+    #expect(joins(plan))
+    // int_key 1 matches S.n 1, int_key 2 matches S.n 2.
+    try crossKindFixture().expect(sql + " ORDER BY T.int_key",
+                                  yields: [[1, 1], [2, 2]])
+  }
+}
+
+/// A correlated scalar subquery whose equi correlation key is the unique
+/// virtual `Id` but cross-kind must not fold to a LEFT `.outer` join; it stays
+/// a residual `.subquery` that faults 42804 through `matches`. A like-kind key
+/// still folds.
+struct DecorrelateScalarComparabilityTests {
+  @Test func `a cross-kind scalar Id key stays correlated and faults`()
+      throws {
+    let sql =
+        "SELECT (SELECT S.label FROM S WHERE S.Id = T.text_key) FROM T"
+    let plan = try crossKindFixture().optimised(sql)
+    #expect(subquery(in: plan))                   // NOT decorrelated
+    #expect(!outers(plan))
+    try crossKindFixture().expect(sql, fails: intVsTextKey)
+    let query = try parse(query: sql)
+    #expect(throws: intVsTextKey) { try crossKindFixture().columns(of: query) }
+  }
+
+  @Test func `a like-kind scalar Id key still decorrelates and matches`()
+      throws {
+    let sql =
+        "SELECT (SELECT S.label FROM S WHERE S.Id = T.int_key) AS v FROM T"
+    let plan = try crossKindFixture().optimised(sql)
+    #expect(outers(plan))                         // decorrelated
+    #expect(!subquery(in: plan))
+    // int_key 1 reads S row 1 (label "a"), int_key 2 reads S row 2 (label "c").
+    try crossKindFixture().expect(sql + " ORDER BY v",
+                                  yields: [["a"], ["c"]])
   }
 }

--- a/Tests/SQLTests/Queries/ComparabilityPlanningTests.swift
+++ b/Tests/SQLTests/Queries/ComparabilityPlanningTests.swift
@@ -1,0 +1,277 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// A relation sorted on `Id` (so a range on it seeks a physical run) beside an
+/// integer `N`, a text `S`, and a second integer `J` — enough to write a
+/// cross-kind residual `N = S` next to a seekable `Id` range, and a comparable
+/// residual `N = J` for the no-regression check.
+private func seekable() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer, "N": .integer, "S": .text, "J": .integer],
+             sorted: "Id") {
+      Row(1, 10, "x", 10)
+      Row(2, 20, "y", 20)
+    }
+  }
+}
+
+/// A left relation `A` joined to a right relation `B` sorted on `Bid`, `B`
+/// carrying an integer `Bn` and a text `Bs` for a cross-kind residual pushed to
+/// the inner side, and a comparable `Ak = Bk` equi key.
+private func joinable() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("A", ["Ak": .integer, "Ax": .integer]) {
+      Row(1, 100)
+      Row(2, 200)
+    }
+    Relation("B", ["Bid": .integer, "Bk": .integer, "Bn": .integer,
+                   "Bs": .text],
+             sorted: "Bid") {
+      Row(1, 1, 10, "x")
+      Row(2, 2, 20, "y")
+    }
+  }
+}
+
+/// The incomparable-type fault a `integer = character varying` pair raises on
+/// both the run and the `validate: true` schema path.
+private let intVsText =
+    SQLError.state("42804", "cannot compare integer with character varying")
+
+// MARK: - Seek must not drop a cross-kind residual
+
+/// Since a cross-kind comparison faults `42804`, the physical seek must not
+/// treat it as a safe residual and drop it over an emptied range — the exact
+/// optimiser bypass the carried comparability classification closes. Both the
+/// run and the validate path fault, in lockstep.
+struct SeekComparabilityTests {
+  @Test func `an emptied seek keeps the cross-kind residual and faults`()
+      throws {
+    // `N = S` is the cross-kind conjunct and `Id < 0` the emptied seekable
+    // range beside it. The un-seeked scan evaluates the leading `N = S` on the
+    // first row and faults; the buggy optimiser would seek the empty `Id < 0`
+    // run and keep `N = S` as a residual over the sought (empty) rows, never
+    // evaluating it. The carried classification marks `N = S` unsafe so the
+    // seek is declined and the fault surfaces on both run and validate.
+    let query = try parse(query: "SELECT Id FROM T WHERE N = S AND Id < 0")
+    #expect(throws: intVsText) { try seekable().columns(of: query) }
+    try seekable().expect("SELECT Id FROM T WHERE N = S AND Id < 0",
+                          fails: intVsText)
+  }
+
+  @Test func `the emptied-seek plan does not seek past the cross-kind conjunct`()
+      throws {
+    // The carried classification marks `N = S` unsafe, so `seek` declines the
+    // one-conjunct seek (an unsafe residual over the sought run) and leaves the
+    // full scan under the whole filter — no seeked `.scan` in the plan.
+    let catalog = try seekable()
+    let compiled = try catalog.compile(parse("SELECT Id FROM T "
+                                              + "WHERE N = S AND Id < 0"))
+    let plan = try catalog.optimise(compiled, [:])
+    #expect(!sought(plan))
+  }
+
+  @Test func `a standalone cross-kind comparison over a sorted table faults`()
+      throws {
+    // No seekable conjunct at all: the whole filter is the cross-kind residual,
+    // which must scan and fault rather than be folded away.
+    let query = try parse(query: "SELECT Id FROM T WHERE N = S")
+    #expect(throws: intVsText) { try seekable().columns(of: query) }
+    try seekable().expect("SELECT Id FROM T WHERE N = S", fails: intVsText)
+  }
+}
+
+// MARK: - Pushdown must not push a cross-kind predicate past a row-dropper
+
+/// A cross-kind conjunct pushed onto a join's inner side, beside a seekable
+/// emptying range on that side, must not be dropped when the executor seeks the
+/// inner by the range — the pushdown/inner-seek analog of the plain seek
+/// bypass. Both paths fault at commit 1.
+struct PushdownComparabilityTests {
+  @Test func `a cross-kind inner conjunct beside an emptied range faults`()
+      throws {
+    // The cross-kind `B.Bn = B.Bs` leads the emptied seekable `B.Bid < 0` on
+    // the inner side, so selection pushdown lands both on `B`'s scan. The
+    // executor materialises `B` under the leading `B.Bn = B.Bs` and faults; the
+    // carried classification keeps it from being seeked past the empty
+    // `B.Bid < 0` run (which would drop it and yield no inner rows).
+    let sql = "SELECT A.Ax FROM A JOIN B ON A.Ak = B.Bk "
+            + "WHERE B.Bn = B.Bs AND B.Bid < 0"
+    #expect(throws: intVsText) { try joinable().columns(of: parse(query: sql)) }
+    try joinable().expect(sql, fails: intVsText)
+  }
+
+  @Test func `a cross-kind ON conjunct bars the key hoist and faults`() throws {
+    // A cross-kind `ON` conjunct beside a comparable equi key forbids hoisting
+    // the key (which would hash the sides into disjoint buckets and silently
+    // drop every pair), so the whole `ON` stays a nested-loop residual that
+    // faults the cross-kind pair — run and validate agree.
+    let sql = "SELECT A.Ax FROM A JOIN B ON A.Ak = B.Bk AND A.Ax = B.Bs"
+    #expect(throws: intVsText) { try joinable().columns(of: parse(query: sql)) }
+    try joinable().expect(sql, fails: intVsText)
+  }
+}
+
+// MARK: - No regression: comparable filters still seek and hash
+
+/// Over-classifying a comparable filter as unsafe would force a scan or a
+/// nested loop where a seek or hash join is available — a real cost. A
+/// like-kind seek and a like-kind equi join must keep their fast plans.
+struct ComparablePlanRegressionTests {
+  @Test func `a like-kind residual still seeks the range`() throws {
+    // `Id < 5` seeks the sorted key and the comparable `N = J` rides below as a
+    // safe residual — the optimised plan still reaches a seeked `.scan`.
+    let catalog = try seekable()
+    let compiled = try catalog.compile(parse("SELECT Id FROM T "
+                                              + "WHERE Id < 5 AND N = J"))
+    let plan = try catalog.optimise(compiled, [:])
+    #expect(sought(plan))
+    try catalog.expect("SELECT Id FROM T WHERE Id < 5 AND N = J",
+                       yields: [[1], [2]])
+  }
+
+  @Test func `a like-kind equi join still hashes`() throws {
+    // `A.Ak = B.Bk` is a comparable key, so the join hoists it and reaches the
+    // hash/index `.join` node rather than a residual product.
+    let catalog = try joinable()
+    let compiled =
+        try catalog.compile(parse("SELECT A.Ax FROM A JOIN B ON A.Ak = B.Bk"))
+    let plan = try catalog.optimise(compiled, [:])
+    #expect(joined(plan))
+  }
+}
+
+// MARK: - An unreachable BETWEEN upper must not bar the hoist
+
+/// `stamped`'s `.between` reconciled both bounds unconditionally, so a
+/// cross-kind upper barred a sibling equi key's hash join even when the lower's
+/// static FALSE makes the upper unreachable — the run's `ranged` short-circuits
+/// on `test >= lower` before ever reaching the upper, so it cannot fault. The
+/// `settled` gate now mirrors that short-circuit, leaving such a BETWEEN safe
+/// so the comparable equi key still hoists. A reachable cross-kind upper (the
+/// lower does not settle) stays unsafe and faults, so soundness is unchanged.
+struct BetweenShortCircuitPlanningTests {
+  @Test func `an unreachable cross-kind BETWEEN upper keeps the hash join`()
+      throws {
+    // `0 BETWEEN 1 AND 'x'`: `0 >= 1` is statically FALSE, so `ranged` never
+    // reaches the `'x'` upper and it cannot fault. The BETWEEN is safe, so
+    // `Scope.on` hoists the comparable `A.Ak = B.Bk` into a hash `.join` rather
+    // than degrading to a Cartesian nested loop.
+    let catalog = try joinable()
+    let sql = "SELECT A.Ax FROM A JOIN B "
+            + "ON 0 BETWEEN 1 AND 'x' AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(try catalog.compile(parse(sql)), [:])
+    #expect(joined(plan))
+  }
+
+  @Test func `the unreachable-upper BETWEEN join runs, no fault`() throws {
+    // The BETWEEN is FALSE for every pair (the `'x'` upper never reached), so
+    // the inner join yields nothing — and crucially never faults 42804, on
+    // either the validate or the run path.
+    let catalog = try joinable()
+    let sql = "SELECT A.Ax FROM A JOIN B "
+            + "ON 0 BETWEEN 1 AND 'x' AND A.Ak = B.Bk"
+    _ = try catalog.columns(of: parse(query: sql))
+    try joinable().empty(sql)
+  }
+
+  @Test func `a reachable cross-kind BETWEEN upper still bars the hoist`()
+      throws {
+    // `5 BETWEEN 1 AND 'x'`: `5 >= 1` is TRUE, so the lower does not settle the
+    // truth and `ranged` reaches the `'x'` upper — a reachable cross-kind pair
+    // that faults. The BETWEEN stays unsafe, no key is hoisted, and both paths
+    // fault 42804.
+    let catalog = try joinable()
+    let sql = "SELECT A.Ax FROM A JOIN B "
+            + "ON 5 BETWEEN 1 AND 'x' AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(try catalog.compile(parse(sql)), [:])
+    #expect(!joined(plan))
+    #expect(throws: intVsText) { try catalog.columns(of: parse(query: sql)) }
+    try joinable().expect(sql, fails: intVsText)
+  }
+}
+
+// MARK: - A NULL-determined LIKE must not bar the hoist
+
+/// `stamped`'s `.like` required the subject to be character (and ignored the
+/// escape), so a NULL-determined LIKE — a NULL pattern, escape, or subject the
+/// run reads as UNKNOWN before any character check, never faulting — barred a
+/// sibling equi key's hash join. The NULL-first gate (`vanishes` and the
+/// constant-NULL subject skip) now leaves such a LIKE safe so the equi key
+/// still hoists, while a reachable non-character LIKE stays unsafe and faults.
+struct LikeNullDeterminedPlanningTests {
+  private let notText =
+      SQLError.state("42804", "LIKE requires character operands")
+
+  @Test func `a NULL pattern over an integer subject keeps the hash join`()
+      throws {
+    // `B.Bn LIKE NULL` (integer `Bn`): the NULL pattern makes the whole LIKE
+    // UNKNOWN before the subject's non-character type is read, so it cannot
+    // fault. Safe, so the comparable `A.Ak = B.Bk` hoists to a `.join`.
+    let catalog = try joinable()
+    let sql = "SELECT A.Ax FROM A JOIN B ON B.Bn LIKE NULL AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(try catalog.compile(parse(sql)), [:])
+    #expect(joined(plan))
+    _ = try catalog.columns(of: parse(query: sql))
+    try joinable().empty(sql)
+  }
+
+  @Test func `a NULL escape over an integer subject keeps the hash join`()
+      throws {
+    // `B.Bn LIKE 'x' ESCAPE NULL`: the NULL escape likewise vanishes the LIKE
+    // to UNKNOWN. The escape was previously ignored by `stamped`, so the
+    // non-text subject wrongly barred the hoist; the gate now reads the escape.
+    let catalog = try joinable()
+    let sql = "SELECT A.Ax FROM A JOIN B "
+            + "ON B.Bn LIKE 'x' ESCAPE NULL AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(try catalog.compile(parse(sql)), [:])
+    #expect(joined(plan))
+    _ = try catalog.columns(of: parse(query: sql))
+    try joinable().empty(sql)
+  }
+
+  @Test func `a NULL subject over a non-character pattern keeps the hash join`()
+      throws {
+    // `NULL LIKE 1`: the constant-NULL subject short-circuits `like` to UNKNOWN
+    // from its `(.null, _, _)` arm before the pattern's type is read, so it
+    // cannot fault. Safe, so the equi key hoists.
+    let catalog = try joinable()
+    let sql = "SELECT A.Ax FROM A JOIN B ON NULL LIKE 1 AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(try catalog.compile(parse(sql)), [:])
+    #expect(joined(plan))
+    _ = try catalog.columns(of: parse(query: sql))
+    try joinable().empty(sql)
+  }
+
+  @Test func `a reachable non-character LIKE still bars the hoist`() throws {
+    // `B.Bn LIKE 'x'` (integer `Bn`, non-NULL pattern): a reachable
+    // non-character subject the run faults. The LIKE stays unsafe, no key is
+    // hoisted, and both paths fault 42804.
+    let catalog = try joinable()
+    let sql = "SELECT A.Ax FROM A JOIN B ON B.Bn LIKE 'x' AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(try catalog.compile(parse(sql)), [:])
+    #expect(!joined(plan))
+    #expect(throws: notText) { try catalog.columns(of: parse(query: sql)) }
+    try joinable().expect(sql, fails: notText)
+  }
+
+  @Test func `a parameter LIKE pattern beside an equi key bars the hoist`()
+      throws {
+    // A `:parameter` pattern is not NULL-determined — it may bind a
+    // non-character value the run faults on — so `stamped` keeps it unsafe
+    // (unlike `check`, which defers it to the run). No key is hoisted, so a
+    // cross-kind binding faults at run rather than hashing rows away first.
+    let catalog = try joinable()
+    let sql = "SELECT A.Ax FROM A JOIN B ON B.Bn LIKE :p AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(try catalog.compile(parse(sql)), [:])
+    #expect(!joined(plan))
+    try joinable().expect(sql, fails: notText, bindings: ["p": .integer(1)])
+  }
+}

--- a/Tests/SQLTests/Queries/ParameterComparabilityPlanningTests.swift
+++ b/Tests/SQLTests/Queries/ParameterComparabilityPlanningTests.swift
@@ -1,0 +1,148 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// A left relation `A` and a right relation `B` with integer join keys, plus a
+/// second integer on each so a comparison against a run-time `:parameter` sits
+/// beside a comparable `A.Ak = B.Bk` equi key.
+private func joinable() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("A", ["Ak": .integer, "Ax": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+    }
+    Relation("B", ["Bk": .integer, "Bm": .integer]) {
+      Row(1, 1)
+      Row(2, 2)
+    }
+  }
+}
+
+/// The incomparable-type fault an `integer` against a `character varying` pair
+/// raises at run.
+private let intVsText =
+    SQLError.state("42804", "cannot compare integer with character varying")
+
+// MARK: - A run-time :parameter operand is a throwable residual, not a key gate
+
+/// A comparison against a `:parameter` (`.bound`) can fault `42804` at run — the
+/// binding may be a non-NULL incomparable value — so it is NOT safe to hoist a
+/// sibling equi key past it. The classifier stamps it unsafe at compile (the
+/// binding is not yet known), so `Scope.on` declines the hoist and the whole
+/// `ON` stays a nested-loop residual that faults, rather than hashing the
+/// comparable key into disjoint buckets and silently returning no rows.
+struct BoundOperandComparabilityTests {
+  @Test func `a text-bound parameter beside an equi key bars the hoist`()
+      throws {
+    // `A.Ak = :p AND A.Ak = B.Bk`: the parameter comparison leads the equi key.
+    // The buggy classifier read `.bound` unconditionally safe, hoisted
+    // `A.Ak = B.Bk` into a hash key, and — with no matching bucket — dropped
+    // every pair before the `.bound` residual ran, silently returning empty.
+    // The `.bound` is now stamped unsafe, so no key is hoisted (no `.join`).
+    let catalog = try joinable()
+    let sql =
+        "SELECT A.Ax FROM A JOIN B ON A.Ak = :p AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(catalog.compile(parse(sql)),
+                                    ["p": .text("z")])
+    #expect(!joined(plan))
+  }
+
+  @Test func `a text-bound parameter beside an equi key faults at run`()
+      throws {
+    // The nested-loop `ON` evaluates `A.Ak = :p` first per pair, so a text-bound
+    // `:p` against the integer `A.Ak` faults `42804` — not a silent empty.
+    let sql =
+        "SELECT A.Ax FROM A JOIN B ON A.Ak = :p AND A.Ak = B.Bk"
+    try joinable().expect(sql, fails: intVsText, bindings: ["p": .text("z")])
+  }
+
+  @Test func `an integer-bound parameter still matches correctly`() throws {
+    // A comparable binding never faults: `:p` = 1 admits the `A.Ak = 1` row and
+    // the equi key selects its `B` partner. The residual stays a nested loop,
+    // but the result is correct — the soundness fix costs no correctness.
+    let sql =
+        "SELECT A.Ax FROM A JOIN B ON A.Ak = :p AND A.Ak = B.Bk"
+    try joinable().expect(sql, yields: [[10]], bindings: ["p": .integer(1)])
+  }
+}
+
+// MARK: - A parameterised BETWEEN bound is a throwable residual
+
+/// A `BETWEEN` with a `:parameter` bound can fault `42804` at run, so a sibling
+/// equi key must not hoist past it — the `.between` analogue of the `.bound`
+/// bar.
+struct BetweenParameterComparabilityTests {
+  @Test func `a text-bound BETWEEN bound beside an equi key bars the hoist`()
+      throws {
+    // `A.Ax BETWEEN :lo AND 10 AND A.Ak = B.Bk`: the parameterised range leads
+    // the equi key. The `.between` is stamped unsafe (its `:lo` bound is an
+    // opaque run-time value), so `Scope.on` declines the hoist — no `.join`.
+    let catalog = try joinable()
+    let sql = "SELECT A.Ax FROM A JOIN B "
+            + "ON A.Ax BETWEEN :lo AND 10 AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(catalog.compile(parse(sql)),
+                                    ["lo": .text("z")])
+    #expect(!joined(plan))
+  }
+
+  @Test func `a text-bound BETWEEN bound beside an equi key faults at run`()
+      throws {
+    // The nested-loop `ON` evaluates the range's `A.Ax >= :lo` per pair, so a
+    // text-bound `:lo` against the integer `A.Ax` faults `42804`.
+    let sql = "SELECT A.Ax FROM A JOIN B "
+            + "ON A.Ax BETWEEN :lo AND 10 AND A.Ak = B.Bk"
+    try joinable().expect(sql, fails: intVsText, bindings: ["lo": .text("z")])
+  }
+}
+
+// MARK: - An unreachable cross-kind IN element must not bar the hoist
+
+/// The membership walk honours the run's Kleene-OR short-circuit: an element
+/// after a definite match is never compared and cannot fault, so it must not
+/// mark the whole `IN` unsafe. A reachable cross-kind element still does. This
+/// is the over-strictness fix — a sibling equi key beside such an `IN` keeps
+/// its hash join.
+struct MembershipReachabilityPlanningTests {
+  @Test func `a constant-matched IN beside an equi key keeps the hash join`()
+      throws {
+    // `1 IN (1, 'x')`: the run matches `1 = 1` and never reaches `'x'`, so the
+    // `IN` cannot fault. The classifier stops at the constant match, leaves the
+    // `IN` safe, and `Scope.on` hoists the comparable `A.Ak = B.Bk` — a `.join`.
+    let catalog = try joinable()
+    let sql = "SELECT A.Ax FROM A JOIN B ON 1 IN (1, 'x') AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(catalog.compile(parse(sql)), [:])
+    #expect(joined(plan))
+    try catalog.expect(sql, yields: [[10], [20]])
+  }
+
+  @Test func `a reflexive IN beside an equi key keeps the hash join`() throws {
+    // `A.Ak IN (A.Ak, 'x')`: `A.Ak = A.Ak` is TRUE for a non-NULL row and
+    // UNKNOWN (never a fault) for a NULL one, so `'x'` is never a reachable
+    // fault. The classifier stops at the reflexive element, so the `IN` is safe
+    // and the equi key still hashes.
+    let catalog = try joinable()
+    let sql =
+        "SELECT A.Ax FROM A JOIN B ON A.Ak IN (A.Ak, 'x') AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(catalog.compile(parse(sql)), [:])
+    #expect(joined(plan))
+    try catalog.expect(sql, yields: [[10], [20]])
+  }
+
+  @Test func `a reachable cross-kind IN element still bars the hoist`() throws {
+    // `A.Ak IN ('x', A.Ak)`: the run compares `A.Ak = 'x'` FIRST and faults, so
+    // the cross-kind element is reachable and the `IN` is unsafe — the equi key
+    // is not hoisted and the run faults `42804`.
+    let catalog = try joinable()
+    let sql =
+        "SELECT A.Ax FROM A JOIN B ON A.Ak IN ('x', A.Ak) AND A.Ak = B.Bk"
+    let plan = try catalog.optimise(catalog.compile(parse(sql)), [:])
+    #expect(!joined(plan))
+    catalog.expect(sql, fails: intVsText)
+  }
+}


### PR DESCRIPTION
A comparison whose operands are of incomparable declared types — a number against a string, a boolean against a blob — used to evaluate to a definite FALSE (the `default: false` arm of `matches`), and a non-boolean bare predicand (`WHERE Age`) silently yielded no rows through its `Age = TRUE` desugar. ISO 9075 requires a comparison's operands to be comparable; an incomparable pair is a data-type mismatch, not a FALSE-valued row. Raise it as SQLSTATE 42804.

The check lives at two mirrored seams so the run and the type-check agree:

  - Runtime: `matches` (and the row-wise `relate`, and `like`) fault 42804 on a cross-kind non-null pair rather than returning FALSE, exactly as `Arithmetic.apply` faults an ill-typed arithmetic operand. This is the sole choke point every comparison funnels through — scalar `=`/`<>`/`<`/…, IN (value list and subquery), BETWEEN, LIKE, quantified ANY/ALL, row comparison, and joins — so the run enforces ISO everywhere it evaluates a reachable operand. The run path never type-checks (`validate: false`), so it must fault at evaluation, matching the arithmetic precedent.

  - Validate: `Scope.check` derives both operand types and faults 42804 when they do not unify (`ValueType.unified`), reachability- and short-circuit- aware, so `columns(of: validate: true)` faults the same reachable operand a run would. Applied to `=`/`<>`/`<`/`>`/`<=`/`>=`, IN value lists, BETWEEN, LIKE (operand and pattern must be character), row comparison, and NULLIF's implicit `v1 = v2`.

run ≡ validate: both fault the same reachable cross-kind pair with the same SQLSTATE; both defer an unreachable one (a short-circuited AND/OR leg, a data-dependent-empty body). A constant-NULL operand is exempt on both paths — the run reads a NULL comparison as UNKNOWN (never a fault), so `text = NULL` stays UNKNOWN, three-valued logic unchanged. A subquery operand's static comparability defers to the run (its single-column type may be a nominal-NULL placeholder, which would else mis-reject a `SELECT NULL` body); the run still faults a cross-kind IN/quantified subquery through `relate`.

The optimiser's equi-join key extraction shares that comparability notion, so an optimised join preserves the fault rather than silently dropping rows. A join's `ON col = col` equality is hoisted into a hash/bucket key — `Scope.on` rewrites it to the `match` node the physical inner `nest`, the `.left`/`.full` bucketed outer join, and the semijoin fast paths all key on — and each of those paths compares only the row pairs that fall in a common bucket. A cross-kind key (`A.n = B.s`, an integer against a string) therefore hashes the two sides into disjoint buckets, compares no candidate pair, and would silently return no matches, even though `check` already faults the same ON equality on the validate path — a run ≠ validate break. The key is now hoisted only when the two columns' declared types unify (`ValueType.unified`, the same notion `check` and `matches` use); an incomparable equality stays a residual `compare` the nested loop evaluates through `matches`, which faults 42804 — so the run faults identically to the nested-loop and validate paths. A comparable key (like-kind or numeric integer/double) still hoists and hashes byte-for-byte as before.

Consequence for the bare predicand: `WHERE p`/`HAVING p`/`ON p` lowers to `p = TRUE`, so a non-boolean `p` now faults (an integer against the boolean literal is incomparable), while a genuine boolean predicand (`p = TRUE`, like-kind) still passes.

Unchanged: `IS [NOT] DISTINCT FROM` stays total — a cross-kind pair is DISTINCT, never a fault — through a dedicated non-throwing equality kernel; NULL/UNKNOWN three-valued logic; and numeric integer/double promotion, which stays comparable (`1 = 1.0`). Compile-time constant folds swallow a would-be comparability fault to an undecided `nil` (as they already do a divide or overflow), so the optimiser keeps the compare and its fault surfaces at run.

Two further run ≠ validate breaks in the row and LIKE seams are closed. The row comparison `relate` folded componentwise and short-circuited the Boolean at the first decisive (or NULL) component, so a later incomparable pair never faulted — `(N, S) = (999, N)` over `N != 999` returned a silent FALSE at run where `check` already rejected it. It now preflights every component pair's comparability through `matches` before the short-circuiting fold, so an incomparable component faults 42804 regardless of an earlier decisive one; the value-list row `IN` and the row-subquery `IN`/quantified paths share `relate`, so they inherit the preflight, and a comparable row still folds byte-for-byte. And `check`'s LIKE handling enforced the subject's character type before accounting for a constant-NULL pattern or escape, while the run reads such a NULL as UNKNOWN before its non-character fallback — so `K LIKE NULL` and `K LIKE 'x' ESCAPE NULL` (integer `K`) ran and selected nothing but validation rejected them. Validation now mirrors that NULL-first ordering: a constant-NULL pattern or escape admits the predicate without enforcing the subject's character type, while a non-NULL pattern over a non-character subject still faults on both paths. Symmetrically, a constant-NULL subject makes the run's `like` UNKNOWN from its `(.null, _, _)` arm before it inspects the pattern's type, so `NULL LIKE 1` runs and selects nothing; validation now skips both the subject and the pattern character check when the subject folds to a constant NULL, matching that arm, while a non-null non-character subject (`K LIKE 1`) still faults on both paths.

The `IN` value-list comparability walk honours a third short-circuit the run's `member` makes, beside the row-independent constant match: a reflexive element, one structurally equal to a stable operand (`K IN (K, …)`). Once it is reached no later element can fault — a non-null operand makes `operand = operand` TRUE and short-circuits the Kleene-OR (later elements never evaluated), and a NULL operand makes every element (this one and each later one) a NULL comparison, UNKNOWN and exempt — so the walk stops there, leaving later elements unchecked. The short-circuit is gated on the operand being stable (`stable`), not merely structurally equal: the run evaluates the operand and the element independently, so `operand = operand` is a definite match only when both evaluations always agree. A column or a deterministic non-column expression (`K + 1`) is stable, so `K IN (K, 'x')` and `K + 1 IN (K + 1, 'x')` (integer `K`) type-check and run where they wrongly faulted 42804 at validate before; a non-deterministic operand is not stable, so `tick() IN (tick(), 'x')` no longer prunes the cross-kind `'x'` — the run reaches `tick() = 'x'` when the two calls disagree and faults, and the walk now faults with it rather than silently admitting. Gating on structural equality alone was unsound for a non-deterministic operand: it declared the first element a definite match and skipped the later cross-kind one the run faults on, a validate-under-rejects-run break. The determinism predicate is recursive — a column or literal is stable, a routine call is stable only when the routine is deterministic and every argument is stable, arithmetic/CAST/ COALESCE/NULLIF/CASE/aggregate over stable sub-expressions stays stable, and a subquery operand is conservatively unstable (no reflexive shortcut, which is safe). `K IN ('x', K)` (the cross-kind element reached first) and `K IN (1, 'x')` (`1` is comparable but not a definite match, so the walk reaches `'x'`) still fault, matching the run's order-preserving fold. The recognition is scoped to the comparability walk, not the shared `matched` reachability fold `constant(_ predicate:)` reads, since `K IN (K, …)` is UNKNOWN (not constant-TRUE) for a NULL operand and the optimiser must not fold it away. The row `IN` (`.among`) does not take the same short-circuit: a partially-NULL left row can reach a later element row and fault on its non-null component, so a reflexive row element is not fault-safe there, unlike the single scalar operand.

Tests: flips the former cross-kind = FALSE / non-match assertions to assert the 42804 fault on both the run and the schema path (Membership, Between, Like, ValueType, and the bare-predicand tests), adds a ComparabilityTests parity probe over scalar/row/subquery/NULL/promotion/DISTINCT shapes, and a JoinComparabilityTests suite asserting a cross-kind inner (hashed) and LEFT/RIGHT/FULL join key faults 42804 at run while a same-kind and a numeric integer/double key still hash and match. The two parity fixes add row short-circuit and lexicographic-ordering cases plus a RowMembershipComparability suite to ComparabilityTests, a LikeNullOperandTests suite over the NULL-pattern/escape parity, and a LikeNullSubjectTests suite over the constant-NULL subject parity — `NULL LIKE 1` admits and selects nothing while `K LIKE 1` (integer `K`) still faults 42804 on both paths. A ReflexiveMembershipComparability suite covers the reflexive short-circuit: `K IN (K, 'x')` admits at run and validate, the cross-kind-first `K IN ('x', K)` and comparable-non-match `K IN (1, 'x')` orderings still fault 42804 on both, a NULL-`K` row runs without a fault, a deterministic non-column `N + 1 IN (N + 1, 'x')` still short-circuits (proving the gate is stability, not column-only), and a non-deterministic `tick() IN (tick(), 'x')` faults 42804 on both paths (proving the stability gate).