### PR TITLE
SQLEngine: drop non-standard `FROM`-less `SELECT

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -459,13 +459,13 @@ public struct Select: Hashable, Sendable {
   /// The columns the query yields.
   public let projection: Projection
 
-  /// The primary relation the query scans, or `nil` for a FROM-less `SELECT`
-  /// that projects over a single empty row.
-  public let from: Relation?
+  /// The primary relation the query scans. A `SELECT` always has a `FROM`: the
+  /// dialect admits no FROM-less `SELECT` (the ISO `VALUES` table value
+  /// constructor is the way to project a computed row).
+  public let from: Relation
 
   /// The joins applied to `from`, in source order — `from JOIN joins[0] JOIN
-  /// joins[1] …`, a left-deep chain. Empty for a single-relation query and for
-  /// a FROM-less one.
+  /// joins[1] …`, a left-deep chain. Empty for a single-relation query.
   public let joins: Array<Join>
 
   /// The row filter, if any.
@@ -495,7 +495,7 @@ public struct Select: Hashable, Sendable {
   public let limit: Limit?
 
   public init(distinct: Bool = false, projection: Projection,
-              from: Relation?, joins: Array<Join> = [],
+              from: Relation, joins: Array<Join> = [],
               predicate: Predicate? = nil, grouping: Grouping = .keys([]),
               having: Predicate? = nil, order: Order? = nil,
               limit: Limit? = nil) {
@@ -510,13 +510,12 @@ public struct Select: Hashable, Sendable {
     self.limit = limit
   }
 
-  /// The name of the primary relation, or the empty string for a FROM-less
-  /// `SELECT`.
+  /// The name of the primary relation.
   ///
   /// Retained for single-relation consumers that only ever name one table; it
   /// reads the `from` relation's name.
   public var table: String {
-    from?.name ?? ""
+    from.name
   }
 
   /// Whether the EXISTS cardinality `probe` preserves this select's existence —

--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -229,15 +229,65 @@ public struct Query: Hashable, Sendable {
     self.carriers = carriers
   }
 
-  /// The first `SELECT` of the query — the leftmost arm, reached by descending
-  /// the left arm of each set operation. Its projection names the result
-  /// columns (the ISO rule — their types unify across every arm), so a `CREATE
-  /// VIEW` infers a set operation's column names from it. Carriers are
-  /// transparent — the first is the body's.
-  public var first: Select {
+  /// The query's leftmost arm as a carrier-free `Query` — reached by descending
+  /// the left arm of each set operation, stopping at the first non-`setop` body
+  /// (a `select`). Its projection names the result columns (the ISO rule —
+  /// their types unify across every arm), so `CREATE VIEW`/CTE column inference
+  /// reads its output. Carriers are transparent — the leftmost is the body's —
+  /// so this works for any body, not only one bottoming out in a `Select`.
+  public var arm: Query {
     switch body {
-    case let .select(select): select
-    case let .setop(_, left, _, _): left.first
+    case .select: core
+    case let .setop(_, left, _, _): left.arm
+    }
+  }
+
+  /// The query's output column names, inferred from its leftmost arm's
+  /// projection — the ISO rule a `UNION`'s result columns follow (the names
+  /// come from the first arm), shared by `CREATE VIEW`/CTE column inference. A
+  /// `*` or an unaliased non-column expression names no column and faults
+  /// `SQLError.named`, exactly as `Projection.names()` does.
+  public var names: Array<String> {
+    get throws(SQLError) {
+      switch arm.body {
+      case let .select(select): try select.projection.names()
+      case .setop: []
+      }
+    }
+  }
+
+  /// The statically-known width of the query's output — the leftmost arm's
+  /// projected item count — or `nil` when it is not statically known (a `SELECT
+  /// *`, whose width resolves only against the relations in scope). It is the
+  /// arity a `CREATE VIEW`/CTE explicit column list is checked against.
+  public var arity: Int? {
+    switch arm.body {
+    case let .select(select):
+      switch select.projection {
+      case .all: nil
+      case let .columns(columns): columns.count
+      case let .expressions(items): items.count
+      }
+    case .setop: nil
+    }
+  }
+
+  /// The projection surface of the query's leftmost arm — the projected items
+  /// an `ORDER BY` ordinal / output-name / projected-expression key resolves
+  /// against on the carrier path. A `columns` list lowers each to a bare-column
+  /// `Projected`, an `expressions` list is itself, and a `*` (no enumerated
+  /// projection) yields none. Body-agnostic so a carrier over any leftmost arm
+  /// reads its output surface uniformly.
+  internal var items: Array<Projected> {
+    switch arm.body {
+    case let .select(select):
+      switch select.projection {
+      case let .expressions(list): list
+      case let .columns(columns):
+        columns.map { Projected(expression: .column($0)) }
+      case .all: []
+      }
+    case .setop: []
     }
   }
 

--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -174,6 +174,16 @@ public struct Query: Hashable, Sendable {
     /// `all`) over a left and a right query term, the right appended so a
     /// same-precedence chain reads left to right.
     case setop(SetOperation, Query, Query, all: Bool)
+    /// The ISO `<table value constructor>` `VALUES (v, …), (v, …), …` — one row
+    /// per parenthesised tuple of scalar expressions, evaluated over the single
+    /// empty row (as a FROM-less `SELECT` evaluates a constant). Every row has
+    /// equal arity (the ISO degree rule), at least one row, each with at least
+    /// one element. Its result columns are named the ISO default `column1,
+    /// column2, …` and typed by unifying each column across the rows (a column
+    /// mixing integer and double widening to double), so `VALUES` is a
+    /// first-class query body — a leaf the compile/schema/execute paths handle
+    /// directly — rather than desugaring to a `UNION ALL` of FROM-less selects.
+    case values(Array<Array<Expression>>)
   }
 
   /// A query-level `ORDER BY` / `SELECT DISTINCT` / `OFFSET`·`FETCH` carried
@@ -237,7 +247,7 @@ public struct Query: Hashable, Sendable {
   /// so this works for any body, not only one bottoming out in a `Select`.
   public var arm: Query {
     switch body {
-    case .select: core
+    case .select, .values: core
     case let .setop(_, left, _, _): left.arm
     }
   }
@@ -251,6 +261,9 @@ public struct Query: Hashable, Sendable {
     get throws(SQLError) {
       switch arm.body {
       case let .select(select): try select.projection.names()
+      case let .values(rows): (0 ..< (rows.first?.count ?? 0)).map {
+        "column\($0 + 1)"
+      }
       case .setop: []
       }
     }
@@ -268,6 +281,7 @@ public struct Query: Hashable, Sendable {
       case let .columns(columns): columns.count
       case let .expressions(items): items.count
       }
+    case let .values(rows): rows.first?.count
     case .setop: nil
     }
   }
@@ -287,6 +301,12 @@ public struct Query: Hashable, Sendable {
         columns.map { Projected(expression: .column($0)) }
       case .all: []
       }
+    case let .values(rows):
+      // The first row named `column1, column2, …` — the ISO default output
+      // names, the surface an `ORDER BY` output-name/ordinal key binds against.
+      (rows.first ?? []).enumerated().map {
+        Projected(expression: $0.element, alias: "column\($0.offset + 1)")
+      }
     case .setop: []
     }
   }
@@ -301,7 +321,7 @@ public struct Query: Hashable, Sendable {
   /// SUM(m)) UNION SELECT n` is a valid one-column union).
   internal var generated: Int {
     let body: Int = switch self.body {
-    case .select: 0
+    case .select, .values: 0
     case let .setop(_, left, _, _): left.generated
     }
     return carriers.reduce(body) { $0 + $1.generated }

--- a/Sources/SQLEngine/Aggregation.swift
+++ b/Sources/SQLEngine/Aggregation.swift
@@ -364,6 +364,35 @@ extension Query {
       left.existential.union(right.existential)
     }
   }
+
+  /// The `Role`s `query` occupies within this arm under a carrier's `order` —
+  /// the union of the roles it occupies in this leftmost arm's own clauses and
+  /// the roles it occupies in the carrier's `ORDER BY` keys. The carrier path
+  /// classifies its `ORDER BY` subqueries this way — over the leftmost arm's
+  /// output surface plus the carrier order — rather than through a synthetic
+  /// `Select`, so it resolves for any body (a `Select` arm or a `VALUES` one).
+  internal func roles(of query: Query, order: Order?) -> Array<Role> {
+    var armScalar = false, armValued = false, armExistential = false
+    if case let .select(select) = arm.body {
+      armScalar = select.scalar.contains(query)
+      armValued = select.valued.contains(query)
+      armExistential = select.existential.contains(query)
+    }
+    var scalar = Set<Query>(), valued = Set<Query>(), existential = Set<Query>()
+    for key in order?.keys ?? [] {
+      guard case let .expression(expression) = key.sort else { continue }
+      expression.collect(scalar: &scalar)
+      expression.collect(valued: &valued)
+      expression.collect(existential: &existential)
+    }
+    var roles = Array<Role>()
+    if armScalar || scalar.contains(query) { roles.append(.scalar) }
+    if armValued || valued.contains(query) { roles.append(.valued) }
+    if armExistential || existential.contains(query) {
+      roles.append(.existential)
+    }
+    return roles
+  }
 }
 
 extension Select {

--- a/Sources/SQLEngine/Aggregation.swift
+++ b/Sources/SQLEngine/Aggregation.swift
@@ -310,6 +310,7 @@ extension Query {
     switch body {
     case let .select(select): select.bound
     case let .setop(_, left, right, _): left.bound || right.bound
+    case let .values(rows): rows.contains { $0.contains(where: \.bound) }
     }
   }
 
@@ -323,6 +324,10 @@ extension Query {
     switch body {
     case let .select(select): select.subqueries
     case let .setop(_, left, right, _): left.subqueries + right.subqueries
+    case let .values(rows):
+      rows.reduce(into: Array<Query>()) { queries, row in
+        for expression in row { expression.collect(subqueries: &queries) }
+      }
     }
   }
 
@@ -336,6 +341,10 @@ extension Query {
     switch body {
     case let .select(select): select.valued
     case let .setop(_, left, right, _): left.valued.union(right.valued)
+    case let .values(rows):
+      rows.reduce(into: Set<Query>()) { queries, row in
+        for expression in row { expression.collect(valued: &queries) }
+      }
     }
   }
 
@@ -348,6 +357,10 @@ extension Query {
     switch body {
     case let .select(select): select.scalar
     case let .setop(_, left, right, _): left.scalar.union(right.scalar)
+    case let .values(rows):
+      rows.reduce(into: Set<Query>()) { queries, row in
+        for expression in row { expression.collect(scalar: &queries) }
+      }
     }
   }
 
@@ -362,23 +375,39 @@ extension Query {
     case let .select(select): select.existential
     case let .setop(_, left, right, _):
       left.existential.union(right.existential)
+    case let .values(rows):
+      rows.reduce(into: Set<Query>()) { queries, row in
+        for expression in row { expression.collect(existential: &queries) }
+      }
     }
   }
 
   /// The `Role`s `query` occupies within this arm under a carrier's `order` —
-  /// the union of the roles it occupies in this leftmost arm's own clauses and
-  /// the roles it occupies in the carrier's `ORDER BY` keys. The carrier path
-  /// classifies its `ORDER BY` subqueries this way — over the leftmost arm's
-  /// output surface plus the carrier order — rather than through a synthetic
-  /// `Select`, so it resolves for any body (a `Select` arm or a `VALUES` one).
+  /// the union of the roles it occupies in this leftmost arm's own clauses (a
+  /// `Select`'s, or a `VALUES` body's row expressions) and the roles it
+  /// occupies in the carrier's `ORDER BY` keys. The carrier path classifies its
+  /// `ORDER BY` subqueries this way — over the leftmost arm's output surface
+  /// plus the carrier order — rather than through a synthetic `Select`, so it
+  /// resolves for any body; `compile(values:)` reuses it (with no order) to
+  /// classify a row expression's own nested subqueries.
   internal func roles(of query: Query, order: Order?) -> Array<Role> {
-    var armScalar = false, armValued = false, armExistential = false
-    if case let .select(select) = arm.body {
-      armScalar = select.scalar.contains(query)
-      armValued = select.valued.contains(query)
-      armExistential = select.existential.contains(query)
-    }
     var scalar = Set<Query>(), valued = Set<Query>(), existential = Set<Query>()
+    switch arm.body {
+    case let .select(select):
+      scalar = select.scalar
+      valued = select.valued
+      existential = select.existential
+    case let .values(rows):
+      for row in rows {
+        for expression in row {
+          expression.collect(scalar: &scalar)
+          expression.collect(valued: &valued)
+          expression.collect(existential: &existential)
+        }
+      }
+    case .setop:
+      break
+    }
     for key in order?.keys ?? [] {
       guard case let .expression(expression) = key.sort else { continue }
       expression.collect(scalar: &scalar)
@@ -386,11 +415,9 @@ extension Query {
       expression.collect(existential: &existential)
     }
     var roles = Array<Role>()
-    if armScalar || scalar.contains(query) { roles.append(.scalar) }
-    if armValued || valued.contains(query) { roles.append(.valued) }
-    if armExistential || existential.contains(query) {
-      roles.append(.existential)
-    }
+    if scalar.contains(query) { roles.append(.scalar) }
+    if valued.contains(query) { roles.append(.valued) }
+    if existential.contains(query) { roles.append(.existential) }
     return roles
   }
 }

--- a/Sources/SQLEngine/Carrier.swift
+++ b/Sources/SQLEngine/Carrier.swift
@@ -57,13 +57,14 @@ extension Catalog where Self: ~Escapable {
     // projected aggregate by resolved identity (`SUM(s.Qty)` ≡ projected
     // `SUM(Qty)`), the plain grouped `ORDER BY` path's rule. A plain arm has no
     // grouped aggregate space and injects none.
+    let arm = union.arm
     let resolver: Resolver? =
-        if case .arm = union.first.grouping {
-          try projected(arm: union.first, context)
+        if case let .select(select) = arm.body, case .arm = select.grouping {
+          try projected(arm: select, context)
         } else {
           nil
         }
-    return try carried(over: plan, output: cols, arm: union.first,
+    return try carried(over: plan, output: cols, arm: arm,
                        distinct: distinct, order: order, limit: limit,
                        generated: generated, resolver: resolver, context)
   }
@@ -93,9 +94,9 @@ extension Catalog where Self: ~Escapable {
   /// `OFFSET`·`FETCH` — over an already-compiled set-operation `plan`, resolved
   /// through the setop's output scope. `plan`'s output sits at slots
   /// `0 ..< output.count`, the arm-0-named, type-unified result columns
-  /// (`output`); `arm` is the union's FIRST arm — its projection is the surface
-  /// a projected-expression / aliased / qualified ORDER BY key matches against
-  /// by AST (a plain set-op arm).
+  /// (`output`); `arm` is the query's leftmost arm (a carrier-free `Query`) —
+  /// its `items` projection surface is what a projected-expression / aliased /
+  /// qualified ORDER BY key matches against by AST (a plain set-op arm).
   ///
   /// `resolver`, when injected, lowers the arm's projected items to a grouped
   /// slot space and lowers an arbitrary expression to the same space — a
@@ -118,7 +119,7 @@ extension Catalog where Self: ~Escapable {
   /// (`0 ..< real`), which also trims any hidden materialised column.
   internal borrowing func carried(over plan: Plan,
                                   output cols: Array<ResolvedColumn>,
-                                  arm: Select, distinct: Bool, order: Order?,
+                                  arm: Query, distinct: Bool, order: Order?,
                                   limit: Limit?, generated: Int,
                                   resolver: Resolver? = nil,
                                   _ context: Context)
@@ -143,14 +144,7 @@ extension Catalog where Self: ~Escapable {
     // slots `0 ..< real` are the real outputs and `real ..< width` the hidden
     // ones. The hidden expressions map to their `*gsN` output slots for a
     // materialised ORDER BY key.
-    let items: Array<Projected> = switch arm.projection {
-    case let .expressions(list):
-      list
-    case let .columns(columns):
-      columns.map { Projected(expression: .column($0)) }
-    case .all:
-      []
-    }
+    let items = arm.items
     // Range-check the `generated` count against the width and derive the trim
     // width `real` through the shared guard (see `real(trimming:of:)`), which
     // faults a malformed public-AST count rather than letting the `0 ..< real`
@@ -207,7 +201,7 @@ extension Catalog where Self: ~Escapable {
     // ORDER BY / DISTINCT names resolve unqualified over the `schema`; its
     // inner query is inspected nowhere here, so the arm-0 `SELECT` stands in
     // for it uniformly.
-    let scope = Scope([(Relation(derived: .select(arm), as: ""), schema)])
+    let scope = Scope([(Relation(derived: arm, as: ""), schema)])
     // collect and resolve the carrier ORDER BY's own nested subqueries — the
     // same machinery a plain `SELECT … ORDER BY CASE WHEN EXISTS (…) …` uses
     // (`subquery(_:_:_:within:)` builds a `Resolution` recording each nested
@@ -221,31 +215,23 @@ extension Catalog where Self: ~Escapable {
     // position bars a new correlation (`.barred` inside `scope.order`), so a
     // genuinely-unsupported case still faults exactly as it does on a SELECT.
     //
-    // `roles(of:)` classifies a subquery by the clause it occurs in, so the
-    // recording pass must inspect a select whose ORDER BY IS the carrier's —
-    // NOT the bare `arm`, whose own ORDER BY does not carry the carrier's sort-
-    // key subqueries. Reusing `arm` there records no runtime plan (empty
-    // roles), so a correlated carrier sort-key subquery lowers to a
+    // `roles(of:order:)` classifies a subquery by the clause it occurs in — the
+    // carrier path's `ORDER BY` IS the carrier's, NOT the leftmost arm's own (a
+    // bare arm's ORDER BY does not carry the carrier's sort-key subqueries).
+    // Classifying over `arm`'s clauses ⊕ the carrier's `order` records a
+    // correlated carrier sort-key subquery's runtime plan (else it lowers to a
     // `Term.subquery`/`.parameter` yet faults "a correlated subquery plan was
-    // not compiled" at execution — where the same ORDER BY on a plain SELECT
-    // records and re-executes it per row. Overlay the carrier's `order` on the
-    // arm (keeping the arm's projection surface a projected-expression key
-    // resolves against) so the recording sees the carrier's sort-key subqueries
-    // in their ORDER BY role. The projected-key resolution itself still runs
-    // over `arm` in `scope.order` below; `subquery(_:_:_:within:)` reads the
-    // passed select ONLY for `roles(of:)`.
+    // not compiled" at execution), and resolves for any leftmost arm — a
+    // `Select` or a `VALUES` — without a synthetic classifier `Select`.
     var subqueries = Array<Query>()
     for key in order?.keys ?? [] {
       if case let .expression(expression) = key.sort {
         expression.collect(subqueries: &subqueries)
       }
     }
-    let classifier = Select(distinct: arm.distinct, projection: arm.projection,
-                            from: arm.from, joins: arm.joins,
-                            predicate: arm.predicate, grouping: arm.grouping,
-                            having: arm.having, order: order, limit: arm.limit)
-    let resolution = try subquery(subqueries, classifier, context,
-                                  within: scope)
+    let resolution = try subquery(subqueries,
+                                  roles: { arm.roles(of: $0, order: order) },
+                                  context, within: scope)
     // The identity projection over the REAL output slots, and the REAL output
     // names a bare ORDER BY name or a DISTINCT key binds against — alias-or-
     // bare, `nil` for an unnamed output. `scope.order` bounds an ordinal key by

--- a/Sources/SQLEngine/Carrier.swift
+++ b/Sources/SQLEngine/Carrier.swift
@@ -468,6 +468,47 @@ extension Catalog where Self: ~Escapable {
       keys = try SQLEngine.distinct(order.keys, keys,
                                     (0 ..< real).map(Term.slot))
     }
+    // A `VALUES` leaf holds each row's cell expressions in the leaf itself,
+    // below the carrier's limit. Stacking a `limit` over it evaluates every
+    // row's cells before the slice runs — the `limit` interpreter materialises
+    // its whole source, then pages — so a row the page drops still evaluates,
+    // faulting `VALUES (1 / 0) FETCH FIRST 0 ROWS` and running a dropped row's
+    // side effects. A `SELECT` is spared this by sitting its projection above
+    // the limit (`Project(Limit(…))`, see `Plan.shaped`), so a dropped row
+    // never runs its select list. Give the constructor the same sparing when it
+    // carries neither an ORDER BY nor a DISTINCT — each of which must evaluate
+    // every row to sort or dedup it — by applying the positional limit at
+    // compile time: slice the leaf's rows, so a discarded row's cells never
+    // lower into the plan and so never evaluate. The `Limit` count and offset
+    // are constant integers (the AST models no dynamic or parameterised page
+    // bound), so the slice is exact and total. An ORDER BY or a DISTINCT keeps
+    // the eager `.values` leaf and evaluates every row, as sorting and
+    // deduplicating require. The sliced set may be empty (`FETCH FIRST 0 ROWS`,
+    // an `OFFSET` past the end); the empty-body guard already passed on the
+    // original non-empty rows, so an empty result is a valid `.values([])`
+    // leaf, not the malformed empty node that guard rejects. The validate
+    // path's value-check pages the same rows through the same `paged`, so a
+    // discarded row's cell faults neither the run nor `columns(of: validate:)`
+    // — the two agree (see `typecheck(values:)`).
+    //
+    // The positional slice pages the rows but does not trim their columns, so a
+    // carrier with a nonzero `generated` (a hand-built public `Query.Carrier`
+    // combining `generated` with a limit over a wider `.values`) still needs
+    // its trailing hidden columns dropped: the schema path trims them
+    // (`columns(unifying:)`, `cols.prefix(real)`), so the run must too or it
+    // returns `width` columns where `columns(of:)` advertises `real`. Trim the
+    // sliced leaf with the same identity projection `0 ..< real` the eager path
+    // below applies — the page already dropped the discarded rows, so the
+    // projection only trims the surviving rows' columns and re-introduces no
+    // eager evaluation. When `real == width` (the parser's every carrier, whose
+    // `generated` is `0`) the projection is the identity, so return the sliced
+    // leaf directly and keep the plan shape the common path had.
+    if !distinct, order == nil, let limit,
+       case let .values(rows, types) = plan {
+      let sliced = Plan.values(rows: paged(rows, by: limit), types: types)
+      guard real < width else { return sliced }
+      return .project((0 ..< real).map(Term.slot), sliced)
+    }
     // Stack the row operators over the union plan, trimming to the REAL output
     // columns with the identity projection `0 ..< real` (dropping any hidden
     // materialised sort column).
@@ -475,4 +516,22 @@ extension Catalog where Self: ~Escapable {
                        projection: (0 ..< real).map(Term.slot),
                        filter: nil, order: keys, limit: limit)
   }
+}
+
+/// The `VALUES` rows a positional `limit` keeps — the compile-time counterpart
+/// of the interpreter's `limited` row slice (see `Interpreter`). Drops the
+/// leading `offset` rows, then caps at `count` (no cap when `count` is nil, an
+/// `OFFSET` without a `FETCH`). Both bounds are the constant integers the parser
+/// and the range guard already vetted non-negative.
+///
+/// It is generic over the row element so the one slice serves both the run and
+/// the validate paths and the two cannot drift: the compile lowers a leaf's
+/// `Term` rows through it, so a discarded row's cells never evaluate, and the
+/// `columns(of: validate:)` value-check pages the `Expression` rows through it,
+/// so it validates only the rows the run evaluates (see `typecheck(values:)`).
+internal func paged<Row>(_ rows: Array<Row>, by limit: Limit) -> Array<Row> {
+  guard limit.offset < rows.count else { return [] }
+  let tail = rows[limit.offset...]
+  guard let count = limit.count else { return Array(tail) }
+  return Array(tail.prefix(count))
 }

--- a/Sources/SQLEngine/Compilation.swift
+++ b/Sources/SQLEngine/Compilation.swift
@@ -364,7 +364,12 @@ extension Catalog where Self: ~Escapable {
                          generated: carrier.generated, context)
     }
     guard case let .setop(kind, left, right, all) = query.body else {
-      return try compile(query.first, context)
+      // A carrier-free non-set-operation body is a single `SELECT` (a `.values`
+      // body is intercepted ahead of this dispatch), compiled directly.
+      guard case let .select(select) = query.body else {
+        preconditionFailure("a carrier-free non-setop body is a SELECT")
+      }
+      return try compile(select, context)
     }
 
     // A set operation collects no derived aliases at the query level — arms are
@@ -376,17 +381,17 @@ extension Catalog where Self: ~Escapable {
     // d` resolves `d`'s width. It is per arm so the left arm's `d` never
     // leaks to the right (the arm-scoping fix); the width each check computes
     // matches what the arm actually produces at run.
-    // Compare each operand's real output width — its first arm's projection
-    // width less the hidden `generated` sort columns the carriers on the path
-    // appended (a parenthesised operand with an unprojected-aggregate ORDER BY
-    // carries one, trimmed at its carrier), so a valid one-column union of such
-    // an operand is not rejected on the leaked hidden column.
-    let head = try augment(context, for: .select(query.first), rows: false)
-    let tail = try augment(context, for: .select(right.first), rows: false)
+    // Compare each operand's real output width — its leftmost arm's width less
+    // the hidden `generated` sort columns the carriers on the path appended (a
+    // parenthesised operand with an unprojected-aggregate ORDER BY carries one,
+    // trimmed at its carrier), so a valid one-column union of such an operand
+    // is not rejected on the leaked hidden column. `arity(_ query:_:)` descends
+    // to the leftmost arm and augments it, so it measures a `SELECT`, a
+    // `TABLE`, or a `VALUES` operand alike.
     let width = try real(trimming: query.generated,
-                         of: arity(query.first, head))
+                         of: arity(query, context))
     let count = try real(trimming: right.generated,
-                         of: arity(right.first, tail))
+                         of: arity(right, context))
     guard count == width else { throw .arity(width, count) }
     // Both arms of a set-operation subquery correlate against the same
     // enclosing scope, so each lowers under the shared `context.outer`. The
@@ -513,6 +518,22 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func subquery(_ queries: Array<Query>, _ select: Select,
                                    _ context: Context, within: Scope?)
       throws(SQLError) -> Resolution {
+    // The select classifies each collected subquery's role (`scalar`/`valued`/
+    // `existential`); the carrier path supplies its own body-agnostic
+    // classifier through the roles overload below.
+    try subquery(queries, roles: { select.roles(of: $0) }, context,
+                 within: within)
+  }
+
+  /// `subquery(_:_:_:within:)` with the subquery-role classification supplied
+  /// as a closure rather than read off a `Select` — the seam the carrier uses
+  /// to classify a query-level `ORDER BY`'s subqueries over a leftmost arm that
+  /// need not be a `Select` (a `VALUES` body). Every other caller passes a
+  /// `Select`'s own `roles(of:)`.
+  internal borrowing func subquery(_ queries: Array<Query>,
+                                   roles: (Query) -> Array<Role>,
+                                   _ context: Context, within: Scope?)
+      throws(SQLError) -> Resolution {
     // A nested subquery's FROM resolves against base tables and enclosing CTEs,
     // NOT the enclosing SELECT's derived-table aliases (SELECT-scoped, unseen
     // by a subquery's FROM as a base-table alias would be) — so strip them, the
@@ -601,7 +622,7 @@ extension Catalog where Self: ~Escapable {
       // exactly as the uncorrelated EXISTS probes. A schema-only path threads a
       // throwaway memo, harmless there.
       if !nested.correlation.isEmpty {
-        for role in select.roles(of: query) {
+        for role in roles(query) {
           // Recompile the EXISTS probe leniently (`validate: false`), the same
           // way the `plan` above compiled: this builds the run-time plan a
           // correlated re-execution reuses, so it must not eager-type-check a
@@ -781,6 +802,26 @@ extension Catalog where Self: ~Escapable {
       relations.append((joins[index].relation, resolved.schema))
     }
     return (joined, relations)
+  }
+
+  /// The raw output width of `query`'s leftmost arm — the operand width the
+  /// `UNION` arity check compares (before trimming the carriers' hidden
+  /// `generated` sort columns). It descends the left arm of each set operation
+  /// to the leftmost non-`setop` body and measures it: a `SELECT`'s projected
+  /// width (a `*` resolved against its own augmented FROM/JOIN scope), or a
+  /// `VALUES` body's row width. Body-agnostic, so a `VALUES` or `TABLE` operand
+  /// measures exactly as a `SELECT` one.
+  private borrowing func arity(_ query: Query, _ context: Context)
+      throws(SQLError) -> Int {
+    switch query.body {
+    case let .setop(_, left, _, _):
+      return try arity(left, context)
+    case let .select(select):
+      // The leftmost arm resolves its own FROM/JOIN derived aliases (arms are
+      // SELECT-scoped), so augment it before measuring a `*`.
+      let scope = try augment(context, for: .select(select), rows: false)
+      return try arity(select, scope)
+    }
   }
 
   /// The number of result columns `select` projects — the extent of a `*` over

--- a/Sources/SQLEngine/Compilation.swift
+++ b/Sources/SQLEngine/Compilation.swift
@@ -364,12 +364,16 @@ extension Catalog where Self: ~Escapable {
                          generated: carrier.generated, context)
     }
     guard case let .setop(kind, left, right, all) = query.body else {
-      // A carrier-free non-set-operation body is a single `SELECT` (a `.values`
-      // body is intercepted ahead of this dispatch), compiled directly.
-      guard case let .select(select) = query.body else {
-        preconditionFailure("a carrier-free non-setop body is a SELECT")
+      // A carrier-free non-set-operation body is a single `SELECT` or a
+      // `VALUES` table value constructor, compiled to its own leaf.
+      switch query.body {
+      case let .select(select):
+        return try compile(select, context)
+      case let .values(rows):
+        return try compile(values: rows, query, context)
+      case .setop:
+        preconditionFailure("a set operation is handled by the guard above")
       }
-      return try compile(select, context)
     }
 
     // A set operation collects no derived aliases at the query level — arms are
@@ -431,6 +435,51 @@ extension Catalog where Self: ~Escapable {
     })
     return try .setop(kind, compile(left, context), compile(right, context),
                       all: all, types: types, widened: widened)
+  }
+
+  /// Compiles a `VALUES` body — the ISO table value constructor — into a
+  /// `Plan.values` leaf: the unified per-column `types` (with the cross-row
+  /// arity check) from `columns(unifying:)`, and each row's expressions lowered
+  /// to `Term`s against the empty FROM-less scope, exactly as the scalar
+  /// projection path lowers a FROM-less `SELECT`'s items.
+  ///
+  /// A row nests a subquery through the same cursor-free `Resolution` the
+  /// FROM'd path builds — every nested query compiled once for its width and
+  /// single-column type, a correlated one's runtime plan recorded into the
+  /// shared box — so a scalar/`IN`/`EXISTS` in a row lowers and runs as
+  /// elsewhere.
+  /// The lowering surface is barred (a projection position), so a bare column
+  /// names nothing and a correlated reference is diagnosed, as in a FROM-less
+  /// `SELECT`'s projection.
+  private borrowing func compile(values rows: Array<Array<Expression>>,
+                                 _ query: Query, _ context: Context)
+      throws(SQLError) -> Plan {
+    // The unified column types (arity checked equal across the rows) — the same
+    // fold `columns(unifying:)` derives, so `run ≡ columns(of:)`.
+    let types = try columns(unifying: query, context).map(\.type)
+    // Resolve the subqueries the rows nest, classified by their role in the row
+    // expressions (a `VALUES` has no ORDER BY of its own here).
+    var subqueries = Array<Query>()
+    for row in rows {
+      for expression in row { expression.collect(subqueries: &subqueries) }
+    }
+    let resolution =
+        try subquery(subqueries, roles: { query.roles(of: $0, order: nil) },
+                     context, within: nil)
+    // Lower each row's expressions against the empty scope, as the FROM-less
+    // scalar path lowers a projection; `terms` bars the resolution surface.
+    let schema = Schema(width: 0, extent: 0, names: [], types: [],
+                        virtuals: [])
+    let relation = Relation(name: "")
+    var lowered = Array<Array<Term>>()
+    lowered.reserveCapacity(rows.count)
+    for row in rows {
+      let projection =
+          Projection.expressions(row.map { Projected(expression: $0) })
+      try lowered.append(schema.terms(projection, in: relation,
+                                      context.routines, subquery: resolution))
+    }
+    return .values(rows: lowered, types: types)
   }
 
   /// The distinct uncorrelated subqueries `select` nests, each compiled once
@@ -722,11 +771,13 @@ extension Catalog where Self: ~Escapable {
   /// The cardinality-only shape of `query` an `EXISTS` tests for non-emptiness:
   /// a `probable` `SELECT`'s probe rewrite (`Select.probe` — its select list
   /// and `ORDER BY` replaced by a cardinality-preserving target, so a `1 / 0`
-  /// projection never evaluates) and the full `query` otherwise (a `HAVING`
-  /// select, a `DISTINCT`-with-`OFFSET` one, or a set operation, whose empty
-  /// test is not a source-only fact the rewrite preserves). The `probe(_:)` run
-  /// and the correlated `existential` plan both compile/execute this shape, so
-  /// a correlated EXISTS probes per outer row as an uncorrelated one does.
+  /// projection never evaluates), a `VALUES` body's per-row rewrite to a single
+  /// constant column (its row count preserved, no cell evaluated), and the full
+  /// `query` otherwise (a `HAVING` select, a `DISTINCT`-with-`OFFSET` one, or a
+  /// set operation, whose empty test is not a source-only fact the rewrite
+  /// preserves). The `probe(_:)` run and the correlated `existential` plan both
+  /// compile/execute this shape, so a correlated EXISTS probes per outer row as
+  /// an uncorrelated one does.
   internal borrowing func probed(_ query: Query) -> Query {
     // An `ordered` carrier over a probable primary — a parenthesised
     // `(SELECT …) ORDER BY … FETCH n` in EXISTS position — must probe its inner
@@ -750,6 +801,16 @@ extension Catalog where Self: ~Escapable {
       if query.dedups, (carrier.limit?.offset ?? 0) >= 1 { return query }
       return .ordered(probed(inner), distinct: carrier.distinct, order: nil,
                       limit: carrier.limit, generated: 0)
+    }
+    // A `VALUES` body probes for existence the same way a `probable` select
+    // does: rewrite each row to a single cheap constant, preserving the row
+    // count (so the EXISTS reads the right cardinality) while never evaluating
+    // a would-fault cell — the `.values` counterpart of `Select.probe`
+    // replacing a select list with a constant target. So `EXISTS (VALUES (1 /
+    // 0), (2))` probes a two-row constant `VALUES` (EXISTS true, no cell run),
+    // as the former `UNION ALL` desugar's probed projection did.
+    if case let .values(rows) = query.body {
+      return Query(body: .values(rows.map { _ in [.literal(.integer(1))] }))
     }
     guard case let .select(select) = query.body, select.probable else {
       return query
@@ -821,6 +882,10 @@ extension Catalog where Self: ~Escapable {
       // SELECT-scoped), so augment it before measuring a `*`.
       let scope = try augment(context, for: .select(select), rows: false)
       return try arity(select, scope)
+    case let .values(rows):
+      // A `VALUES` operand's width is its row width (every row equal by the ISO
+      // degree rule).
+      return rows.first?.count ?? 0
     }
   }
 

--- a/Sources/SQLEngine/Compilation.swift
+++ b/Sources/SQLEngine/Compilation.swift
@@ -3,68 +3,6 @@
 
 // MARK: - Compilation
 
-extension Projection {
-  /// Compiles this scalar (FROM-less) `SELECT <expr-list>` projection into
-  /// `Project(single)` — the projection evaluated against the one empty row the
-  /// `single` leaf yields — ordered and paged by any `order`/`limit` tail.
-  ///
-  /// The projection resolves against an empty schema (no columns), so only
-  /// literals, scalar calls, and arithmetic over them lower; a `SELECT *` has
-  /// no relation to expand and a bare-column reference no column to bind, each
-  /// faulting (`SQLError.column` for a column, `SQLError.unsupported` for `*`).
-  /// The terms hold no slots, so the `single` row's empty record carries every
-  /// value the projection needs.
-  ///
-  /// `subquery` carries the compile-time width map of the uncorrelated
-  /// subqueries the projection nests, so an `EXISTS`/`IN (Q)` inside a scalar
-  /// term lowers exactly as it does on the FROM'd path — the FROM-less scalar
-  /// select is otherwise the one path that would hit the default unsupported
-  /// map and reject a subquery a run materialises. The `Resolution` is
-  /// threaded, not run, here (see `subquery(of:)`).
-  ///
-  /// A projection is a barred clause position, so a correlated column of this
-  /// query has no evaluator here. `Schema.terms` bars the seam intrinsically,
-  /// so this FROM-less projection cannot admit correlation even when handed the
-  /// admitting `plans.rest` — the same cut `columns(of:)` applies on the schema
-  /// path, keeping run and derive in lockstep.
-  ///
-  /// A trailing `ORDER BY`/`OFFSET`·`FETCH` (`order`/`limit`) orders and pages
-  /// that single row through the shared `shaped` plan shape, so a FROM-less
-  /// query expression's tail runs (`VALUES (1) ORDER BY 1`) rather than
-  /// faulting. An empty schema binds only an ordinal or an output-alias key —
-  /// the sole ISO keys over a FROM-less select, which has no source column to
-  /// order on — so an ordinary column key faults (`SQLError.column`) as it does
-  /// on the projection.
-  internal func scalar(_ routines: Routines = [:],
-                       subquery: Resolution = .unsupported,
-                       distinct: Bool = false,
-                       order: Order? = nil, limit: Limit? = nil)
-      throws(SQLError) -> Plan {
-    guard case .all = self else {
-      let schema = Schema(width: 0, extent: 0, names: [], types: [],
-                          virtuals: [])
-      let relation = Relation(name: "")
-      let terms = try schema.terms(self, in: relation, routines,
-                                   subquery: subquery)
-      var keys = Array<SortKey>()
-      if let order {
-        let names = self.outputs(count: terms.count)
-        keys = try schema.order(order, in: relation, terms, names, routines,
-                                subquery: subquery)
-        // Every FROM-less ORDER BY key is a select-list output already, so the
-        // DISTINCT rule (a key must be a projected value) rebinds none; the
-        // call still enforces it against a direct `Select`.
-        if distinct { keys = try SQLEngine.distinct(order.keys, keys, terms) }
-      }
-      return Plan.single.shaped(distinct: distinct, projection: terms,
-                                filter: nil, order: keys, limit: limit)
-    }
-    // `SELECT *` names every column of the relations in scope; a FROM-less
-    // query has none, so there is nothing to expand.
-    throw .unsupported("SELECT * requires a FROM clause")
-  }
-}
-
 /// A relation resolved for compilation: its name-resolution `schema` and a
 /// `leaf` factory that, given the ordinals the query references on its side,
 /// builds the leaf `Plan` — a `scan` for a base table, a `derived` over the
@@ -897,10 +835,8 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Int {
     switch select.projection {
     case .all:
-      // `SELECT *` spans the relations in scope; a FROM-less arm has none.
-      guard let relation = select.from else {
-        throw .named("SELECT * with no FROM")
-      }
+      // `SELECT *` spans the relations in scope.
+      let relation = select.from
       // The FROM resolves once here; each join then resolves through the shared
       // helper, which threads each join's preceding scope into its resolve — so
       // a LATERAL arm's body derives its projected preceding-FROM column
@@ -1452,55 +1388,7 @@ extension Catalog where Self: ~Escapable {
     // a same-named derived alias here shadows stays visible. The layered
     // overlay never overwrote the CTE, so no separate pre-augment context runs.
     let context = try augment(context, for: .select(select), rows: false)
-    guard let relation = select.from else {
-      // A FROM-less select projects expressions over a single row. A `WHERE`,
-      // `GROUP BY`, `HAVING`, or `JOIN` has no relation to apply to, so reject
-      // it rather than silently ignore the clause — a scalar projection would
-      // drop a `GROUP BY`/`HAVING` otherwise. `ORDER BY` and `OFFSET`/`FETCH`
-      // do apply: they order and page that single-row result (ISO), so the
-      // enclosing query expression's trailing tail on a FROM-less primary —
-      // `VALUES (1) ORDER BY 1`, `(SELECT 1 FETCH FIRST 0 ROWS ONLY) UNION …` —
-      // runs rather than faulting. The parser never produces a WHERE/GROUP/
-      // HAVING/JOIN here, but a direct `Select(from: nil, …)` can.
-      let ungrouped = if case .keys([]) = select.grouping { true } else {
-        false
-      }
-      guard select.joins.isEmpty, select.predicate == nil,
-          ungrouped, select.having == nil else {
-        throw .unsupported(
-            "a WHERE, GROUP BY, HAVING, or JOIN requires a FROM clause")
-      }
-      if let limit = select.limit {
-        // As on the FROM'd path, a direct `Limit` may carry negatives the
-        // executor would trap on (the parser yields only non-negative counts).
-        guard limit.offset >= 0 else {
-          throw .state("2201X", "OFFSET row count must be non-negative")
-        }
-        guard (limit.count ?? 0) >= 0 else {
-          throw .state("2201W", "FETCH row count must be non-negative")
-        }
-      }
-      // A scalar projection may still nest an uncorrelated subquery
-      // (`SELECT CASE WHEN EXISTS (Q) …`); compile each once for its width and
-      // thread the map through so the term lowers as it does on the FROM'd path
-      // rather than hit the default unsupported map. The run path builds the
-      // matching run-time cache from `query.subqueries` (which descends the
-      // projection), so the subquery is materialised there — `compile` runs it
-      // never.
-      // A FROM-less select adds no relations, so its nested subqueries
-      // correlate against this select's own enclosing scope `outer` unchanged;
-      // and its own columns (none but a projected outer reference) correlate
-      // outward through `outer` too. The seam is `plans.rest`; `scalar` (via
-      // `Schema.terms`) bars it — a projection is a barred clause position — so
-      // a correlated column of this query is diagnosed, not lowered to a
-      // `Term.parameter`, matching `columns(of:)`'s schema-path rejection.
-      let plans = try subquery(of: select, context)
-      return try select.projection.scalar(context.routines,
-                                          subquery: plans.rest,
-                                          distinct: select.distinct,
-                                          order: select.order,
-                                          limit: select.limit)
-    }
+    let relation = select.from
     // A LATERAL first FROM item has no preceding relation to correlate against,
     // so it is meaningless (and ISO forbids it) — fault rather than resolve a
     // lateral body against nothing.

--- a/Sources/SQLEngine/Decorrelation.swift
+++ b/Sources/SQLEngine/Decorrelation.swift
@@ -30,8 +30,9 @@ extension Catalog where Self: ~Escapable {
     switch plan {
     // `.empty` is produced only by `optimise`, which runs after decorrelation,
     // so a plan reaching here never carries one; the arm is a structural
-    // no-op keeping the switch exhaustive.
-    case .single, .empty, .scan, .join:
+    // no-op keeping the switch exhaustive. A `values` leaf holds no correlated
+    // apply/subquery of its own to lift.
+    case .single, .empty, .values, .scan, .join:
       return plan
     case let .derived(name, plan, ordinals, seek):
       // A view body is compiled and re-executed under its own scope; its

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -677,6 +677,11 @@ extension Query {
     case let .setop(_, left, right, _):
       left.collect(into: &names)
       right.collect(into: &names)
+    case .values:
+      // A `VALUES` body names no `FROM`/`JOIN` relation — its rows are
+      // FROM-less constant tuples — so it contributes no store relation here (a
+      // subquery a row nests binds its own store relations in its own scope).
+      break
     }
   }
 
@@ -713,7 +718,7 @@ extension Query {
     switch body {
     case let .select(select):
       select.collect(derived: &derivations)
-    case .setop:
+    case .setop, .values:
       break
     }
   }
@@ -730,7 +735,7 @@ extension Query {
     switch body {
     case let .select(select):
       select.collect(ranges: &ranges)
-    case .setop:
+    case .setop, .values:
       break
     }
   }
@@ -749,7 +754,7 @@ extension Query {
     switch body {
     case let .select(select):
       select.collect(sources: &sources)
-    case .setop:
+    case .setop, .values:
       break
     }
   }

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -763,7 +763,7 @@ extension Query {
 extension Select {
   /// Collects this select's `FROM` and `JOIN` relation names into `names`.
   func collect(into names: inout Set<String>) {
-    if let from { names.insert(from.name) }
+    names.insert(from.name)
     for join in joins { names.insert(join.relation.name) }
   }
 
@@ -772,7 +772,7 @@ extension Select {
   /// relation's spelling), matching `Scope.admits` — into `ranges`, duplicates
   /// kept so a collision counts.
   func collect(ranges: inout Array<String>) {
-    if let from { ranges.append(from.alias ?? from.name) }
+    ranges.append(from.alias ?? from.name)
     for join in joins {
       ranges.append(join.relation.alias ?? join.relation.name)
     }
@@ -783,7 +783,7 @@ extension Select {
   /// that `resolve` keys the relation on — into `sources`, a derived table's
   /// source contributing none (its rows key on its alias, already a range).
   func collect(sources: inout Array<String>) {
-    if let from, case .named = from.source { sources.append(from.name) }
+    if case .named = from.source { sources.append(from.name) }
     for join in joins {
       if case .named = join.relation.source {
         sources.append(join.relation.name)
@@ -799,9 +799,9 @@ extension Select {
   /// rather than through the overlay `augment` builds.
   func collect(derived derivations:
                    inout Array<(String, Query, Array<String>)>) {
-    if case let .derived(query) = from?.source, let alias = from?.alias,
-        !(from?.lateral ?? false) {
-      derivations.append((alias, query, from?.columns ?? []))
+    if case let .derived(query) = from.source, let alias = from.alias,
+        !from.lateral {
+      derivations.append((alias, query, from.columns))
     }
     for join in joins {
       if case let .derived(query) = join.relation.source,

--- a/Sources/SQLEngine/Definition.swift
+++ b/Sources/SQLEngine/Definition.swift
@@ -85,7 +85,7 @@ extension View {
     guard case let .select(query) = try! Statement(parsing: text) else {
       fatalError("a view body must be a SELECT")
     }
-    self.init(query: query, columns: try! query.first.projection.names())
+    self.init(query: query, columns: try! query.names)
   }
 
   /// The engine-provided (built-in `INFORMATION_SCHEMA`) view named `name`

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -547,7 +547,7 @@ extension Catalog where Self: ~Escapable {
           // all page and order the same set-op output, so each validates it.
           let outputs = try columns(unifying: anchor, scope)
           for carrier in carriers {
-            try validate(carrier: carrier, over: outputs, arm: anchor.first,
+            try validate(carrier: carrier, over: outputs, arm: anchor.arm,
                          context.validating(true))
           }
         }
@@ -798,7 +798,7 @@ extension Catalog where Self: ~Escapable {
       // innermost first — the peel order — each over the prior result, so the
       // outer tail pages/orders what the inner already produced.
       for carrier in carriers {
-        result = try apply(carrier, result, named, arm: anchor.first, context)
+        result = try apply(carrier, result, named, arm: anchor.arm, context)
       }
     }
     return (result, merged)
@@ -807,7 +807,8 @@ extension Catalog where Self: ~Escapable {
   /// Applies a peeled query-level `carrier` — `DISTINCT`/`ORDER BY`/`OFFSET`·
   /// `FETCH` — to the materialised `rows` a recursive-CTE fixpoint produced,
   /// typed by the fixpoint's unified `carrier` `columns` (the body's arm-0
-  /// output names), `arm` the body's FIRST arm (the anchor).
+  /// output names), `arm` the body's leftmost arm as a carrier-free `Query`
+  /// (the anchor).
   ///
   /// The rows are bound as a temporary relation under a non-spellable name; a
   /// bare scan over it seeds the shared `carried(over:)` carrier resolver — the
@@ -821,7 +822,7 @@ extension Catalog where Self: ~Escapable {
   private borrowing func apply(_ carrier: Query.Carrier,
                                _ rows: Array<Array<Value>>,
                                _ columns: Array<ResolvedColumn>,
-                               arm: Select, _ context: Context)
+                               arm: Query, _ context: Context)
       throws(SQLError) -> Array<Array<Value>> {
     let name = "*fixpoint"
     let temp = RelationInstance(from: columns, rows: rows)
@@ -873,12 +874,13 @@ extension Catalog where Self: ~Escapable {
   /// shared `carried(over:)` resolver `apply` runs, under a validating context,
   /// so a schema-path `columns(of:validate:true)` faults a carrier `ORDER BY`
   /// naming a missing column or function exactly as the run does, closing the
-  /// run-vs-validate gap. `arm` is the body's FIRST arm (the anchor), the
-  /// projection surface an ordinal / projected-expression / aliased key binds
-  /// against. Discards the resolved plan — only its resolution can fault.
+  /// run-vs-validate gap. `arm` is the body's leftmost arm as a carrier-free
+  /// `Query` (the anchor), the projection surface an ordinal / projected-
+  /// expression / aliased key binds against. Discards the resolved plan — only
+  /// its resolution can fault.
   private borrowing func validate(carrier: Query.Carrier,
                                   over columns: Array<ResolvedColumn>,
-                                  arm: Select, _ context: Context)
+                                  arm: Query, _ context: Context)
       throws(SQLError) {
     let name = "*fixpoint"
     let temp = RelationInstance(from: columns, rows: [])

--- a/Sources/SQLEngine/GroupingSets.swift
+++ b/Sources/SQLEngine/GroupingSets.swift
@@ -34,6 +34,9 @@ extension Query {
         return Query(body: .setop(kind, try left.expanded,
                                   try right.expanded, all: all),
                      carriers: carriers)
+      case .values:
+        // A `VALUES` body carries no grouping to expand.
+        return self
       }
     }
   }

--- a/Sources/SQLEngine/Interpreter.swift
+++ b/Sources/SQLEngine/Interpreter.swift
@@ -26,6 +26,24 @@ extension Catalog where Self: ~Escapable {
       // The FROM-less single row: one record with no cells, the source a scalar
       // projection evaluates its constant/call expressions against.
       return [Record([])]
+    case let .values(rows, types):
+      // The ISO table value constructor: one record per row, each the row's
+      // lowered terms evaluated against the single empty record (as `single`'s
+      // row is) then coerced to the unified column `types` — so `VALUES (1),
+      // (2.5)` yields a `double` column. An explicit loop keeps the borrowed
+      // `~Escapable` self a row's scalar subquery materialises against out of a
+      // closure capture.
+      var records = Array<Record>()
+      records.reserveCapacity(rows.count)
+      for row in rows {
+        var cells = Array<Value>()
+        cells.reserveCapacity(row.count)
+        for term in row {
+          try cells.append(evaluate(Record([]), term, context))
+        }
+        records.append(Record(cells).coerced(to: types))
+      }
+      return records
     case .empty:
       // The known-empty relation yields no records — the optimiser proved its
       // constant-false guard admits none — so nothing above it (a project, an

--- a/Sources/SQLEngine/Operator.swift
+++ b/Sources/SQLEngine/Operator.swift
@@ -118,6 +118,16 @@ internal indirect enum Plan {
   /// record (no slots), the row a scalar projection (`SELECT 1 + 1`) computes
   /// its expressions against.
   case single
+  /// The ISO `<table value constructor>` leaf — one `Record` per row, each the
+  /// row's lowered `Term`s evaluated against the single empty record (as the
+  /// `single` leaf's row is) then coerced to the unified column `types`.
+  /// `types` is the per-column type unified across the rows (a mixed
+  /// integer/double column widening to `double`), one entry per output column;
+  /// every row has `types.count` terms (the ISO equal-degree rule the compile
+  /// enforces). It is a leaf the pushdown/optimise/decorrelate passes recurse
+  /// through unchanged, feeding a query-level `ORDER BY`/`OFFSET`·`FETCH`/
+  /// `DISTINCT` carrier.
+  case values(rows: Array<Array<Term>>, types: Array<ValueType>)
   /// The known-empty relation of `slots` columns: it yields zero records over
   /// exactly that combined slot width, the shape the optimiser rewrites a
   /// provably constant-false selection into (a `WHERE 1 = 0` admits no row).
@@ -285,6 +295,9 @@ extension Plan {
       // replaced, so a view sub-plan measuring a data-empty body reads its true
       // column count rather than the `select`'s conservative zero.
       slots
+    case let .values(_, types):
+      // A values leaf's output is one column per unified column type.
+      types.count
     case let .project(terms, _):
       terms.count
     case let .setop(_, left, _, _, _, _):
@@ -323,6 +336,10 @@ extension Plan {
       // The single empty row has no slots — a FROM-less projection reads only
       // constants and calls over them, never a slot of this row.
       0
+    case let .values(_, types):
+      // A values leaf yields one slot per unified column, so a downstream
+      // consumer that reads its width shapes correctly.
+      types.count
     case let .empty(slots):
       // The known-empty relation spans exactly the slots of the subtree it
       // replaced — it drops the rows, never the schema — so a downstream join's
@@ -414,6 +431,11 @@ extension Plan {
       // A single empty row and the known-empty relation both yield their rows
       // without evaluating anything — neither can raise.
       true
+    case let .values(rows, _):
+      // Each row's terms evaluate over the empty record, so a values leaf is
+      // throw-free only when every term is (a constant row is; a `1 / 0` row is
+      // not).
+      rows.allSatisfy { $0.allSatisfy(\.safe) }
     case .scan:
       // A scan reads cells and never evaluates an expression, so materialising
       // it cannot raise; a compiled plan's scan name is already resolved.
@@ -508,13 +530,14 @@ extension Plan {
       }
       return covered == Set(0 ..< width)
     // A base `scan` is an ISO multiset (a duplicate row is possible, no unique
-    // key is tracked); a `derived` view body runs an arbitrary sub-plan; a
+    // key is tracked); a `values` leaf likewise keeps duplicate rows (`VALUES
+    // (1), (1)`); a `derived` view body runs an arbitrary sub-plan; a
     // `product`/`join`/`outer`/`apply` can multiply rows (a fan-out pairs one
     // row with many). None provably yields distinct full rows, so each reports
     // `false` — the `.distinct` stays, never unsound. A `semijoin` emits each
     // left row at most once but does not deduplicate the left, so it is only as
     // unique as its left source and is conservatively `false` here.
-    case .scan, .derived, .product, .join, .outer, .semijoin, .apply:
+    case .scan, .values, .derived, .product, .join, .outer, .semijoin, .apply:
       return false
     }
   }

--- a/Sources/SQLEngine/Optimisation.swift
+++ b/Sources/SQLEngine/Optimisation.swift
@@ -34,6 +34,10 @@ extension Catalog where Self: ~Escapable {
     switch plan {
     case .single:
       plan
+    case .values:
+      // A values leaf is already physical — no seek, join, or source below it —
+      // so it optimises to itself.
+      plan
     case .empty:
       // The known-empty relation is already physical — no seek, join, or source
       // to rewrite below it — so it optimises to itself (and re-optimising a

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -29,8 +29,8 @@
 /// term           := select | TABLE identifier | values
 ///                   // TABLE t = SELECT * FROM t; none of these primaries
 ///                   // consumes a trailing tail — `query` does, above
-/// values         := VALUES tuple (',' tuple)*  // ISO table value constructor;
-///                   // desugars to a UNION ALL of FROM-less constant SELECTs
+/// values         := VALUES tuple (',' tuple)*  // ISO table value constructor,
+///                   // the first-class `Query.Body.values` node
 /// tuple          := '(' expression (',' expression)* ')'
 /// select         := SELECT [DISTINCT | ALL] projection
 ///                   [FROM relation (join)*
@@ -368,9 +368,9 @@ internal struct Parser: ~Escapable {
   /// to the enclosing query expression (`query()` takes it), as after any
   /// primary — the primary itself carries no order.
   ///
-  /// `VALUES (…), …` desugars to a `UNION ALL` of FROM-less constant selects
-  /// (see `values()`); a trailing `ORDER BY`/limit binds to the enclosing
-  /// query expression, as after any primary.
+  /// `VALUES (…), …` parses to the first-class `Query.Body.values` node (see
+  /// `values()`); a trailing `ORDER BY`/limit binds to the enclosing query
+  /// expression, as after any primary.
   private mutating func term()
       throws(SQLError) -> (query: Query, parenthesized: Bool) {
     if try match(.lparen) {
@@ -400,26 +400,18 @@ internal struct Parser: ~Escapable {
   }
 
   /// Parses the ISO `<table value constructor>` `VALUES (v, …), (v, …), …` (the
-  /// `VALUES` keyword is the next token), desugaring it to a `UNION ALL` of
-  /// FROM-less constant `SELECT`s — no new AST node, so `compile`, execute, the
-  /// per-column type unification, and set-operation composition all apply
-  /// unchanged.
+  /// `VALUES` keyword is the next token) directly into the first-class
+  /// `Query.Body.values` node — one row per parenthesised tuple, in source
+  /// order.
   ///
   /// Each parenthesised row is a tuple of scalar expressions (usually literals,
-  /// but any row-independent expression is admitted, since a FROM-less `SELECT`
-  /// evaluates it over the single empty row). Every row must have equal arity —
-  /// a mismatch is `SQLError.arity` — and there is at least one row, each with
-  /// at least one element (the parser rejects an empty `VALUES ()`). The rows
-  /// lower to `SELECT v, … UNION ALL SELECT v, …` in source order, so `UNION
-  /// ALL` preserves both the order and any duplicate rows.
-  ///
-  /// The constructor's DEFAULT column names are the ISO `column1, column2, …`,
-  /// emitted as the FIRST arm's projection aliases (the ISO rule that a set
-  /// operation's result columns come from its first arm) so a `SELECT column1
-  /// FROM (VALUES …) AS t` names them. A per-column `ValueType` unifies across
-  /// the rows through the same set-operation schema derivation `UNION` uses (a
-  /// column mixing integer and double widens to double), so this parse only
-  /// shapes the desugar and leaves the typing to resolution.
+  /// but any row-independent expression is admitted, since it evaluates over
+  /// the single empty row). There is at least one row, each with at least one
+  /// element (the parser rejects an empty `VALUES ()`). The equal-arity rule
+  /// (the ISO degree constraint), the ISO default `column1, column2, …` output
+  /// names, and the per-column type unification across the rows are all
+  /// resolved by the node's compile/schema paths (`columns(unifying:)`), so
+  /// this parse only shapes the rows.
   private mutating func values() throws(SQLError) -> Query {
     try expect(.values)
 
@@ -429,35 +421,7 @@ internal struct Parser: ~Escapable {
       try rows.append(tuple())
     }
 
-    // Every row constructs the same number of columns; a later row of a
-    // different arity is an ISO arity error.
-    let arity = rows[0].count
-    for row in rows.dropFirst() where row.count != arity {
-      throw .arity(arity, row.count)
-    }
-
-    // The FIRST arm carries the default `column1, column2, …` output names as
-    // explicit aliases; the ISO first-arm rule propagates them to the result.
-    // Later arms need no aliases — a set operation names its result from the
-    // first arm alone — so they project the bare expressions.
-    var query = Query.select(row(rows[0], named: true))
-    for arm in rows.dropFirst() {
-      query = .setop(.union, query, .select(row(arm, named: false)),
-                     all: true)
-    }
-    return query
-  }
-
-  /// Builds one `VALUES` arm — a FROM-less `SELECT` projecting `row`'s element
-  /// expressions. The FIRST arm (`named`) aliases each column `column1,
-  /// column2, …` (the constructor's default names); a later arm leaves them
-  /// bare, as a set operation names its result from the first arm alone.
-  private func row(_ row: Array<Expression>, named: Bool) -> Select {
-    let items = row.enumerated().map { (index, expression) in
-      Projected(expression: expression,
-                alias: named ? "column\(index + 1)" : nil)
-    }
-    return Select(projection: .expressions(items), from: nil)
+    return Query(body: .values(rows))
   }
 
   /// Parses one parenthesised `VALUES` row — `'(' expression (',' expression)*

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -536,10 +536,10 @@ internal struct Parser: ~Escapable {
 
   /// Parses a `SELECT` query.
   ///
-  /// `FROM` is optional: a FROM-less `SELECT <expr-list>` projects over a
-  /// single empty row (the standard way to compute a scalar, `SELECT 1 + 1`),
-  /// and so admits no relation, joins, `WHERE`, `ORDER BY`, or `LIMIT` to
-  /// follow.
+  /// A `SELECT` requires a `FROM` clause: the dialect admits no FROM-less
+  /// `SELECT`. The ISO `VALUES` table value constructor projects a computed row
+  /// (`VALUES (1 + 1)`) and is parsed by `query`, not here — a bare `SELECT`
+  /// with no `FROM` faults 42601 rather than projecting over an empty row.
   private mutating func select() throws(SQLError) -> Select {
     try expect(.select)
     // An optional set quantifier: `DISTINCT` deduplicates the result rows;
@@ -548,7 +548,9 @@ internal struct Parser: ~Escapable {
     if !distinct { _ = try match(.all) }
     let projection = try projection()
     guard try match(.from) else {
-      return Select(distinct: distinct, projection: projection, from: nil)
+      throw .state("42601",
+                   "a SELECT requires a FROM clause; use VALUES to project a "
+                   + "computed row")
     }
     let from = try relation()
 

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -254,14 +254,13 @@ internal struct Parser: ~Escapable {
   /// (`SQLError.duplicate`).
   private func columns(_ explicit: Array<String>?, _ query: Query)
       throws(SQLError) -> Array<String> {
-    if let explicit, let arity = arity(query.first.projection),
-        explicit.count != arity {
+    if let explicit, let arity = query.arity, explicit.count != arity {
       throw .columns(expected: arity, got: explicit.count)
     }
     let columns: Array<String> = if let explicit {
       explicit
     } else {
-      try query.first.projection.names()
+      try query.names
     }
     var seen = Set<String>()
     for column in columns where !seen.insert(column.lowercased()).inserted {
@@ -568,21 +567,6 @@ internal struct Parser: ~Escapable {
     case "BLOB", "BINARY": return .blob
     default:
       throw .unexpected(text, expected: "a type", at: token.location)
-    }
-  }
-
-  /// The number of values `projection` projects, or `nil` when it is not
-  /// statically known — a `SELECT *`, whose width depends on the relations it
-  /// is resolved against. A `.columns` or `.expressions` projection has a fixed
-  /// item count.
-  private func arity(_ projection: Projection) -> Int? {
-    switch projection {
-    case .all:
-      nil
-    case let .columns(columns):
-      columns.count
-    case let .expressions(items):
-      items.count
     }
   }
 

--- a/Sources/SQLEngine/Pushdown.swift
+++ b/Sources/SQLEngine/Pushdown.swift
@@ -24,8 +24,9 @@ extension Plan {
   internal func pushdown() throws(SQLError) -> Plan {
     switch self {
     // Pushdown runs before optimise, the only producer of `.empty`, so a plan
-    // reaching here never carries one; the arm keeps the switch exhaustive.
-    case .single, .empty, .scan, .join:
+    // reaching here never carries one; the arm keeps the switch exhaustive. A
+    // `values` leaf is FROM-less — no `WHERE` conjunct rides into it.
+    case .single, .empty, .values, .scan, .join:
       self
     case let .derived(name, sub, ordinals, seek):
       try .derived(name: name, plan: sub.pushdown(), ordinals: ordinals,

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -345,6 +345,61 @@ extension Catalog where Self: ~Escapable {
       cols = try l.indices.map { index throws(SQLError) in
         try merge(l[index], r[index], shape: context.shape)
       }
+    case let .values(rows):
+      // The ISO table value constructor's result columns: each row's
+      // expressions typed against the empty FROM-less scope (a subquery a row
+      // nests reads its single-column type from the same cursor-free
+      // `Resolution` the compile path builds), then folded column-wise across
+      // the rows through the SAME set-operation `merge` a `UNION ALL` uses — so
+      // a mixed integer/double column widens to `double` and an irreconcilable
+      // pair (`VALUES ('a'), (1)`) faults `SQLError.operand` exactly as the
+      // former `UNION ALL` desugar did. Each row has equal arity (the ISO
+      // degree rule) — a mismatch is `SQLError.arity(first, offending)` — and
+      // the result columns are named the ISO default `column1, column2, …` off
+      // the first row's aliases (the ISO first-arm rule the `merge` carries).
+      //
+      // The parser enforces the ISO `≥ 1 row, each ≥ 1 element` shape
+      // syntactically, but `Query`/`Query.Body` are public: a caller can hand-
+      // build `.values([])` (no rows) or `.values([[]])` (a zero-column row),
+      // which the type fold below would otherwise treat as a valid empty
+      // relation. Reject them here — the single deriver both the run
+      // (`compile(values:)`) and `columns(of: validate:)` reach — before the
+      // fold, so a malformed AST faults cleanly rather than producing a zero-
+      // column relation. A later empty row is caught by the equal-arity check.
+      guard let first = rows.first else {
+        throw .state("42601", "VALUES requires at least one row")
+      }
+      guard !first.isEmpty else {
+        throw .state("42601", "VALUES requires at least one column per row")
+      }
+      let arity = first.count
+      for row in rows.dropFirst() where row.count != arity {
+        throw .arity(arity, row.count)
+      }
+      var subqueries = Array<Query>()
+      for row in rows {
+        for expression in row { expression.collect(subqueries: &subqueries) }
+      }
+      let resolution =
+          try subquery(subqueries, roles: { query.roles(of: $0, order: nil) },
+                       context, within: nil)
+      var folded: Array<ResolvedColumn>? = nil
+      for row in rows {
+        let items = row.enumerated().map {
+          Projected(expression: $0.element, alias: "column\($0.offset + 1)")
+        }
+        let typed = try Scope([]).columns(of: .expressions(items),
+                                          context.routines,
+                                          subquery: resolution.barred)
+        if let current = folded {
+          folded = try current.indices.map { index throws(SQLError) in
+            try merge(current[index], typed[index], shape: context.shape)
+          }
+        } else {
+          folded = typed
+        }
+      }
+      cols = folded ?? []
     }
     // A carrier is transparent to the result schema: `ORDER BY`, `DISTINCT`,
     // and `OFFSET`/`FETCH` are row operators — they do NOT project — so the
@@ -613,6 +668,12 @@ extension Catalog where Self: ~Escapable {
       // enclosing scope, so each type-checks under the shared `context.outer`.
       try typecheck(left, context)
       try typecheck(right, context)
+    case let .values(rows):
+      // A `VALUES` body type-checks each row's expressions — its reachable
+      // operands and calls (validate), or its cross-kind comparisons (the run's
+      // comparability walk) — exactly as the former `UNION ALL` of FROM-less
+      // selects type-checked each arm's projection.
+      try typecheck(values: rows, query, context)
     }
     // Each carrier's own `ORDER BY` keys are a new expression surface, handled
     // only by the carrier compile (`ordered(…)`). A reached scalar/`IN`
@@ -955,6 +1016,95 @@ extension Catalog where Self: ~Escapable {
       try prefix.check(select.joins[index].on, context.routines, subquery: on)
       for reach in on.visited {
         try typecheck(shape(of: reach), revealed.with(outer: scope))
+      }
+    }
+  }
+
+  /// Type-checks a `VALUES` body's row expressions — the first-class node's
+  /// counterpart of the former `UNION ALL` of FROM-less selects, so a run and a
+  /// `columns(of:)` derive fault a `VALUES` alike.
+  ///
+  /// The rows are a FROM-less barred surface (an empty scope, `Scope([])`), so
+  /// a row's expression resolves only its literals, calls, and subqueries — a
+  /// bare column names nothing and faults, and a correlated reference is
+  /// barred, exactly as a FROM-less `SELECT`'s projection is. Each row
+  /// subquery's
+  /// cursor-free width and single-column type derive against the enclosing
+  /// `outer` (a `VALUES` in subquery position), then in validate mode each row
+  /// expression's reachable operands and calls are checked (`aggregates`/
+  /// `validate`) and each reached subquery body recursed, and in the run's
+  /// comparability mode each row expression's cross-kind comparisons are found
+  /// (`comparisons`) and each reached body recursed — the same discipline the
+  /// carrier `ORDER BY` and the plain arm use.
+  private borrowing func typecheck(values rows: Array<Array<Expression>>,
+                                   _ query: Query, _ context: Context)
+      throws(SQLError) {
+    let scope = Scope([])
+    let expressions = rows.flatMap { $0 }
+    let nested = context.outer
+    var subqueries = Array<Query>()
+    var scalars = Set<Query>()
+    for expression in expressions {
+      expression.collect(subqueries: &subqueries)
+      expression.collect(scalar: &scalars)
+    }
+    if context.comparability {
+      // The run's comparability walk: derive each row subquery's width best-
+      // effort (a structural fault defers, matching the finder's discipline),
+      // find each row expression's cross-kind comparisons, and recurse the
+      // finder into each reached predicate/scalar-subquery body — rethrowing
+      // only 42804.
+      var widths = Dictionary<Query, Int>()
+      var types = Dictionary<Query, ValueType>()
+      for query in subqueries {
+        do {
+          try width(query, [], context, nested, &widths, &types)
+        } catch let error {
+          guard case let .state(code, _) = error, code == "42804" else {
+            continue
+          }
+          throw error
+        }
+      }
+      let check = SubqueryCheck(widths, types, deferred: scalars).barred
+      for expression in expressions {
+        try scope.comparisons(in: expression, context.routines, subquery: check)
+      }
+      let inner = context.revealed().with(outer: nested).comparing()
+      for reach in check.visited {
+        do {
+          try typecheck(shape(of: reach), inner)
+        } catch let error {
+          guard case let .state(code, _) = error, code == "42804" else {
+            continue
+          }
+          throw error
+        }
+      }
+    } else {
+      // Validate mode: derive each row subquery's width/type, type-check each
+      // row expression's reachable operands and calls, then re-derive each
+      // reached scalar/`IN` subquery body strictly (an `EXISTS`/`LATERAL` reach
+      // does not constrain column type).
+      var widths = Dictionary<Query, Int>()
+      var types = Dictionary<Query, ValueType>()
+      for query in subqueries {
+        try width(query, [], context, nested, &widths, &types)
+      }
+      let check = SubqueryCheck(widths, types, deferred: scalars).barred
+      for expression in expressions {
+        try scope.aggregates(in: expression, context.routines, subquery: check)
+        _ = try scope.validate(expression, context.routines, subquery: check)
+      }
+      let inner = context.revealed().with(outer: nested)
+      for reach in check.visited {
+        try typecheck(shape(of: reach), inner)
+        switch reach.role {
+        case .scalar, .valued:
+          _ = try columns(unifying: reach.query, inner)
+        case .existential, .lateral:
+          break
+        }
       }
     }
   }

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -568,7 +568,7 @@ extension Catalog where Self: ~Escapable {
     // `validate` gates that body's own reachable-operand check the same as the
     // outer query's — a `validate: false` derive trusts a run-proven body.
     let context = try augment(context, for: .select(select), rows: false)
-    guard let relation = select.from else { return Scope([]) }
+    let relation = select.from
     // Build the running scope incrementally so a LATERAL join's schema derives
     // against the preceding FROM — per ISO its projection may name a preceding
     // column, so its output shape types from that scope. A non-lateral join's
@@ -599,11 +599,11 @@ extension Catalog where Self: ~Escapable {
   /// FROM relation and joins `0…index`, the relations available at that join
   /// point, never one joined later. A join `ON`'s subquery correlates against
   /// its prefix (so a reference to a later-joined relation faults), matching
-  /// the compile path's `subquery(of:)`. Empty for a FROM-less or join-less
-  /// select.
+  /// the compile path's `subquery(of:)`. Empty for a join-less select.
   private borrowing func prefixes(of select: Select, _ context: Context)
       throws(SQLError) -> Array<Scope> {
-    guard let relation = select.from, !select.joins.isEmpty else { return [] }
+    guard !select.joins.isEmpty else { return [] }
+    let relation = select.from
     // Build the running scope incrementally so a LATERAL join's schema derives
     // against the preceding FROM (the same reason `scope(of:)` does), the
     // preceding scope carrying the joins-before's merged columns through the
@@ -935,13 +935,11 @@ extension Catalog where Self: ~Escapable {
       return
     }
     // This select's own resolution scope — the one its nested subqueries
-    // correlate against (`nil` for a FROM-less select, which adds no relations
-    // and correlates through `outer` unchanged). Built from the unrevealed
-    // `context` — correlation resolves against the enclosing scope's relations
-    // (its derived aliases among them), unlike an inner subquery's own FROM,
-    // which resolves against the revealed base below.
-    let enclosing = select.from == nil
-        ? nil : try scope(of: select, context)
+    // correlate against. Built from the unrevealed `context` — correlation
+    // resolves against the enclosing scope's relations (its derived aliases
+    // among them), unlike an inner subquery's own FROM, which resolves against
+    // the revealed base below.
+    let enclosing = try scope(of: select, context)
     // The prefix scope of each join, the surface its `ON`'s subquery correlates
     // against — matching the run's `subquery(of:)`.
     let prefixes = try prefixes(of: select, context)
@@ -976,7 +974,7 @@ extension Catalog where Self: ~Escapable {
     // enclosing scope's ordinals.
     let revealed = context.revealed()
     let base = context.outer ?? Outer()
-    let nested = enclosing.map { base.nested(under: $0) } ?? context.outer
+    let nested = base.nested(under: enclosing)
     let inner = revealed.with(outer: nested)
     for reach in subquery.visited {
       try typecheck(shape(of: reach), inner)
@@ -1204,7 +1202,7 @@ extension Catalog where Self: ~Escapable {
     let subquery: SubqueryCheck
     do {
       scope = try self.scope(of: select, context)
-      enclosing = select.from == nil ? nil : scope
+      enclosing = scope
       prefixes = try self.prefixes(of: select, context)
       subquery = try subqueryCheck(of: select, context, enclosing: enclosing,
                                    prefixes: prefixes)
@@ -1367,11 +1365,10 @@ extension Catalog where Self: ~Escapable {
     }
     // The projection runs after any limit: a limit that drops every row it
     // would yield leaves only its aggregate folds (checked above) reachable. A
-    // single-row result (a whole-result aggregate, or a FROM-less select) is
-    // dropped by a positive OFFSET too. DISTINCT is the exception (its plan
-    // evaluates the projection before the cap pages the deduplicated result).
-    let sole = select.from == nil
-        || (select.aggregates && select.grouping.expressions.isEmpty)
+    // single-row result (a whole-result aggregate) is dropped by a positive
+    // OFFSET too. DISTINCT is the exception (its plan evaluates the projection
+    // before the cap pages the deduplicated result).
+    let sole = select.aggregates && select.grouping.expressions.isEmpty
     var reachable = select.distinct
     if !reachable { reachable = !drops(select.limit, single: sole) }
     if reachable, case let .expressions(items) = select.projection {
@@ -1432,7 +1429,7 @@ extension Catalog where Self: ~Escapable {
   private borrowing func comparability(ofViewsIn select: Select,
                                        _ context: Context)
       throws(SQLError) {
-    var relations = [select.from].compactMap { $0 }
+    var relations = [select.from]
     relations.append(contentsOf: select.joins.map(\.relation))
     for relation in relations {
       guard case let .named(name) = relation.source else { continue }
@@ -1603,8 +1600,7 @@ extension Catalog where Self: ~Escapable {
     // result — a zero FETCH or skipping OFFSET does not spare it. A false WHERE
     // still yields no rows to dedup (handled above), so only the limit-based
     // elision is bypassed for DISTINCT.
-    let sole = select.from == nil
-        || (select.aggregates && select.grouping.expressions.isEmpty)
+    let sole = select.aggregates && select.grouping.expressions.isEmpty
     var reachable = select.distinct
     if !reachable { reachable = !drops(select.limit, single: sole) }
     if reachable, case let .expressions(items) = select.projection {

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -1024,11 +1024,10 @@ extension Catalog where Self: ~Escapable {
   /// counterpart of the former `UNION ALL` of FROM-less selects, so a run and a
   /// `columns(of:)` derive fault a `VALUES` alike.
   ///
-  /// The rows are a FROM-less barred surface (an empty scope, `Scope([])`), so
-  /// a row's expression resolves only its literals, calls, and subqueries — a
-  /// bare column names nothing and faults, and a correlated reference is
-  /// barred, exactly as a FROM-less `SELECT`'s projection is. Each row
-  /// subquery's
+  /// The rows are a barred surface (an empty scope, `Scope([])`), so a row's
+  /// expression resolves only its literals, calls, and subqueries — a bare
+  /// column names nothing and faults, and a correlated reference is barred,
+  /// exactly as a FROM-less `SELECT`'s projection is. Each row subquery's
   /// cursor-free width and single-column type derive against the enclosing
   /// `outer` (a `VALUES` in subquery position), then in validate mode each row
   /// expression's reachable operands and calls are checked (`aggregates`/
@@ -1036,6 +1035,13 @@ extension Catalog where Self: ~Escapable {
   /// comparability mode each row expression's cross-kind comparisons are found
   /// (`comparisons`) and each reached body recursed — the same discipline the
   /// carrier `ORDER BY` and the plain arm use.
+  ///
+  /// A LATERAL `VALUES` constructor (`context.lateral`) is the exception, the
+  /// counterpart of a LATERAL FROM-less `SELECT`'s projection: ISO puts the
+  /// preceding FROM references in scope throughout the constructor, so the
+  /// `SubqueryCheck` carries the enclosing `outer` and admits a correlated
+  /// preceding column everywhere (`everywhere`) — `barred` a no-op there —
+  /// while a non-LATERAL constructor stays barred, its correlation faulted.
   private borrowing func typecheck(values rows: Array<Array<Expression>>,
                                    _ query: Query, _ context: Context)
       throws(SQLError) {
@@ -1084,7 +1090,9 @@ extension Catalog where Self: ~Escapable {
           throw error
         }
       }
-      let check = SubqueryCheck(widths, types, deferred: scalars).barred
+      let check = SubqueryCheck(widths, types, deferred: scalars,
+                                outer: nested,
+                                everywhere: context.lateral).barred
       for expression in expressions {
         try scope.comparisons(in: expression, context.routines, subquery: check)
       }
@@ -1109,7 +1117,9 @@ extension Catalog where Self: ~Escapable {
       for query in subqueries {
         try width(query, [], context, nested, &widths, &types)
       }
-      let check = SubqueryCheck(widths, types, deferred: scalars).barred
+      let check = SubqueryCheck(widths, types, deferred: scalars,
+                                outer: nested,
+                                everywhere: context.lateral).barred
       for expression in expressions {
         try scope.aggregates(in: expression, context.routines, subquery: check)
         _ = try scope.validate(expression, context.routines, subquery: check)

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -1039,6 +1039,24 @@ extension Catalog where Self: ~Escapable {
   private borrowing func typecheck(values rows: Array<Array<Expression>>,
                                    _ query: Query, _ context: Context)
       throws(SQLError) {
+    // Value-check (and, on the run's comparability walk, compare) only the rows
+    // the run evaluates. A carried positional limit over a bare `VALUES` — no
+    // ORDER BY, no DISTINCT — pages the constructor at compile time: the run
+    // slices the `.values` leaf's rows before their cells lower (`paged`, see
+    // `ordered`), so a discarded row never evaluates and its cell faults never
+    // surface — exactly as a `FETCH FIRST 0 ROWS` SELECT's projection is
+    // unreachable. Page these AST rows through that same `paged` so a discarded
+    // row's `1 / 0` faults neither the run nor `columns(of: validate:)`. An
+    // ORDER BY or a DISTINCT carrier keeps the eager leaf — every row evaluates
+    // to sort or dedup it — so `surviving` stops the peel at the first such
+    // carrier and every row that reaches it is checked (a `VALUES (1 / 0) ORDER
+    // BY 1 FETCH FIRST 0 ROWS` still faults, matching the run).
+    //
+    // The arity/degree and column-type derivation is not sliced: it stays over
+    // all the rows in `columns(unifying:)` (the result schema is limit-
+    // independent, and the run arity-checks every row before its own carrier
+    // slice), so a discarded row's arity mismatch still faults on both paths.
+    let rows = surviving(rows, under: query.carriers)
     let scope = Scope([])
     let expressions = rows.flatMap { $0 }
     let nested = context.outer
@@ -1107,6 +1125,27 @@ extension Catalog where Self: ~Escapable {
         }
       }
     }
+  }
+
+  /// The `VALUES` rows the run evaluates under its query-level carriers — the
+  /// rows a value-check faults over, matching the run's compile-time page.
+  ///
+  /// It mirrors the compile's carrier peel (`ordered`, innermost first): a
+  /// carrier that neither orders nor deduplicates and carries a positional
+  /// limit pages the still-`.values` leaf (`paged`), so the rows it discards
+  /// never evaluate. The peel stops at the first carrier that orders or
+  /// deduplicates — its eager leaf evaluates every row that reaches it — or that
+  /// carries no limit, leaving the surviving rows those the run evaluates.
+  private func surviving(_ rows: Array<Array<Expression>>,
+                         under carriers: Array<Query.Carrier>)
+      -> Array<Array<Expression>> {
+    var rows = rows
+    for carrier in carriers {
+      guard !carrier.distinct, carrier.order == nil,
+            let limit = carrier.limit else { return rows }
+      rows = paged(rows, by: limit)
+    }
+    return rows
   }
 
   /// The comparison-finder over a single arm — the comparability-only

--- a/Sources/SQLEngine/With.swift
+++ b/Sources/SQLEngine/With.swift
@@ -98,7 +98,7 @@ extension Select {
   /// n FROM a) AS d` names `a`) yet is NOT fooled by a shadowing derived alias
   /// (`FROM (SELECT … ) AS a` does not name the CTE `a`).
   internal func references(_ name: String) -> Bool {
-    from?.references(name) ?? false
+    from.references(name)
         || joins.contains { $0.relation.references(name) }
   }
 }

--- a/Sources/SQLEngine/With.swift
+++ b/Sources/SQLEngine/With.swift
@@ -76,6 +76,11 @@ extension Query {
       select.references(name)
     case let .setop(_, left, right, _):
       left.references(name) || right.references(name)
+    case .values:
+      // A `VALUES` body names no relation in a `FROM`/`JOIN` — its rows are
+      // FROM-less constant tuples — so it references none (a subquery nested in
+      // a row is not descended, exactly as a select's own subqueries are not).
+      false
     }
   }
 }

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -773,7 +773,7 @@ internal struct Shell: ~Escapable {
                                           validate: false) {
       return columns.map(\.name)
     }
-    return Shell.names(of: Shell.trailing(statement).first.projection, rows)
+    return Shell.names(of: Shell.trailing(statement), rows)
   }
 
   /// The row-producing query of `statement` — a `select`'s query, or a `with`'s
@@ -796,6 +796,19 @@ internal struct Shell: ~Escapable {
   /// aliased or bare column projects its name, the qualifier dropped; a
   /// computed expression with no alias falls back to a positional `column N`);
   /// a `SELECT *` carries no names, so it frames by the produced width.
+  private static func names(of query: SQLEngine.Query,
+                            _ rows: Array<Array<Value>>) -> Array<String> {
+    // The names come off the query's leftmost arm's projection — the ISO rule a
+    // set operation's result columns follow; a body with no syntactic
+    // projection frames by the produced width.
+    switch query.arm.body {
+    case let .select(select):
+      return names(of: select.projection, rows)
+    case .setop:
+      return generic(rows)
+    }
+  }
+
   private static func names(of projection: SQLEngine.Projection,
                             _ rows: Array<Array<Value>>) -> Array<String> {
     switch projection {

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -804,6 +804,9 @@ internal struct Shell: ~Escapable {
     switch query.arm.body {
     case let .select(select):
       return names(of: select.projection, rows)
+    case let .values(rows):
+      // The ISO table value constructor's default output names.
+      return (0 ..< (rows.first?.count ?? 0)).map { "column\($0 + 1)" }
     case .setop:
       return generic(rows)
     }

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -786,7 +786,7 @@ internal struct Shell: ~Escapable {
     case let .with(_, query): query
     case let .create(_, view): view.query
     case .function:
-      .select(Select(projection: .all, from: nil))
+      SQLEngine.Query(body: .values([]))
     }
   }
 

--- a/Tests/SQLTests/Expressions/CastTests.swift
+++ b/Tests/SQLTests/Expressions/CastTests.swift
@@ -71,16 +71,16 @@ struct CastNumericTests {
   }
 
   @Test func `a number casts to its canonical text`() throws {
-    try things().expect("SELECT CAST(42 AS TEXT)", yields: [["42"]])
+    try things().expect("VALUES (CAST(42 AS TEXT))", yields: [["42"]])
   }
 
   @Test func `text parses to an integer`() throws {
-    try things().expect("SELECT CAST('42' AS INTEGER)", yields: [[42]])
+    try things().expect("VALUES (CAST('42' AS INTEGER))", yields: [[42]])
   }
 
   @Test func `text parses to a double`() throws {
-    try things().expect("SELECT CAST('2.5' AS DOUBLE)", yields: [[2.5]])
-    try things().expect("SELECT CAST('1.5' AS DOUBLE)", yields: [[1.5]])
+    try things().expect("VALUES (CAST('2.5' AS DOUBLE))", yields: [[2.5]])
+    try things().expect("VALUES (CAST('1.5' AS DOUBLE))", yields: [[1.5]])
   }
 
   @Test func `text of overflowing magnitude to double faults`() throws {
@@ -90,7 +90,7 @@ struct CastNumericTests {
     // NOT the invalid-character fault (`22018`) reserved for an unparseable
     // spelling.
     try things().expect(
-        "SELECT CAST('1e999' AS DOUBLE)",
+        "VALUES (CAST('1e999' AS DOUBLE))",
         fails: .magnitude("double '1e999' out of range for cast"))
   }
 
@@ -98,7 +98,7 @@ struct CastNumericTests {
     // `'abc'` is no number at all, so its cast raises the ISO
     // invalid-character-for-cast fault (`22018`), distinct from the
     // out-of-range fault above.
-    try things().expect("SELECT CAST('abc' AS DOUBLE)",
+    try things().expect("VALUES (CAST('abc' AS DOUBLE))",
                         fails: .state("22018", "cannot cast 'abc' to double"))
   }
 
@@ -120,27 +120,27 @@ struct CastValueTests {
   }
 
   @Test func `a boolean casts to text`() throws {
-    try things().expect("SELECT CAST(TRUE AS TEXT)", yields: [["true"]])
+    try things().expect("VALUES (CAST(TRUE AS TEXT))", yields: [["true"]])
   }
 
   @Test func `text casts to a boolean`() throws {
-    try things().expect("SELECT CAST('no' AS BOOLEAN)", yields: [[false]])
+    try things().expect("VALUES (CAST('no' AS BOOLEAN))", yields: [[false]])
   }
 
   @Test func `text casts to a blob as its UTF-8 octets`() throws {
-    try things().expect("SELECT CAST('AB' AS BLOB)",
+    try things().expect("VALUES (CAST('AB' AS BLOB))",
                         yields: [[[UInt8(0x41), UInt8(0x42)]]])
   }
 
   @Test func `a blob casts back to text`() throws {
-    try things().expect("SELECT CAST(x'4142' AS TEXT)", yields: [["AB"]])
+    try things().expect("VALUES (CAST(x'4142' AS TEXT))", yields: [["AB"]])
   }
 
   @Test func `an unsupported cross-kind cast faults`() throws {
     // A boolean has no conversion to an integer — a cross-kind pair with no ISO
     // conversion faults `42846` (cannot coerce).
     try things().expect(
-        "SELECT CAST(TRUE AS INTEGER)",
+        "VALUES (CAST(TRUE AS INTEGER))",
         fails: .state("42846", "cannot cast boolean to integer"))
   }
 }
@@ -177,7 +177,8 @@ struct CastSchemaTests {
     // schema type-check rejects it rather than advertising an integer column.
     #expect(throws: SQLError.state("42846",
                                    "cannot cast boolean to integer")) {
-      _ = try things().columns(of: parse(query: "SELECT CAST(TRUE AS INTEGER)"))
+      _ = try things()
+          .columns(of: parse(query: "VALUES (CAST(TRUE AS INTEGER))"))
     }
   }
 
@@ -185,8 +186,8 @@ struct CastSchemaTests {
     // A castable-but-value-dependent pair — `integer` → `double` always
     // convertible, `text` → `integer` convertible for a good spelling —
     // type-checks and reports the target type; only a bad value faults at run.
-    #expect(try things().type(of: "SELECT CAST(1 AS DOUBLE)") == .double)
-    #expect(try things().type(of: "SELECT CAST('1' AS INTEGER)") == .integer)
+    #expect(try things().type(of: "VALUES (CAST(1 AS DOUBLE))") == .double)
+    #expect(try things().type(of: "VALUES (CAST('1' AS INTEGER))") == .integer)
   }
 
   @Test func `a constant cast that always fails is rejected at validation`()
@@ -196,7 +197,7 @@ struct CastSchemaTests {
     // at validation, not only at run.
     #expect(throws: SQLError.state("22018",
                                    "cannot cast 'abc' to integer")) {
-      let query = try parse(query: "SELECT CAST('abc' AS INTEGER)")
+      let query = try parse(query: "VALUES (CAST('abc' AS INTEGER))")
       _ = try things().columns(of: query)
     }
   }
@@ -207,7 +208,7 @@ struct CastSchemaTests {
     // unsupported. The constant fold runs FIRST, so the folded NULL trial-casts
     // to `.blob` — a NULL casts to ANY target — and validation succeeds with a
     // blob column rather than rejecting `42846` a query the run would perform.
-    let sql = "SELECT CAST(CASE WHEN 1 = 0 THEN 1 END AS BLOB)"
+    let sql = "VALUES (CAST(CASE WHEN 1 = 0 THEN 1 END AS BLOB))"
     let columns = try things().columns(of: parse(query: sql), validate: true)
     #expect(columns.count == 1)
     #expect(columns[0].type == .blob)
@@ -220,8 +221,9 @@ struct CastSchemaTests {
     // `42846`, the same fault the structural check would raise.
     #expect(throws: SQLError.state("42846",
                                    "cannot cast boolean to integer")) {
-      _ = try things().columns(of: parse(query: "SELECT CAST(TRUE AS INTEGER)"),
-                               validate: true)
+      _ = try things()
+          .columns(of: parse(query: "VALUES (CAST(TRUE AS INTEGER))"),
+                   validate: true)
     }
   }
 
@@ -242,7 +244,7 @@ struct CastSchemaTests {
     // `CAST('1' AS INTEGER)` is a castable pair whose fault depends on the
     // value, so it type-checks as an integer column even after the reorder —
     // the trial cast of the constant `'1'` succeeds.
-    #expect(try things().type(of: "SELECT CAST('1' AS INTEGER)") == .integer)
+    #expect(try things().type(of: "VALUES (CAST('1' AS INTEGER))") == .integer)
   }
 }
 
@@ -253,7 +255,7 @@ struct CastNumericFormatTests {
     // `Double('0x1p2')` is `4.0`, a Swift spelling the SQL grammar rejects, so
     // the cast faults invalid character (`22018`), never yielding `4.0`.
     try things().expect(
-        "SELECT CAST('0x1p2' AS DOUBLE)",
+        "VALUES (CAST('0x1p2' AS DOUBLE))",
         fails: .state("22018", "cannot cast '0x1p2' to double"))
   }
 
@@ -261,12 +263,12 @@ struct CastNumericFormatTests {
     // `Double('inf')` parses to a non-finite magnitude, but `inf` is no SQL
     // numeric spelling, so it is an invalid character (`22018`) — NOT the
     // out-of-range fault (`22003`) a valid-format overflow raises.
-    try things().expect("SELECT CAST('inf' AS DOUBLE)",
+    try things().expect("VALUES (CAST('inf' AS DOUBLE))",
                         fails: .state("22018", "cannot cast 'inf' to double"))
   }
 
   @Test func `the NaN spelling is not a SQL number`() throws {
-    try things().expect("SELECT CAST('nan' AS DOUBLE)",
+    try things().expect("VALUES (CAST('nan' AS DOUBLE))",
                         fails: .state("22018", "cannot cast 'nan' to double"))
   }
 
@@ -275,14 +277,14 @@ struct CastNumericFormatTests {
     // so it passes the format gate and faults out-of-range (`22003`),
     // unchanged.
     try things().expect(
-        "SELECT CAST('1e999' AS DOUBLE)",
+        "VALUES (CAST('1e999' AS DOUBLE))",
         fails: .magnitude("double '1e999' out of range for cast"))
   }
 
   @Test func `valid SQL decimal spellings parse`() throws {
-    try things().expect("SELECT CAST('1.5' AS DOUBLE)", yields: [[1.5]])
-    try things().expect("SELECT CAST('-3' AS DOUBLE)", yields: [[-3.0]])
-    try things().expect("SELECT CAST('2e3' AS DOUBLE)", yields: [[2000.0]])
+    try things().expect("VALUES (CAST('1.5' AS DOUBLE))", yields: [[1.5]])
+    try things().expect("VALUES (CAST('-3' AS DOUBLE))", yields: [[-3.0]])
+    try things().expect("VALUES (CAST('2e3' AS DOUBLE))", yields: [[2000.0]])
   }
 
   @Test func `a format-valid integer overflow is out of range`() throws {
@@ -291,7 +293,7 @@ struct CastNumericFormatTests {
     // range, faulting out-of-range (`22003`), NOT the invalid-character fault
     // (`22018`) an unspellable text raises.
     try things().expect(
-        "SELECT CAST('9223372036854775808' AS INTEGER)",
+        "VALUES (CAST('9223372036854775808' AS INTEGER))",
         fails: .magnitude(
             "integer '9223372036854775808' out of range for cast"))
   }
@@ -301,15 +303,15 @@ struct CastNumericFormatTests {
     // fraction — so each is an invalid character (`22018`), the format gate
     // rejecting them before `Int(_:)` conflates them with a range overflow.
     try things().expect(
-        "SELECT CAST('12abc' AS INTEGER)",
+        "VALUES (CAST('12abc' AS INTEGER))",
         fails: .state("22018", "cannot cast '12abc' to integer"))
     try things().expect(
-        "SELECT CAST('1.5' AS INTEGER)",
+        "VALUES (CAST('1.5' AS INTEGER))",
         fails: .state("22018", "cannot cast '1.5' to integer"))
   }
 
   @Test func `valid SQL integer spellings parse`() throws {
-    try things().expect("SELECT CAST('42' AS INTEGER)", yields: [[42]])
-    try things().expect("SELECT CAST('-7' AS INTEGER)", yields: [[-7]])
+    try things().expect("VALUES (CAST('42' AS INTEGER))", yields: [[42]])
+    try things().expect("VALUES (CAST('-7' AS INTEGER))", yields: [[-7]])
   }
 }

--- a/Tests/SQLTests/Expressions/ComparabilityTests.swift
+++ b/Tests/SQLTests/Expressions/ComparabilityTests.swift
@@ -501,7 +501,7 @@ private func joins(_ plan: Plan) -> Bool {
   case let .semijoin(left, right, _, _): joins(left) || joins(right)
   case let .apply(left, _, _, _, _, _): joins(left)
   case let .setop(_, left, right, _, _, _): joins(left) || joins(right)
-  case .single, .empty, .scan: false
+  case .single, .values, .empty, .scan: false
   }
 }
 
@@ -524,7 +524,7 @@ private func residual(_ plan: Plan) -> Bool {
   case let .semijoin(left, right, _, _): residual(left) || residual(right)
   case let .apply(left, _, _, _, _, _): residual(left)
   case let .setop(_, left, right, _, _, _): residual(left) || residual(right)
-  case .single, .empty, .scan: false
+  case .single, .values, .empty, .scan: false
   }
 }
 

--- a/Tests/SQLTests/Expressions/ConcatTests.swift
+++ b/Tests/SQLTests/Expressions/ConcatTests.swift
@@ -46,7 +46,7 @@ struct ConcatParsingTests {
 
 struct ConcatEvaluationTests {
   @Test func `concatenates two text values`() throws {
-    try things().expect("SELECT 'a' || 'b'", yields: [["ab"]])
+    try things().expect("VALUES ('a' || 'b')", yields: [["ab"]])
   }
 
   @Test func `a NULL right operand propagates NULL`() throws {
@@ -70,7 +70,7 @@ struct ConcatEvaluationTests {
   @Test func `a non-text operand faults`() throws {
     // `||` is a character-string operator; a numeric operand is a type error,
     // as arithmetic faults on a non-numeric one.
-    try things().expect("SELECT 'a' || 1", fails:
+    try things().expect("VALUES ('a' || 1)", fails:
         .operand("|| operands must be text"))
   }
 
@@ -80,7 +80,7 @@ struct ConcatEvaluationTests {
     // it inspects kinds, so this validates — the output-schema text guard
     // admits the folded NULL rather than rejecting the `.integer` type — and
     // runs, yielding NULL; the caller need not fall back to a CASE desugar.
-    try things().expect("SELECT (CASE WHEN 1 = 0 THEN 1 END) || 'x'",
+    try things().expect("VALUES ((CASE WHEN 1 = 0 THEN 1 END) || 'x')",
                         yields: [[nil]])
   }
 
@@ -90,7 +90,7 @@ struct ConcatEvaluationTests {
     // operand's type: `(CASE WHEN 1 = 0 THEN 1 END) || 1` — a folded NULL
     // beside a bare integer — validates and yields NULL rather than being
     // rejected for the integer right operand.
-    try things().expect("SELECT (CASE WHEN 1 = 0 THEN 1 END) || 1",
+    try things().expect("VALUES ((CASE WHEN 1 = 0 THEN 1 END) || 1)",
                         yields: [[nil]])
   }
 }

--- a/Tests/SQLTests/Expressions/ConcatTests.swift
+++ b/Tests/SQLTests/Expressions/ConcatTests.swift
@@ -32,7 +32,7 @@ struct ConcatParsingTests {
 
   @Test func `concatenation is left-associative`() throws {
     // `a || b || c` reads `(a || b) || c`.
-    let select = try parse(select: "SELECT 'a' || 'b' || 'c'")
+    let select = try parse(select: "SELECT 'a' || 'b' || 'c' FROM T")
     let inner = Expression.binary(.concatenate, .literal(.string("a")),
                                   .literal(.string("b")))
     let outer = Expression.binary(.concatenate, inner,

--- a/Tests/SQLTests/Expressions/LikeTests.swift
+++ b/Tests/SQLTests/Expressions/LikeTests.swift
@@ -403,7 +403,7 @@ private func seeks(_ plan: Plan) -> Bool {
   case let .semijoin(left, right, _, _): seeks(left) || seeks(right)
   case let .apply(left, _, _, _, _, _): seeks(left)
   case let .setop(_, left, right, _, _, _): seeks(left) || seeks(right)
-  case .single, .empty: false
+  case .single, .values, .empty: false
   }
 }
 
@@ -424,7 +424,7 @@ private func joins(_ plan: Plan) -> Bool {
   case let .semijoin(left, right, _, _): joins(left) || joins(right)
   case let .apply(left, _, _, _, _, _): joins(left)
   case let .setop(_, left, right, _, _, _): joins(left) || joins(right)
-  case .single, .empty, .scan: false
+  case .single, .values, .empty, .scan: false
   }
 }
 
@@ -447,7 +447,7 @@ private func residual(_ plan: Plan) -> Bool {
   case let .semijoin(left, right, _, _): residual(left) || residual(right)
   case let .apply(left, _, _, _, _, _): residual(left)
   case let .setop(_, left, right, _, _, _): residual(left) || residual(right)
-  case .single, .empty, .scan: false
+  case .single, .values, .empty, .scan: false
   }
 }
 

--- a/Tests/SQLTests/Expressions/NullifTests.swift
+++ b/Tests/SQLTests/Expressions/NullifTests.swift
@@ -19,15 +19,15 @@ struct NullifTests {
   }
 
   @Test func `equal arguments yield NULL`() throws {
-    try nullable().expect("SELECT NULLIF(1, 1)", yields: [[nil]])
+    try nullable().expect("VALUES (NULLIF(1, 1))", yields: [[nil]])
   }
 
   @Test func `unequal integer arguments yield the first`() throws {
-    try nullable().expect("SELECT NULLIF(1, 2)", yields: [[1]])
+    try nullable().expect("VALUES (NULLIF(1, 2))", yields: [[1]])
   }
 
   @Test func `unequal text arguments yield the first`() throws {
-    try nullable().expect("SELECT NULLIF('a', 'b')", yields: [["a"]])
+    try nullable().expect("VALUES (NULLIF('a', 'b'))", yields: [["a"]])
   }
 
   @Test func `the column type is the first argument's`() throws {

--- a/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
+++ b/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
@@ -78,7 +78,7 @@ private func selects(_ plan: Plan) -> Bool {
     selects(left)
   case let .setop(_, left, right, _, _, _):
     selects(left) || selects(right)
-  case .single, .empty, .scan:
+  case .single, .empty, .values, .scan:
     false
   }
 }
@@ -117,7 +117,7 @@ private func empties(_ plan: Plan) -> Bool {
     empties(left)
   case let .setop(_, left, right, _, _, _):
     empties(left) || empties(right)
-  case .single, .scan:
+  case .single, .values, .scan:
     false
   }
 }

--- a/Tests/SQLTests/Optimisation/DecorrelateTests.swift
+++ b/Tests/SQLTests/Optimisation/DecorrelateTests.swift
@@ -29,7 +29,7 @@ private func applies(_ plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return applies(left) || applies(right)
-  case .single, .empty, .scan, .join:
+  case .single, .values, .empty, .scan, .join:
     return false
   }
 }
@@ -49,7 +49,7 @@ private func joins(_ plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return joins(left) || joins(right)
-  case .single, .empty, .scan, .apply:
+  case .single, .values, .empty, .scan, .apply:
     return false
   }
 }
@@ -69,7 +69,7 @@ private func outers(_ plan: Plan) -> Bool {
   case let .product(left, right), let .semijoin(left, right, _, _),
        let .setop(_, left, right, _, _, _):
     return outers(left) || outers(right)
-  case .single, .empty, .scan, .join, .apply:
+  case .single, .values, .empty, .scan, .join, .apply:
     return false
   }
 }
@@ -91,7 +91,7 @@ private func semijoins(_ plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .setop(_, left, right, _, _, _):
     return semijoins(left) || semijoins(right)
-  case .single, .empty, .scan, .join, .apply:
+  case .single, .values, .empty, .scan, .join, .apply:
     return false
   }
 }
@@ -111,7 +111,7 @@ private func semijoins(_ plan: Plan, anti wanted: Bool) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .setop(_, left, right, _, _, _):
     return semijoins(left, anti: wanted) || semijoins(right, anti: wanted)
-  case .single, .empty, .scan, .join, .apply:
+  case .single, .values, .empty, .scan, .join, .apply:
     return false
   }
 }
@@ -132,7 +132,7 @@ private func semijoinCount(_ plan: Plan) -> Int {
   case let .product(left, right), let .outer(left, right, _, _),
        let .setop(_, left, right, _, _, _):
     return semijoinCount(left) + semijoinCount(right)
-  case .single, .empty, .scan, .join, .apply:
+  case .single, .values, .empty, .scan, .join, .apply:
     return 0
   }
 }
@@ -157,7 +157,7 @@ private func semijoinCount(_ plan: Plan, anti wanted: Bool) -> Int {
        let .setop(_, left, right, _, _, _):
     return semijoinCount(left, anti: wanted)
         + semijoinCount(right, anti: wanted)
-  case .single, .empty, .scan, .join, .apply:
+  case .single, .values, .empty, .scan, .join, .apply:
     return 0
   }
 }
@@ -177,7 +177,7 @@ private func exists(in plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return exists(in: left) || exists(in: right)
-  case .single, .empty, .scan, .join, .apply:
+  case .single, .values, .empty, .scan, .join, .apply:
     return false
   }
 }
@@ -213,7 +213,7 @@ private func within(in plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return within(in: left) || within(in: right)
-  case .single, .empty, .scan, .join, .apply:
+  case .single, .values, .empty, .scan, .join, .apply:
     return false
   }
 }
@@ -252,7 +252,7 @@ private func subquery(in plan: Plan) -> Bool {
   case let .product(left, right), let .outer(left, right, _, _),
        let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
     return subquery(in: left) || subquery(in: right)
-  case .single, .empty, .scan, .join, .apply:
+  case .single, .values, .empty, .scan, .join, .apply:
     return false
   }
 }

--- a/Tests/SQLTests/Optimisation/DistinctFoldTests.swift
+++ b/Tests/SQLTests/Optimisation/DistinctFoldTests.swift
@@ -65,7 +65,7 @@ private func distincts(_ plan: Plan) -> Bool {
     distincts(left)
   case let .setop(_, left, right, _, _, _):
     distincts(left) || distincts(right)
-  case .single, .empty, .scan:
+  case .single, .values, .empty, .scan:
     false
   }
 }

--- a/Tests/SQLTests/Queries/ComparabilityPlanningTests.swift
+++ b/Tests/SQLTests/Queries/ComparabilityPlanningTests.swift
@@ -345,7 +345,7 @@ struct CarrierSubqueryComparabilityTests {
     let catalog = try crossable()
     let sql = """
         WITH RECURSIVE t(n) AS (
-          SELECT 1 AS x
+          VALUES (1)
           UNION ALL
           SELECT n + 1 FROM t WHERE n < 3
           ORDER BY CASE WHEN EXISTS (SELECT 1 FROM A a WHERE a.num = a.txt)

--- a/Tests/SQLTests/Queries/DerivedColumnListTests.swift
+++ b/Tests/SQLTests/Queries/DerivedColumnListTests.swift
@@ -59,7 +59,7 @@ struct DerivedColumnListParsingTests {
     let select = try parse(select: "SELECT d.a FROM (SELECT x AS a FROM S) AS d")
     let inner = try parse(query: "SELECT x AS a FROM S")
     #expect(select.from == Relation(derived: inner, as: "d"))
-    #expect(select.from?.columns == [])
+    #expect(select.from.columns == [])
   }
 
   @Test func `a column list is optional on a named relation`() throws {
@@ -67,7 +67,7 @@ struct DerivedColumnListParsingTests {
     // fires only after an alias, so a plain named relation stays list-free.
     let select = try parse(select: "SELECT V FROM T")
     #expect(select.from == Relation(name: "T"))
-    #expect(select.from?.columns == [])
+    #expect(select.from.columns == [])
   }
 }
 

--- a/Tests/SQLTests/Queries/DerivedColumnListTests.swift
+++ b/Tests/SQLTests/Queries/DerivedColumnListTests.swift
@@ -190,37 +190,37 @@ struct ColumnListFaultTests {
 // MARK: - Execution: LATERAL derived table
 
 struct LateralColumnListTests {
-  @Test func `a column list renames a lateral body's duplicate inner names`()
+  @Test func `a column list names a lateral row of two equal values`()
       throws {
-    // The reviewer's case: the body projects `T.Id AS x` twice — a duplicate
-    // INNER name the `d(a, b)` list renames positionally to the unique exposed
-    // `a`, `b`. The compile-path validation in `lateral` must check the renamed
-    // names, so this runs (both columns = `T.Id`) rather than faulting the
-    // inner duplicate — parity with the schema pass.
+    // The reviewer's case in VALUES form: the lateral row lists `T.Id` twice,
+    // which the `d(a, b)` list names positionally as the exposed `a`, `b`. The
+    // compile-path validation in `lateral` checks the exposed names, so this
+    // runs (both columns = `T.Id`) rather than faulting — parity with the
+    // schema pass.
     try fixture().expect(
         "SELECT d.a, d.b FROM T " +
-        "JOIN LATERAL (SELECT T.Id AS x, T.Id AS x) AS d(a, b) ON 1 = 1 " +
+        "JOIN LATERAL (VALUES (T.Id, T.Id)) AS d(a, b) ON 1 = 1 " +
         "ORDER BY d.a",
         yields: [[1, 1], [2, 2]])
   }
 
-  @Test func `a column list renames a lateral body's distinct columns`()
+  @Test func `a column list names a lateral row's distinct values`()
       throws {
-    // A list over DISTINCT inner columns renames them positionally, unchanged
-    // by the fix — the body projects two real columns, addressed as `a`, `b`.
+    // A list over two distinct values names them positionally, unchanged by the
+    // fix — the lateral row lists `T.Id`, `T.V`, addressed as `a`, `b`.
     try fixture().expect(
         "SELECT d.a, d.b FROM T " +
-        "JOIN LATERAL (SELECT T.Id, T.V) AS d(a, b) ON 1 = 1 " +
+        "JOIN LATERAL (VALUES (T.Id, T.V)) AS d(a, b) ON 1 = 1 " +
         "ORDER BY d.a",
         yields: [[1, 100], [2, 200]])
   }
 
   @Test func `a lateral column list of the wrong arity faults`() throws {
-    // A one-name list against a two-column body mismatches —
+    // A one-name list against a two-column lateral row mismatches —
     // `SQLError.columns`, as the non-lateral seam faults.
     try fixture().expect(
         "SELECT d.a FROM T " +
-        "JOIN LATERAL (SELECT T.Id, T.V) AS d(a) ON 1 = 1",
+        "JOIN LATERAL (VALUES (T.Id, T.V)) AS d(a) ON 1 = 1",
         fails: .columns(expected: 2, got: 1))
   }
 
@@ -231,7 +231,7 @@ struct LateralColumnListTests {
     // names, and here they collide.
     try fixture().expect(
         "SELECT d.a FROM T " +
-        "JOIN LATERAL (SELECT T.Id, T.V) AS d(a, a) ON 1 = 1",
+        "JOIN LATERAL (VALUES (T.Id, T.V)) AS d(a, a) ON 1 = 1",
         fails: .duplicate("a"))
   }
 }

--- a/Tests/SQLTests/Queries/DerivedTableTests.swift
+++ b/Tests/SQLTests/Queries/DerivedTableTests.swift
@@ -104,7 +104,7 @@ struct DerivedTableParsingTests {
     // The default is non-lateral — a plain `(SELECT …)` never sets `lateral`.
     let select = try parse(select:
         "SELECT t.a FROM (SELECT V AS a FROM S) AS t")
-    #expect(!(select.from?.lateral ?? true))
+    #expect(!select.from.lateral)
   }
 
   @Test func `LATERAL before a named relation faults`() throws {

--- a/Tests/SQLTests/Queries/DerivedTableTests.swift
+++ b/Tests/SQLTests/Queries/DerivedTableTests.swift
@@ -533,7 +533,7 @@ struct DerivedTableScopingTests {
     // a statement, so run it through the statement entry rather than the
     // query-only `expect`.
     let statement = try Statement(parsing:
-        "WITH t(x) AS (SELECT 99) " +
+        "WITH t(x) AS (VALUES (99)) " +
         "SELECT a FROM (SELECT V AS a FROM S) AS t ORDER BY a")
     let rows = try fixture().run(statement, .standard)
     #expect(rows == [[.integer(10)], [.integer(20)], [.integer(30)]])
@@ -773,7 +773,7 @@ struct DerivedTableWithValidateThreadingTests {
     // re-augmented the trailing query's derived table with the DEFAULT
     // `validate: true` before this fix, so it still faulted `.operand`.
     let statement = try Statement(parsing:
-        "WITH c(x) AS (SELECT 1) " +
+        "WITH c(x) AS (VALUES (1)) " +
         "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d")
     let rows = try fixture().run(statement, .standard)
     #expect(rows.isEmpty)
@@ -786,7 +786,7 @@ struct DerivedTableWithValidateThreadingTests {
     // on the same trailing-query body still faults its ill-typed projection.
     #expect(throws: SQLError.operand("operands must be numeric")) {
       let statement = try Statement(parsing:
-          "WITH c(x) AS (SELECT 1) " +
+          "WITH c(x) AS (VALUES (1)) " +
           "SELECT * FROM (SELECT Label + 1 AS x FROM K WHERE k = 0) AS d")
       _ = try fixture().columns(of: statement, validate: true)
     }
@@ -914,7 +914,7 @@ struct DerivedTableSetOperationScopingTests {
     // shared arm map bound the right `T` query-wide, hiding the CTE from the
     // left arm.
     let statement = try Statement(parsing:
-        "WITH T(Id) AS (SELECT 100 UNION ALL SELECT 200) " +
+        "WITH T(Id) AS (VALUES (100) UNION ALL VALUES (200)) " +
         "SELECT Id FROM T " +
         "UNION ALL SELECT a FROM (SELECT V AS a FROM S) AS T")
     let rows = try fixture().run(statement, .standard)
@@ -1107,13 +1107,13 @@ private func views() throws -> FixtureCatalog {
 struct DerivedTableCTEShadowTests {
   @Test func `a derived body resolves an enclosing CTE of its own alias name`()
       throws {
-    // `WITH t(x) AS (SELECT 1) SELECT * FROM (SELECT x FROM t) AS t` — the
+    // `WITH t(x) AS (VALUES (1)) SELECT * FROM (SELECT x FROM t) AS t` — the
     // inner `FROM t` is inside the derived table also aliased `t`; the alias
     // being defined is out of scope in its own body, so `t` resolves the CTE
     // (projecting its `x` = 1), not the derived table itself. A name-blanket
     // drop removed the CTE, faulting `.relation("t")` (or resolving a base).
     let statement = try Statement(parsing:
-        "WITH t(x) AS (SELECT 1) SELECT * FROM (SELECT x FROM t) AS t")
+        "WITH t(x) AS (VALUES (1)) SELECT * FROM (SELECT x FROM t) AS t")
     let rows = try fixture().run(statement, .standard)
     #expect(rows == [[.integer(1)]])
   }
@@ -1122,7 +1122,7 @@ struct DerivedTableCTEShadowTests {
     // Schema ↔ run parity: `columns(of:)` derives the body against the CTE `t`
     // too, so the result column is the CTE's `x`, resolved rather than faulted.
     let statement = try Statement(parsing:
-        "WITH t(x) AS (SELECT 1) SELECT * FROM (SELECT x FROM t) AS t")
+        "WITH t(x) AS (VALUES (1)) SELECT * FROM (SELECT x FROM t) AS t")
     let columns = try fixture().columns(of: statement, validate: true)
     #expect(columns.map(\.name) == ["x"])
   }
@@ -1148,7 +1148,7 @@ struct DerivedTableCTEShadowTests {
     // 7 and the cross join to the three-row sibling `a` gives 7 three times;
     // had `b` read the sibling derived `a` it would be three rows, product 9.
     let statement = try Statement(parsing:
-        "WITH a(v) AS (SELECT 7) " +
+        "WITH a(v) AS (VALUES (7)) " +
         "SELECT b.v FROM (SELECT V AS v FROM S) AS a " +
         "JOIN (SELECT v FROM a) AS b ON b.v = b.v ORDER BY b.v")
     let rows = try fixture().run(statement, .standard)
@@ -1171,7 +1171,7 @@ struct DerivedTableCTEShadowScalarTests {
     // the shadowing derived `d`; the outer FROM's derived `d` yields three rows
     // (T's Ids), so each output row is the CTE's 1.
     let statement = try Statement(parsing:
-        "WITH d(x) AS (SELECT 1) " +
+        "WITH d(x) AS (VALUES (1)) " +
         "SELECT (SELECT x FROM d) FROM (SELECT Id AS y FROM T) AS d")
     let rows = try fixture().run(statement, .standard)
     #expect(rows == [[.integer(1)], [.integer(1)], [.integer(1)]])
@@ -1181,7 +1181,7 @@ struct DerivedTableCTEShadowScalarTests {
     // Schema ↔ run parity: `columns(of:)` derives the scalar against the CTE
     // `d` too, so the projection resolves rather than faulting `.relation`.
     let statement = try Statement(parsing:
-        "WITH d(x) AS (SELECT 1) " +
+        "WITH d(x) AS (VALUES (1)) " +
         "SELECT (SELECT x FROM d) FROM (SELECT Id AS y FROM T) AS d")
     let columns = try fixture().columns(of: statement, validate: true)
     #expect(columns.count == 1)
@@ -1193,7 +1193,7 @@ struct DerivedTableCTEShadowScalarTests {
     // every outer row, so all three derived `d` rows survive — the behaviour
     // the lazy scalar now matches.
     let statement = try Statement(parsing:
-        "WITH d(x) AS (SELECT 1) " +
+        "WITH d(x) AS (VALUES (1)) " +
         "SELECT y FROM (SELECT Id AS y FROM T) AS d " +
         "WHERE EXISTS (SELECT 1 FROM d) ORDER BY y")
     let rows = try fixture().run(statement, .standard)
@@ -1205,7 +1205,7 @@ struct DerivedTableCTEShadowScalarTests {
     // over the CTE `d`'s single value 1, so only the derived row with Id = 1
     // survives — the CTE, not the shadowing derived `d`, feeds the membership.
     let statement = try Statement(parsing:
-        "WITH d(x) AS (SELECT 1) " +
+        "WITH d(x) AS (VALUES (1)) " +
         "SELECT y FROM (SELECT Id AS y FROM T) AS d " +
         "WHERE y IN (SELECT x FROM d) ORDER BY y")
     let rows = try fixture().run(statement, .standard)
@@ -1220,7 +1220,7 @@ struct DerivedTableCTEShadowScalarTests {
     // to avoid the source `T` collision) drives the rows; the scalar collapses
     // to MAX = 3, so each of the three rows carries 3.
     let statement = try Statement(parsing:
-        "WITH c(x) AS (SELECT 1) " +
+        "WITH c(x) AS (VALUES (1)) " +
         "SELECT (SELECT MAX(y) FROM (SELECT Id AS y FROM T) AS e) " +
         "FROM (SELECT Id FROM T) AS d")
     let rows = try fixture().run(statement, .standard)
@@ -1681,21 +1681,21 @@ struct DerivedTableSetOperationValidateTests {
 /// genuine self-reference nested inside a derived body IS.
 struct DerivedTableRecursionReferenceTests {
   @Test func `a shadowing derived alias is not a recursive reference`() throws {
-    // `WITH RECURSIVE a(n) AS (SELECT 1 UNION ALL SELECT n FROM (SELECT 2 AS n)
-    // AS a) SELECT n FROM a` — the second arm's `FROM (…) AS a` merely names a
-    // derived table `a`; it does not reference the CTE `a`, so the CTE is NOT
+    // `WITH RECURSIVE a(n) AS (VALUES (1) UNION ALL SELECT n FROM (VALUES (2))
+    // AS a(n)) SELECT n FROM a` — the second arm's `FROM (…) AS a` merely names
+    // a derived table `a`; it does not reference the CTE `a`, so the CTE is NOT
     // recursive and the arm runs once (never to the recursion cap). The
     // `UNION ALL` keeps both arms: the anchor 1, then the derived table's 2.
     let statement = try Statement(parsing:
         "WITH RECURSIVE a(n) AS " +
-        "(SELECT 1 UNION ALL SELECT n FROM (SELECT 2 AS n) AS a) " +
+        "(VALUES (1) UNION ALL SELECT n FROM (VALUES (2)) AS a(n)) " +
         "SELECT n FROM a ORDER BY n")
     let rows = try fixture().run(statement, .standard)
     #expect(rows == [[.integer(1)], [.integer(2)]])
   }
 
   @Test func `a self-reference nested in a derived body is detected`() throws {
-    // `WITH RECURSIVE a(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM (SELECT n
+    // `WITH RECURSIVE a(n) AS (VALUES (1) UNION ALL SELECT n + 1 FROM (SELECT n
     // FROM a) AS d WHERE n < 3) …` — the second arm's derived body `FROM a`
     // genuinely references the CTE `a`, so the CTE IS recursive and routes
     // through the fixpoint. Detecting the nested reference is what makes the
@@ -1704,7 +1704,7 @@ struct DerivedTableRecursionReferenceTests {
     // once against an unbound `a` and fault.
     let statement = try Statement(parsing:
         "WITH RECURSIVE a(n) AS " +
-        "(SELECT 1 UNION ALL " +
+        "(VALUES (1) UNION ALL " +
         "SELECT n + 1 FROM (SELECT n FROM a) AS d WHERE n < 3) " +
         "SELECT n FROM a ORDER BY n")
     let rows = try fixture().run(statement, .standard)
@@ -1849,7 +1849,7 @@ struct DerivedTableSubqueryScopeTests {
     // derived `d`. The alias is SELECT-scoped, invisible to the subquery's
     // FROM, so it faults `.relation("d")` at a run.
     try fixture().expect(
-        "SELECT x FROM (SELECT 1 AS x) AS d WHERE EXISTS (SELECT 1 FROM d)",
+        "SELECT x FROM (VALUES (1)) AS d(x) WHERE EXISTS (SELECT 1 FROM d)",
         fails: .relation("d"))
   }
 
@@ -1858,7 +1858,7 @@ struct DerivedTableSubqueryScopeTests {
     // Schema ↔ run parity: `columns(of:)` faults `.relation("d")` on the same
     // subquery FROM naming the enclosing derived alias.
     let query = try parse(query:
-        "SELECT x FROM (SELECT 1 AS x) AS d WHERE EXISTS (SELECT 1 FROM d)")
+        "SELECT x FROM (VALUES (1)) AS d(x) WHERE EXISTS (SELECT 1 FROM d)")
     #expect(throws: SQLError.relation("d")) {
       _ = try fixture().columns(of: query, validate: true)
     }
@@ -1879,7 +1879,7 @@ struct DerivedTableSubqueryScopeTests {
     // The `IN` variant: `Id IN (SELECT Id FROM d)` names the enclosing derived
     // `d`, invisible to the subquery's FROM — the same `.relation("d")` fault.
     try fixture().expect(
-        "SELECT x FROM (SELECT 1 AS x, 1 AS Id) AS d " +
+        "SELECT x FROM (VALUES (1, 1)) AS d(x, Id) " +
         "WHERE Id IN (SELECT Id FROM d)",
         fails: .relation("d"))
   }
@@ -1889,7 +1889,7 @@ struct DerivedTableSubqueryScopeTests {
     // The scalar variant: `(SELECT MAX(x) FROM d)` names the enclosing derived
     // `d` — invisible to its FROM, so it faults `.relation("d")`.
     try fixture().expect(
-        "SELECT x FROM (SELECT 1 AS x) AS d " +
+        "SELECT x FROM (VALUES (1)) AS d(x) " +
         "WHERE (SELECT MAX(x) FROM d) = 1",
         fails: .relation("d"))
   }
@@ -1900,8 +1900,8 @@ struct DerivedTableSubqueryScopeTests {
     // `EXISTS (SELECT 1 FROM d)` resolves the CTE `d` (one row), so the
     // subquery is TRUE and the outer derived row is kept.
     let statement = try Statement(parsing:
-        "WITH d(x) AS (SELECT 1) " +
-        "SELECT y FROM (SELECT 2 AS y) AS d WHERE EXISTS (SELECT 1 FROM d)")
+        "WITH d(x) AS (VALUES (1)) " +
+        "SELECT y FROM (VALUES (2)) AS d(y) WHERE EXISTS (SELECT 1 FROM d)")
     let rows = try fixture().run(statement, .standard)
     #expect(rows == [[.integer(2)]])
   }
@@ -1912,19 +1912,19 @@ struct DerivedTableSubqueryScopeTests {
     // subquery FROM too (never faulting on the stripped enclosing derived `d`),
     // advertising the outer projection `y`.
     let statement = try Statement(parsing:
-        "WITH d(x) AS (SELECT 1) " +
-        "SELECT y FROM (SELECT 2 AS y) AS d WHERE EXISTS (SELECT 1 FROM d)")
+        "WITH d(x) AS (VALUES (1)) " +
+        "SELECT y FROM (VALUES (2)) AS d(y) WHERE EXISTS (SELECT 1 FROM d)")
     let columns = try fixture().columns(of: statement, validate: true)
     #expect(columns.map(\.name) == ["y"])
   }
 
   @Test func `a subquery's own derived table still resolves`() throws {
     // The subquery augments its own derived table `e` — the strip drops only
-    // the enclosing derived aliases, so `EXISTS (SELECT 1 FROM (SELECT 2 AS z)
+    // the enclosing derived aliases, so `EXISTS (SELECT 1 FROM (VALUES (2))
     // AS e)` resolves `e` and the subquery is TRUE, keeping the outer row.
     try fixture().expect(
-        "SELECT x FROM (SELECT 1 AS x) AS d " +
-        "WHERE EXISTS (SELECT 1 FROM (SELECT 2 AS z) AS e)",
+        "SELECT x FROM (VALUES (1)) AS d(x) " +
+        "WHERE EXISTS (SELECT 1 FROM (VALUES (2)) AS e)",
         yields: [[1]])
   }
 
@@ -1954,17 +1954,17 @@ struct DerivedTableSubqueryScopeTests {
 struct DerivedTableBodyCTEShadowSubqueryTests {
   @Test func `a body FROM alias shadows a CTE its nested subquery still reads`()
       throws {
-    // `WITH t(x) AS (SELECT 1) SELECT * FROM (SELECT y FROM (SELECT 2 AS y)
-    // AS t WHERE EXISTS (SELECT x FROM t)) AS d` — the outer derived body's own
-    // `FROM (SELECT 2 AS y) AS t` shadows the CTE `t`, and the body's nested
-    // `EXISTS (SELECT x FROM t)` names `t` — which resolves the CTE
+    // `WITH t(x) AS (VALUES (1)) SELECT * FROM (SELECT y FROM (VALUES (2))
+    // AS t(y) WHERE EXISTS (SELECT x FROM t)) AS d` — the outer derived body's
+    // own `FROM (VALUES (2)) AS t(y)` shadows the CTE `t`, and the body's
+    // nested `EXISTS (SELECT x FROM t)` names `t` — which resolves the CTE
     // (statement-scoped, visible in a subquery), reading its `x` = 1. The CTE
     // has one row, so the EXISTS is TRUE and the body yields `y` = 2. Before
     // the fix the schema walk's overlay overwrote the CTE with the body's
     // derived `t`, so subscoping dropped it and `SELECT x FROM t` faulted.
     let statement = try Statement(parsing:
-        "WITH t(x) AS (SELECT 1) " +
-        "SELECT * FROM (SELECT y FROM (SELECT 2 AS y) AS t " +
+        "WITH t(x) AS (VALUES (1)) " +
+        "SELECT * FROM (SELECT y FROM (VALUES (2)) AS t(y) " +
                        "WHERE EXISTS (SELECT x FROM t)) AS d")
     let rows = try fixture().run(statement, .standard)
     #expect(rows == [[.integer(2)]])
@@ -1976,8 +1976,8 @@ struct DerivedTableBodyCTEShadowSubqueryTests {
     // faulting on the body's derived `t` (no column `x`) — advertising the
     // outer projection `y`.
     let statement = try Statement(parsing:
-        "WITH t(x) AS (SELECT 1) " +
-        "SELECT * FROM (SELECT y FROM (SELECT 2 AS y) AS t " +
+        "WITH t(x) AS (VALUES (1)) " +
+        "SELECT * FROM (SELECT y FROM (VALUES (2)) AS t(y) " +
                        "WHERE EXISTS (SELECT x FROM t)) AS d")
     let columns = try fixture().columns(of: statement, validate: true)
     #expect(columns.map(\.name) == ["y"])
@@ -2136,7 +2136,7 @@ private func scopedScalarView() throws -> FixtureCatalog {
     // The scalar `(SELECT COUNT(*) FROM T)` is a lazy scalar occurrence keyed
     // under `.view("count")`; it must resolve against the base `T` (count 3),
     // never a caller CTE `T`.
-    try View("Count", "SELECT (SELECT COUNT(*) FROM T) AS n", as: ["n"])
+    try View("Count", "VALUES ((SELECT COUNT(*) FROM T))", as: ["n"])
   }
 }
 
@@ -2155,8 +2155,8 @@ struct DerivedTableViewScalarScopeTests {
     // 5. The lazy scalar now resolves under its own `.view("count")` scope (the
     // view's base `T`), not the merged caller scope.
     let statement = try Statement(parsing:
-        "WITH T(V) AS (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 " +
-        "UNION ALL SELECT 4 UNION ALL SELECT 5) SELECT * FROM Count")
+        "WITH T(V) AS (VALUES (1) UNION ALL VALUES (2) UNION ALL VALUES (3) " +
+        "UNION ALL VALUES (4) UNION ALL VALUES (5)) SELECT * FROM Count")
     let rows = try scopedScalarView().run(statement, .standard)
     #expect(rows == [[.integer(3)]])
   }
@@ -2167,8 +2167,8 @@ struct DerivedTableViewScalarScopeTests {
     // same `.view` scope, advertising the view's projection `n` rather than
     // faulting or shifting to the caller CTE.
     let statement = try Statement(parsing:
-        "WITH T(V) AS (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 " +
-        "UNION ALL SELECT 4 UNION ALL SELECT 5) SELECT * FROM Count")
+        "WITH T(V) AS (VALUES (1) UNION ALL VALUES (2) UNION ALL VALUES (3) " +
+        "UNION ALL VALUES (4) UNION ALL VALUES (5)) SELECT * FROM Count")
     let columns = try scopedScalarView().columns(of: statement, validate: true)
     #expect(columns.map(\.name) == ["n"])
   }
@@ -2180,8 +2180,8 @@ struct DerivedTableViewScalarScopeTests {
     // against. The per-`Subscope` map keeps the caller scalar on the caller
     // scope and the view scalar on the view scope at once.
     let statement = try Statement(parsing:
-        "WITH T(V) AS (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 " +
-        "UNION ALL SELECT 4 UNION ALL SELECT 5) " +
+        "WITH T(V) AS (VALUES (1) UNION ALL VALUES (2) UNION ALL VALUES (3) " +
+        "UNION ALL VALUES (4) UNION ALL VALUES (5)) " +
         "SELECT (SELECT COUNT(*) FROM T) AS n FROM One")
     let rows = try scopedScalarView().run(statement, .standard)
     #expect(rows == [[.integer(5)]])
@@ -2262,14 +2262,14 @@ struct DerivedTableDirectCompileTests {
 struct DerivedTableGroupedOrderScalarShadowTests {
   @Test func `a grouped ORDER BY aggregate subquery reads the shadowed CTE`()
       throws {
-    // `WITH d(x) AS (SELECT 1) SELECT y FROM (SELECT 2 AS y) AS d GROUP BY y
+    // `WITH d(x) AS (VALUES (1)) SELECT y FROM (VALUES (2)) AS d(y) GROUP BY y
     // ORDER BY SUM((SELECT x FROM d))` — the scalar `(SELECT x FROM d)` in
     // the ORDER BY aggregate names the CTE `d` (x = 1), NOT the shadowing
     // `d` (whose column is `y`). One group (y = 2), so `SUM` folds the single
     // scalar value 1; the row is the group's `y` = 2. Had the scalar read the
     // derived `d`, `x` would not resolve and it would fault.
     let statement = try Statement(parsing:
-        "WITH d(x) AS (SELECT 1) SELECT y FROM (SELECT 2 AS y) AS d " +
+        "WITH d(x) AS (VALUES (1)) SELECT y FROM (VALUES (2)) AS d(y) " +
         "GROUP BY y ORDER BY SUM((SELECT x FROM d))")
     let rows = try fixture().run(statement, .standard)
     #expect(rows == [[.integer(2)]])
@@ -2282,7 +2282,7 @@ struct DerivedTableGroupedOrderScalarShadowTests {
     // CTE `d` rather than faulting on the shadowing derived `d`, and advertises
     // the outer projection `y`.
     let statement = try Statement(parsing:
-        "WITH d(x) AS (SELECT 1) SELECT y FROM (SELECT 2 AS y) AS d " +
+        "WITH d(x) AS (VALUES (1)) SELECT y FROM (VALUES (2)) AS d(y) " +
         "GROUP BY y ORDER BY SUM((SELECT x FROM d))")
     let columns = try fixture().columns(of: statement, validate: true)
     #expect(columns.map(\.name) == ["y"])
@@ -2362,7 +2362,7 @@ struct DerivedTableLenientOutputTests {
 /// constraint on it, exactly as a bare constant-NULL set-operation arm does.
 /// `materialise` carries the fold's per-column unconstrained marker through the
 /// derived-table binding (and through an `AS d(a)` rename), so a transparent
-/// `(SELECT NULLIF('a','a') AS x) AS d` wrapper unifies with a later typed arm
+/// `(VALUES (NULLIF('a','a'))) AS d(x)` wrapper unifies with a later typed arm
 /// ORDER-independently rather than folding as its literal-fix type and
 /// faulting.
 struct DerivedTableNullUnificationTests {
@@ -2372,7 +2372,7 @@ struct DerivedTableNullUnificationTests {
     // unconstrained and unify it with the `1` arm — the reviewer's case, which
     // faulted before the marker survived the derived-table binding.
     try fixture().expect(
-        "SELECT x FROM (SELECT NULLIF('a', 'a') AS x) AS d UNION SELECT 1",
+        "SELECT x FROM (VALUES (NULLIF('a', 'a'))) AS d(x) UNION VALUES (1)",
         yields: [[nil], [1]])
   }
 
@@ -2382,7 +2382,7 @@ struct DerivedTableNullUnificationTests {
     // the derived column would fold as its literal-fix type and fault; the
     // marker unifies it either way.
     try fixture().expect(
-        "SELECT 1 AS n UNION SELECT x FROM (SELECT NULLIF('a', 'a') AS x) AS d",
+        "VALUES (1) UNION SELECT x FROM (VALUES (NULLIF('a', 'a'))) AS d(x)",
         yields: [[1], [nil]])
   }
 
@@ -2392,7 +2392,7 @@ struct DerivedTableNullUnificationTests {
     // column-list rename, so `d(a)` over a constant-NULL body still unifies
     // with the `1` arm rather than taking a concrete literal-fix type.
     try fixture().expect(
-        "SELECT a FROM (SELECT NULLIF('a', 'a') AS x) AS d(a) UNION SELECT 1",
+        "SELECT a FROM (VALUES (NULLIF('a', 'a'))) AS d(a) UNION VALUES (1)",
         yields: [[nil], [1]])
   }
 
@@ -2401,7 +2401,7 @@ struct DerivedTableNullUnificationTests {
     // over-marked as unconstrained, so a UNION with an integer arm still faults
     // on the irreconcilable text/integer pair.
     try fixture().expect(
-        "SELECT x FROM (SELECT 'a' AS x) AS d UNION SELECT 1",
+        "SELECT x FROM (VALUES ('a')) AS d(x) UNION VALUES (1)",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 }

--- a/Tests/SQLTests/Queries/EngineJoinTests.swift
+++ b/Tests/SQLTests/Queries/EngineJoinTests.swift
@@ -1527,7 +1527,7 @@ struct EngineNaturalUsingTests {
 
   @Test func `a USING join defers to the right when the left is unconstrained`()
       throws {
-    // `(SELECT NULLIF(1, 1) AS k) AS a` — the left `k` is constant NULL, so
+    // `(VALUES (NULLIF(1, 1))) AS a(k)` — the left `k` is constant NULL, so
     // unconstrained (a placeholder `integer` that places no type constraint) —
     // RIGHT JOIN `B_text` whose `k` is `text`. The merged `k` types off the
     // constrained right (`text`) through the same mask-aware unification the
@@ -1541,7 +1541,7 @@ struct EngineNaturalUsingTests {
       }
     }
     let text = """
-        SELECT k FROM (SELECT NULLIF(1, 1) AS k) AS a
+        SELECT k FROM (VALUES (NULLIF(1, 1))) AS a(k)
           RIGHT JOIN B_text USING (k) ORDER BY k
         """
     let columns = try catalog.columns(of: Statement(parsing: text),
@@ -1554,7 +1554,7 @@ struct EngineNaturalUsingTests {
   @Test func `a USING join defers to the left when the right is unconstrained`()
       throws {
     // The symmetric case: the constrained left `A_text.k` (`text`) beside an
-    // unconstrained right `(SELECT NULLIF(1, 1) AS k)` — the merged `k` types
+    // unconstrained right `(VALUES (NULLIF(1, 1)))` — the merged `k` types
     // off the left (`text`), and a LEFT join keeps every left row, its merged
     // `k` the left value (the always-NULL right coalesces away).
     let catalog = try Catalog {
@@ -1565,7 +1565,7 @@ struct EngineNaturalUsingTests {
     }
     let text = """
         SELECT k FROM A_text
-          LEFT JOIN (SELECT NULLIF(1, 1) AS k) AS b USING (k) ORDER BY k
+          LEFT JOIN (VALUES (NULLIF(1, 1))) AS b(k) USING (k) ORDER BY k
         """
     let columns = try catalog.columns(of: Statement(parsing: text),
                                       validate: true)
@@ -1577,11 +1577,11 @@ struct EngineNaturalUsingTests {
   @Test func `a USING join of two unconstrained sides stays unconstrained`()
       throws {
     // both constituents constant NULL (unconstrained): the merged `k` stays a
-    // placeholder that places no constraint, so a further `UNION SELECT 1` over
-    // it unifies to `integer` rather than faulting the placeholder beside the
-    // typed arm — the merged column carries its own `unconstrained` bit into
-    // the enclosing set-operation fold, exactly as a bare unconstrained column
-    // would.
+    // placeholder that places no constraint, so a further `UNION VALUES (1)`
+    // over it unifies to `integer` rather than faulting the placeholder beside
+    // the typed arm — the merged column carries its own `unconstrained` bit
+    // into the enclosing set-operation fold, exactly as a bare unconstrained
+    // column would.
     let catalog = try Catalog {
       Relation("Unit", ["only": .integer]) {
         Row(1)
@@ -1590,7 +1590,7 @@ struct EngineNaturalUsingTests {
     let text = """
         SELECT k FROM (SELECT NULLIF(1, 1) AS k FROM Unit) AS a
           JOIN (SELECT NULLIF(1, 1) AS k FROM Unit) AS b USING (k)
-        UNION SELECT 1
+        UNION VALUES (1)
         """
     let columns = try catalog.columns(of: Statement(parsing: text),
                                       validate: true)
@@ -1655,7 +1655,7 @@ struct EngineNaturalUsingTests {
     // `.ambiguous` between the two physical `Dept`s. Run and schema agree.
     let text = """
         SELECT d.n FROM Emp JOIN Team USING (Dept)
-          JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
+          JOIN LATERAL (VALUES (Dept)) AS d(n) ON 1 = 1
         """
     try named().expect(text, yields: [[20], [20]])
     let columns = try named()
@@ -1668,7 +1668,7 @@ struct EngineNaturalUsingTests {
     // same way `USING` does.
     let text = """
         SELECT d.n FROM Emp NATURAL JOIN Team
-          JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
+          JOIN LATERAL (VALUES (Dept)) AS d(n) ON 1 = 1
         """
     try named().expect(text, yields: [[20], [20]])
   }
@@ -1680,7 +1680,7 @@ struct EngineNaturalUsingTests {
     // the `.coalesce` correlation source over the outer row's two cells.
     let text = """
         SELECT d.n FROM Emp RIGHT JOIN Team USING (Dept)
-          JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
+          JOIN LATERAL (VALUES (Dept)) AS d(n) ON 1 = 1
         """
     try named().expect(text, yields: [[20], [20], [30]])
   }
@@ -1691,7 +1691,7 @@ struct EngineNaturalUsingTests {
     // reaches its own physical side, correlating as an ordinary outer slot.
     let text = """
         SELECT d.n FROM Emp JOIN Team USING (Dept)
-          JOIN LATERAL (SELECT Emp.Dept AS n) AS d ON 1 = 1
+          JOIN LATERAL (VALUES (Emp.Dept)) AS d(n) ON 1 = 1
         """
     try named().expect(text, yields: [[20], [20]])
   }
@@ -1703,21 +1703,21 @@ struct EngineNaturalUsingTests {
     let text = """
         SELECT d.n FROM Emp JOIN Team USING (Dept)
           JOIN Bonus ON Bonus.Dept = Emp.Dept
-          JOIN LATERAL (SELECT Dept AS n) AS d ON 1 = 1
+          JOIN LATERAL (VALUES (Dept)) AS d(n) ON 1 = 1
         """
     try named().expect(text, fails: .ambiguous("Dept"))
   }
 
   @Test func `a merged column and its constituent correlate independently`()
       throws {
-    // A LATERAL body of `Emp RIGHT JOIN Team USING (Dept)` projects both the
-    // bare merged `Dept` (COALESCE) and the physical `Emp.Dept` constituent. On
-    // the right-only Dept 30 row the merged `Dept` coalesces to 30 while
-    // `Emp.Dept` is NULL — each correlates through its own parameter identity,
-    // so neither read overwrites the other regardless of projection order.
+    // A LATERAL body of `Emp RIGHT JOIN Team USING (Dept)` names in its row
+    // both the bare merged `Dept` (COALESCE) and the physical `Emp.Dept`
+    // constituent. On the right-only Dept 30 row the merged `Dept` coalesces to
+    // 30 while `Emp.Dept` is NULL — each correlates through its own parameter
+    // identity, so neither read overwrites the other regardless of row order.
     let forward = """
         SELECT m, e FROM Emp RIGHT JOIN Team USING (Dept)
-          JOIN LATERAL (SELECT Dept AS m, Emp.Dept AS e) AS d ON 1 = 1
+          JOIN LATERAL (VALUES (Dept, Emp.Dept)) AS d(m, e) ON 1 = 1
           ORDER BY m
         """
     try named().expect(forward, yields: [
@@ -1725,12 +1725,12 @@ struct EngineNaturalUsingTests {
       [20, 20],
       [30, nil],
     ])
-    // The reverse projection order yields the same values — the merged and the
+    // The reverse row order yields the same values — the merged and the
     // constituent correlation keys do not collide, so lowering order is
     // irrelevant.
     let reverse = """
         SELECT m, e FROM Emp RIGHT JOIN Team USING (Dept)
-          JOIN LATERAL (SELECT Emp.Dept AS e, Dept AS m) AS d ON 1 = 1
+          JOIN LATERAL (VALUES (Emp.Dept, Dept)) AS d(e, m) ON 1 = 1
           ORDER BY m
         """
     try named().expect(reverse, yields: [
@@ -1750,7 +1750,7 @@ struct EngineNaturalUsingTests {
     let star = """
         SELECT * FROM (SELECT NULLIF(1, 1) AS k FROM Solo) AS a
           JOIN (SELECT NULLIF(1, 1) AS k FROM Solo) AS b USING (k)
-          UNION SELECT 'x'
+          UNION VALUES ('x')
         """
     let starred = try named()
         .columns(of: Statement(parsing: star), validate: true)
@@ -1760,7 +1760,7 @@ struct EngineNaturalUsingTests {
     let explicit = """
         SELECT k FROM (SELECT NULLIF(1, 1) AS k FROM Solo) AS a
           JOIN (SELECT NULLIF(1, 1) AS k FROM Solo) AS b USING (k)
-          UNION SELECT 'x'
+          UNION VALUES ('x')
         """
     let named = try named()
         .columns(of: Statement(parsing: explicit), validate: true)
@@ -1774,7 +1774,7 @@ struct EngineNaturalUsingTests {
     // integer and the text UNION arm is irreconcilable: 42804 still faults,
     // proving the mask is carried, not hard-coded unconstrained.
     let text = """
-        SELECT * FROM Emp JOIN Team USING (Dept) UNION SELECT 'x', 'y', 'z'
+        SELECT * FROM Emp JOIN Team USING (Dept) UNION VALUES ('x', 'y', 'z')
         """
     try named().expect(text,
         fails: .operand("UNION arms have irreconcilable types"))
@@ -2055,7 +2055,7 @@ struct EngineNaturalUsingTests {
     // now unifies rather than faulting.
     try named().expect("""
         SELECT * FROM Emp JOIN Team USING (Id)
-        UNION ALL SELECT 9, 99, 'z', 88, 'w'
+        UNION ALL VALUES (9, 99, 'z', 88, 'w')
         """,
         yields: [
           [1, 10, "Ann", 20, "Deb"],
@@ -2070,7 +2070,7 @@ struct EngineNaturalUsingTests {
     // arm's five) still faults `.arity`, so deriving width from the enumeration
     // did not disable the check.
     try named().expect("""
-        SELECT * FROM Emp JOIN Team USING (Id) UNION ALL SELECT 1, 2, 3
+        SELECT * FROM Emp JOIN Team USING (Id) UNION ALL VALUES (1, 2, 3)
         """,
         fails: .arity(5, 3))
   }

--- a/Tests/SQLTests/Queries/EngineJoinTests.swift
+++ b/Tests/SQLTests/Queries/EngineJoinTests.swift
@@ -752,7 +752,7 @@ private func outers(_ plan: Plan) -> Bool {
     outers(left) || outers(right)
   case let .aggregate(_, _, source):
     outers(source)
-  case .single, .empty, .scan:
+  case .single, .values, .empty, .scan:
     false
   }
 }

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -274,17 +274,17 @@ struct EngineUnionTests {
   @Test func `an all-NULL view column unifies with a later text arm`() throws {
     // The reviewer's VIEW all-NULL case. The view `v`'s column `x` is a constant
     // NULL in both arms, so its resolved schema marks the column unconstrained:
-    // an enclosing `SELECT x FROM v UNION SELECT 'c'` must unify the view column
-    // with the text `'c'` arm and run — yielding the NULL and the text — rather
-    // than fault integer against text. The view's schema resolution builds its
-    // Schema from the body carrier through `Schema(from:)`, so the `Scope`
-    // reader reports the column unconstrained and the outer fold skips its type,
-    // exactly as it skips a fresh constant-NULL arm.
+    // an enclosing `SELECT x FROM v UNION VALUES ('c')` must unify the view
+    // column with the text `'c'` arm and run — yielding the NULL and the text —
+    // rather than fault integer against text. The view's schema resolution
+    // builds its Schema from the body carrier through `Schema(from:)`, so the
+    // `Scope` reader reports the column unconstrained and the outer fold skips
+    // its type, exactly as it skips a fresh constant-NULL arm.
     let view = try View(query: select("""
-        SELECT NULLIF(1, 1) AS x UNION SELECT NULLIF('b', 'b')
+        VALUES (NULLIF(1, 1)) UNION VALUES (NULLIF('b', 'b'))
         """), columns: ["x"])
     let catalog = EngineMemory(tags().catalog, views: ["V": view])
-    let rows = try catalog.run(parse("SELECT x FROM V UNION SELECT 'c'"))
+    let rows = try catalog.run(parse("SELECT x FROM V UNION VALUES ('c')"))
     #expect(rows == [[.null], [.text("c")]])
   }
 
@@ -787,11 +787,11 @@ struct EngineScalarSelectTests {
     return select
   }
 
-  @Test func `a FROM-less arm of a UNION combines with a FROM arm`() throws {
-    // Both arms project one integer column; the FROM-less arm contributes its
-    // single computed row, deduplicating against the People ages.
+  @Test func `a VALUES arm of a UNION combines with a FROM arm`() throws {
+    // Both arms project one integer column; the VALUES arm contributes its
+    // single row, deduplicating against the People ages.
     let rows = try roster().run(parse("""
-        SELECT 100 UNION ALL SELECT Age FROM People WHERE Id = 1
+        VALUES (100) UNION ALL SELECT Age FROM People WHERE Id = 1
         """))
     #expect(rows == [[.integer(100)], [.integer(30)]])
   }
@@ -856,7 +856,7 @@ struct EngineSetOperationCoercionTests {
 
   @Test func `a nested-arm UNION arity mismatch faults not traps`() throws {
     // The outer widths match (both 2), so the outer check passes; the fold
-    // then descends into the left child `SELECT 1, 2 UNION SELECT 3` whose
+    // then descends into the left child `VALUES (1, 2) UNION VALUES (3)` whose
     // arms differ (2 vs 1) — the fold's own guard faults `.arity` rather than
     // trapping on an out-of-bounds column index.
     try roster().expect("VALUES (1, 2) UNION VALUES (3) UNION VALUES (4, 5)",
@@ -880,7 +880,7 @@ struct EngineSetOperationCoercionTests {
     // The derived table runs through the `.setop` Plan node, whose carried
     // `types` (computed at compile) coerce each arm's rows — the outer
     // `SELECT *` reads the widened `double` column.
-    try roster().expect("SELECT * FROM (SELECT 1 UNION SELECT 2.5) AS d",
+    try roster().expect("SELECT * FROM (VALUES (1) UNION VALUES (2.5)) AS d",
                               yields: [[1.0], [2.5]])
   }
 
@@ -892,7 +892,7 @@ struct EngineSetOperationCoercionTests {
     // explicit output column list). Selecting `d.a` reads the widened, coerced
     // values under the list's name — the two features compose.
     try roster().expect(
-        "SELECT d.a FROM (SELECT 1 UNION SELECT 2.5) AS d(a) ORDER BY d.a",
+        "SELECT d.a FROM (VALUES (1) UNION VALUES (2.5)) AS d(a) ORDER BY d.a",
         yields: [[1.0], [2.5]])
   }
 
@@ -915,7 +915,7 @@ struct EngineSetOperationCoercionTests {
     // its rows).
     let rows = try statement("""
         WITH RECURSIVE t (n) AS (
-          SELECT 1 UNION ALL SELECT n + 0.5 FROM t WHERE n < 3
+          VALUES (1) UNION ALL SELECT n + 0.5 FROM t WHERE n < 3
         ) SELECT n FROM t
         """, roster())
     #expect(rows == [[.double(1.0)], [.double(1.5)], [.double(2.0)],
@@ -955,16 +955,16 @@ struct EngineCorrelatedNullUnificationTests {
   @Test func `a correlated all-NULL column unifies through a LATERAL set-op arm`()
       throws {
     // The reviewer's case. `t`'s column `x` is a constant NULL in both arms, so
-    // it is unconstrained. The lateral body `SELECT x UNION SELECT 'c'`
+    // it is unconstrained. The lateral body `VALUES (x) UNION VALUES ('c')`
     // references the correlated `x`, whose mask must survive the correlation
     // surface so the arm is unconstrained and unifies with the text `'c'` — the
     // body yields the NULL row and the `'c'` row. Before the read-side
     // unification the mask was read local-only, so the correlated `x` folded as
     // a concrete integer and the arm faulted int-vs-text.
     let rows = try statement("""
-        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
+        WITH t (x) AS (VALUES (NULLIF(1, 1)) UNION VALUES (NULLIF('a', 'a')))
           SELECT y FROM t
-          JOIN LATERAL (SELECT x UNION SELECT 'c') AS d (y) ON 1 = 1
+          JOIN LATERAL (VALUES (x) UNION VALUES ('c')) AS d (y) ON 1 = 1
         """, family())
     #expect(rows == [[.null], [.text("c")]])
   }
@@ -977,11 +977,11 @@ struct EngineCorrelatedNullUnificationTests {
     // unconstrained mask up from that grandparent scope, so the innermost arm
     // still unifies the NULL with the text `'c'`.
     let rows = try statement("""
-        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
+        WITH t (x) AS (VALUES (NULLIF(1, 1)) UNION VALUES (NULLIF('a', 'a')))
           SELECT z FROM t
           JOIN LATERAL (
-            SELECT y FROM (SELECT 1 AS one) AS u
-            JOIN LATERAL (SELECT x UNION SELECT 'c') AS d (y) ON 1 = 1
+            SELECT y FROM (VALUES (1)) AS u(one)
+            JOIN LATERAL (VALUES (x) UNION VALUES ('c')) AS d (y) ON 1 = 1
           ) AS e (z) ON 1 = 1
         """, family())
     #expect(rows == [[.null], [.text("c")]])
@@ -990,16 +990,16 @@ struct EngineCorrelatedNullUnificationTests {
   @Test func `a genuinely-typed correlated column in a LATERAL arm stays concrete`()
       throws {
     // The over-marking guard: `t`'s column `x` is a concrete integer (a plain
-    // `SELECT 1`), so the correlated reference must NOT be marked
-    // unconstrained — the lateral arm `SELECT x UNION SELECT 'c'` then folds a
-    // genuine integer against text and faults `.operand` (SQLSTATE 42804),
-    // exactly as an irreconcilable local pair does. This proves the mask is
-    // not spuriously set for every correlated column.
+    // `VALUES (1)`), so the correlated reference must NOT be marked
+    // unconstrained — the lateral arm `VALUES (x) UNION VALUES ('c')` then
+    // folds a genuine integer against text and faults `.operand` (SQLSTATE
+    // 42804), exactly as an irreconcilable local pair does. This proves the
+    // mask is not spuriously set for every correlated column.
     #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
       _ = try statement("""
-          WITH t (x) AS (SELECT 1)
+          WITH t (x) AS (VALUES (1))
             SELECT y FROM t
-            JOIN LATERAL (SELECT x UNION SELECT 'c') AS d (y) ON 1 = 1
+            JOIN LATERAL (VALUES (x) UNION VALUES ('c')) AS d (y) ON 1 = 1
           """, family())
     }
   }
@@ -1009,8 +1009,8 @@ struct EngineCorrelatedNullUnificationTests {
     // local path, whose resolved lookup carries the same mask, so a bare
     // reference in a set-op arm unifies with the text arm and runs.
     let rows = try statement("""
-        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
-          SELECT x FROM t UNION SELECT 'c'
+        WITH t (x) AS (VALUES (NULLIF(1, 1)) UNION VALUES (NULLIF('a', 'a')))
+          SELECT x FROM t UNION VALUES ('c')
         """, family())
     #expect(rows == [[.null], [.text("c")]])
   }
@@ -1032,7 +1032,7 @@ struct EngineCorrelatedNullUnificationTests {
     let people = try roster()
     #expect(throws: SQLError.state("0A000",
         "a correlated column is only supported in a subquery's WHERE")) {
-      _ = try people.run(parse("SELECT (SELECT P.Age) FROM People AS P"))
+      _ = try people.run(parse("SELECT (VALUES (P.Age)) FROM People AS P"))
     }
   }
 }
@@ -1050,8 +1050,8 @@ struct EngineCorrelatedNullUnificationTests {
 /// fault `.operand` (SQLSTATE 42804), so the seal marks exactly the
 /// constant-NULL columns and no others. The scalar-subquery pair is the fix for
 /// the last leaking channel: the output memo once stored a bare `ValueType`, so
-/// a scalar wrapper dropped the mask — `SELECT (SELECT NULLIF('a','a')) UNION
-/// SELECT 1` was wrongly rejected while the unwrapped form ran.
+/// a scalar wrapper dropped the mask — `VALUES ((VALUES (NULLIF('a','a'))))
+/// UNION VALUES (1)` was wrongly rejected while the unwrapped form ran.
 struct EngineUnconstrainedMaskSealTests {
   @Test func `a bare all-NULL arm unifies with a typed arm; a typed one faults`()
       throws {
@@ -1067,16 +1067,16 @@ struct EngineUnconstrainedMaskSealTests {
 
   @Test func `a scalar-subquery all-NULL wrapper unifies; a typed one faults`()
       throws {
-    // the fix. The scalar subquery `(SELECT NULLIF('a','a'))` collapses to a
+    // the fix. The scalar subquery `(VALUES (NULLIF('a','a')))` collapses to a
     // constant NULL, so its resolved output column is unconstrained — the memo
     // now carries that mask into the outer fold, which unifies the wrapper with
     // the integer arm and runs (NULL row + `1` row). A genuinely-typed wrapper
-    // `(SELECT 'a')` stays concrete text and faults int-vs-text.
+    // `(VALUES ('a'))` stays concrete text and faults int-vs-text.
     try roster().expect(
-        "SELECT (SELECT NULLIF('a', 'a')) UNION SELECT 1",
+        "VALUES ((VALUES (NULLIF('a', 'a')))) UNION VALUES (1)",
         yields: [[nil], [1]])
     try roster().expect(
-        "SELECT (SELECT 'a') UNION SELECT 1",
+        "VALUES ((VALUES ('a'))) UNION VALUES (1)",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -1085,14 +1085,14 @@ struct EngineUnconstrainedMaskSealTests {
     // The scalar subquery's own body is a set operation both of whose arms fold
     // to constant NULL, so the inner unification leaves the column
     // unconstrained — the memo carries that mask out, and the outer fold unifies
-    // the wrapper with the text `'c'` arm. A typed inner UNION (`SELECT 1 UNION
-    // SELECT 2`) stays a concrete integer and faults int-vs-text.
+    // the wrapper with the text `'c'` arm. A typed inner UNION (`VALUES (1)
+    // UNION VALUES (2)`) stays a concrete integer and faults int-vs-text.
     try roster().expect("""
-        SELECT (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a'))
-          UNION SELECT 'c'
+        VALUES ((VALUES (NULLIF(1, 1)) UNION VALUES (NULLIF('a', 'a'))))
+          UNION VALUES ('c')
         """, yields: [[nil], ["c"]])
     try roster().expect(
-        "SELECT (SELECT 1 UNION SELECT 2) UNION SELECT 'c'",
+        "VALUES ((VALUES (1) UNION VALUES (2))) UNION VALUES ('c')",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -1101,12 +1101,12 @@ struct EngineUnconstrainedMaskSealTests {
     // The derived-table channel: the derived body's column `x` folds to constant
     // NULL, so its resolved schema marks it unconstrained; a bare reference in
     // the outer set-op arm unifies with the integer `1`. A typed derived column
-    // (`SELECT 'a' AS x`) stays concrete text and faults int-vs-text.
+    // (`VALUES ('a')`) stays concrete text and faults int-vs-text.
     try roster().expect("""
-        SELECT x FROM (SELECT NULLIF('a', 'a') AS x) AS d UNION SELECT 1
+        SELECT x FROM (VALUES (NULLIF('a', 'a'))) AS d(x) UNION VALUES (1)
         """, yields: [[nil], [1]])
     try roster().expect(
-        "SELECT x FROM (SELECT 'a' AS x) AS d UNION SELECT 1",
+        "SELECT x FROM (VALUES ('a')) AS d(x) UNION VALUES (1)",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 }
@@ -1127,7 +1127,7 @@ struct EngineUnconstrainedMaskSealTests {
 /// still raises `SQLError.function` when the arm is reached, so a
 /// genuinely-missing routine is never hidden — only the fold defers. A CTE's
 /// declared-name carrier is likewise a placeholder, so a genuine body
-/// incompatibility (`SELECT 'b' UNION SELECT 1`) propagates `.operand`
+/// incompatibility (`VALUES ('b') UNION VALUES (1)`) propagates `.operand`
 /// identically at run and at `columns(of:validate:true)`, rather than being
 /// swallowed into a phantom `.integer`. A registered-only expression carries a
 /// genuine type and still constrains, and a literal mismatch still faults, so
@@ -1158,7 +1158,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // only the reached `'x'` row.
     try roster().expect("""
         (SELECT NOPE(Name) FROM People FETCH FIRST 0 ROWS ONLY)
-          UNION SELECT 'x'
+          UNION VALUES ('x')
         """, yields: [["x"]])
   }
 
@@ -1171,7 +1171,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // `.operand` on the fabricated `.integer`. The union yields only `'x'`.
     try roster().expect("""
         (SELECT NOPE(Name) + 0 FROM People FETCH FIRST 0 ROWS ONLY)
-          UNION SELECT 'x'
+          UNION VALUES ('x')
         """, yields: [["x"]])
   }
 
@@ -1183,7 +1183,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // `.operand`. Deferring the fold does not hide the missing routine even
     // when it is nested.
     try roster().expect("""
-        SELECT NOPE(Name) + 0 FROM People UNION SELECT 'x'
+        SELECT NOPE(Name) + 0 FROM People UNION VALUES ('x')
         """, fails: .function("nope"))
   }
 
@@ -1216,7 +1216,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // reachable-branch mirror of `derive`) marks it unconstrained. The arm is
     // reached, so the run dispatches `missing()` and faults `.function`.
     try roster().expect("""
-        SELECT CASE WHEN 1 = 1 THEN missing() END UNION SELECT 'x'
+        VALUES (CASE WHEN 1 = 1 THEN missing() END) UNION VALUES ('x')
         """, fails: .function("missing"))
   }
 
@@ -1240,7 +1240,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // call, so the union folds and yields only the reached text `'x'`.
     try roster().expect("""
         (SELECT COALESCE(missing(), 1) FROM People FETCH FIRST 0 ROWS ONLY)
-          UNION SELECT 'x'
+          UNION VALUES ('x')
         """, yields: [["x"]])
   }
 
@@ -1270,14 +1270,14 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 
   @Test func `a scalar subquery with an unregistered call defers via the memo`()
       throws {
-    // Subquery composition: `(SELECT NOPE())` resolves its own single column
+    // Subquery composition: `(VALUES (NOPE()))` resolves its own single column
     // through the subquery memo (`scalar(resolved:)`), which already carries
     // the unconstrained mask for the unregistered call inside — so `unresolved`
     // returns false for the outer `.subquery` and does NOT double-handle it.
-    // The outer fold defers to the text `'x'`; the FROM-less subquery arm is
+    // The outer fold defers to the text `'x'`; the VALUES subquery arm is
     // reached, so the run dispatches `NOPE` (folded to `nope`) and faults
     // `.function`.
-    try roster().expect("SELECT (SELECT NOPE()) UNION SELECT 'x'",
+    try roster().expect("VALUES ((VALUES (NOPE()))) UNION VALUES ('x')",
                               fails: .function("nope"))
   }
 
@@ -1289,7 +1289,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     let routines: Routines = [
       "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
     ]
-    try roster().expect("SELECT tag(Name) FROM People UNION SELECT 1",
+    try roster().expect("SELECT tag(Name) FROM People UNION VALUES (1)",
                               fails: .operand(
                                   "UNION arms have irreconcilable types"),
                               routines: routines)
@@ -1301,7 +1301,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     let routines: Routines =
         ["tag": Routine(returns: .text, parameters: [.text]) { row in row[0] }]
     try roster().expect("""
-        SELECT tag(Name) FROM People WHERE Id = 1 UNION SELECT 'x'
+        SELECT tag(Name) FROM People WHERE Id = 1 UNION VALUES ('x')
         """, yields: [["Alice"], ["x"]], routines: routines)
   }
 
@@ -1314,13 +1314,13 @@ struct EnginePlaceholderUnconstrainedClosureTests {
   }
 
   @Test func `a genuine CTE body incompatibility faults at run`() throws {
-    // The CTE-validate case at run: the body `SELECT 'b' UNION SELECT 1` folds
-    // two genuine types (text vs integer) — irreconcilable — so the run faults
-    // `.operand` rather than swallowing it into the declared `.integer`
+    // The CTE-validate case at run: the body `VALUES ('b') UNION VALUES (1)`
+    // folds two genuine types (text vs integer) — irreconcilable — so the run
+    // faults `.operand` rather than swallowing it into the declared `.integer`
     // placeholder.
     #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
       _ = try statement(
-          "WITH a(x) AS (SELECT 'b' UNION SELECT 1) SELECT x FROM a",
+          "WITH a(x) AS (VALUES ('b') UNION VALUES (1)) SELECT x FROM a",
           family())
     }
   }
@@ -1331,7 +1331,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // throw `.operand` — no divergence, no phantom integer column advertised
     // for a query that cannot run.
     let statement = try Statement(parsing:
-        "WITH a(x) AS (SELECT 'b' UNION SELECT 1) SELECT x FROM a")
+        "WITH a(x) AS (VALUES ('b') UNION VALUES (1)) SELECT x FROM a")
     #expect(throws: SQLError.operand("UNION arms have irreconcilable types")) {
       _ = try family().columns(of: statement, validate: true)
     }
@@ -1346,21 +1346,23 @@ struct EnginePlaceholderUnconstrainedClosureTests {
 /// walk that decides which subqueries actually run, so it must NOT fault
 /// `SQLError.operand` (SQLSTATE 42804) on an incompatible set-operation
 /// subquery a short-circuited `AND`/`OR` leg never reaches — a `… WHERE 1 = 0
-/// AND EXISTS (SELECT 'x' UNION SELECT 1)` runs and yields no rows. Deferral
-/// alone would hide a genuine incompatibility in a subquery that does run, so
-/// a reached scalar or `IN`/quantified occurrence is re-folded strictly on the
-/// reached path and faults exactly as before; an `EXISTS`/`LATERAL` reach does
-/// not constrain column type and never faults on it. The top-level and CTE
-/// folds are outside the pre-pass (`shape` is `false`), so they keep faulting.
+/// AND EXISTS (VALUES ('x') UNION VALUES (1))` runs and yields no rows.
+/// Deferral alone would hide a genuine incompatibility in a subquery that runs,
+/// so a reached scalar or `IN`/quantified occurrence is re-folded strictly on
+/// the reached path and faults exactly as before; an `EXISTS`/`LATERAL` reach
+/// does not constrain column type and never faults on it. The top-level and
+/// CTE folds are outside the pre-pass (`shape` is `false`), so they keep
+/// faulting.
 struct EngineDeferredSetopShapeTests {
   @Test func `a dead-branch EXISTS over an incompatible UNION runs to no rows`()
       throws {
     // The reviewer oracle: the `EXISTS` is short-circuited by `1 = 0 AND …`, so
-    // the incompatible `SELECT 'x' UNION SELECT 1` is never reached — the shape
-    // pre-pass defers its operand fold rather than faulting 42804, and the
-    // query runs to no rows.
+    // the incompatible `VALUES ('x') UNION VALUES (1)` is never reached — the
+    // shape pre-pass defers its operand fold rather than faulting 42804, and
+    // the query runs to no rows.
     try roster().empty("""
-        SELECT 1 FROM People WHERE 1 = 0 AND EXISTS (SELECT 'x' UNION SELECT 1)
+        SELECT 1 FROM People
+          WHERE 1 = 0 AND EXISTS (VALUES ('x') UNION VALUES (1))
         """)
   }
 
@@ -1370,7 +1372,7 @@ struct EngineDeferredSetopShapeTests {
     // on the incompatible pair (role `.existential`, skipped by the re-fold).
     // People has rows, so the EXISTS is present and every row projects `1`.
     try roster().expect("""
-        SELECT 1 FROM People WHERE EXISTS (SELECT 'x' UNION SELECT 1)
+        SELECT 1 FROM People WHERE EXISTS (VALUES ('x') UNION VALUES (1))
         """, yields: Array(repeating: [1], count: 5))
   }
 
@@ -1379,7 +1381,8 @@ struct EngineDeferredSetopShapeTests {
     // The `IN` is unreachable behind `1 = 0 AND …`, so its incompatible UNION
     // defers in the shape pre-pass and the query runs to no rows.
     try roster().empty("""
-        SELECT 1 FROM People WHERE 1 = 0 AND Age IN (SELECT 'a' UNION SELECT 1)
+        SELECT 1 FROM People
+          WHERE 1 = 0 AND Age IN (VALUES ('a') UNION VALUES (1))
         """)
   }
 
@@ -1388,7 +1391,7 @@ struct EngineDeferredSetopShapeTests {
     // re-fold on the reached path restores the strict operand check and the
     // incompatible UNION faults 42804 — the deferral does not hide it.
     try roster().expect("""
-        SELECT 1 FROM People WHERE Age IN (SELECT 'a' UNION SELECT 1)
+        SELECT 1 FROM People WHERE Age IN (VALUES ('a') UNION VALUES (1))
         """, fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -1397,7 +1400,7 @@ struct EngineDeferredSetopShapeTests {
     // the reached re-fold checks its arms strictly and the incompatible UNION
     // faults 42804 in the comparison.
     try roster().expect("""
-        SELECT 1 FROM People WHERE Age = (SELECT 'a' UNION SELECT 1)
+        SELECT 1 FROM People WHERE Age = (VALUES ('a') UNION VALUES (1))
         """, fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -1407,7 +1410,7 @@ struct EngineDeferredSetopShapeTests {
     // operand fold defers in the pre-pass and the query runs to no rows.
     try roster().empty("""
         SELECT 1 FROM People
-          WHERE 1 = 0 AND Age = (SELECT 'a' UNION SELECT 1)
+          WHERE 1 = 0 AND Age = (VALUES ('a') UNION VALUES (1))
         """)
   }
 
@@ -1425,7 +1428,7 @@ struct EngineDeferredSetopShapeTests {
     // deferral changes nothing for a query that folds cleanly. A `WITH` is a
     // statement, so it runs through the statement overload.
     let rows = try statement(
-        "WITH a(x) AS (SELECT 'b') SELECT x FROM a UNION SELECT 'c'",
+        "WITH a(x) AS (VALUES ('b')) SELECT x FROM a UNION VALUES ('c')",
         roster())
     #expect(rows == [[.text("b")], [.text("c")]])
   }
@@ -1455,8 +1458,8 @@ struct EngineReachedCorrelatedSetopTests {
     // longer coerces to the placeholder type and silently passes.
     try roster().expect("""
         SELECT Id FROM People WHERE 1 IN ( \
-        SELECT 'x' FROM (SELECT 1 AS k) AS d WHERE d.k = People.Id \
-        UNION SELECT 1)
+        SELECT 'x' FROM (VALUES (1)) AS d(k) WHERE d.k = People.Id \
+        UNION VALUES (1))
         """, fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -1467,8 +1470,8 @@ struct EngineReachedCorrelatedSetopTests {
     // to no rows.
     try roster().empty("""
         SELECT Id FROM People WHERE 1 = 0 AND 1 IN ( \
-        SELECT 'x' FROM (SELECT 1 AS k) AS d WHERE d.k = People.Id \
-        UNION SELECT 1)
+        SELECT 'x' FROM (VALUES (1)) AS d(k) WHERE d.k = People.Id \
+        UNION VALUES (1))
         """)
   }
 
@@ -1480,8 +1483,8 @@ struct EngineReachedCorrelatedSetopTests {
     // the EXISTS is present for every outer row and each projects its `Id`.
     try roster().expect("""
         SELECT Id FROM People WHERE EXISTS ( \
-        SELECT 'x' FROM (SELECT 1 AS k) AS d WHERE d.k = People.Id \
-        UNION SELECT 1)
+        SELECT 'x' FROM (VALUES (1)) AS d(k) WHERE d.k = People.Id \
+        UNION VALUES (1))
         """, yields: [[1], [2], [3], [4], [5]])
   }
 
@@ -1495,21 +1498,22 @@ struct EngineReachedCorrelatedSetopTests {
       "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
     ]
     try roster().expect("""
-        (SELECT tag() FROM People FETCH FIRST 0 ROWS ONLY) UNION SELECT 1
+        (SELECT tag() FROM People FETCH FIRST 0 ROWS ONLY) UNION VALUES (1)
         """, yields: [[1]], routines: routines)
   }
 
   @Test func `an invalid reachable call faults on its bad arity, not 42804`()
       throws {
-    // The counterpart on a validating path: `SELECT tag() UNION SELECT 1` calls
-    // `tag(text)` with no argument. The invalid call does not constrain the
-    // fold (so no spurious 42804), but the strict `validate: true` schema path
-    // catches the bad arity and faults `.argument` — NOT the operand fold. (The
-    // lenient run path does not validate arity, so it does not fault there.)
+    // The counterpart on a validating path: `VALUES (tag()) UNION VALUES (1)`
+    // calls `tag(text)` with no argument. The invalid call does not constrain
+    // the fold (so no spurious 42804), but the strict `validate: true` schema
+    // path catches the bad arity and faults `.argument` — NOT the operand fold.
+    // (The lenient run path does not validate arity, so it does not fault
+    // there.)
     let routines: Routines = [
       "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
     ]
-    let statement = try Statement(parsing: "SELECT tag() UNION SELECT 1")
+    let statement = try Statement(parsing: "VALUES (tag()) UNION VALUES (1)")
     #expect(throws: SQLError.argument("tag takes 1 arguments")) {
       _ = try roster().columns(of: statement, routines: routines,
                                      validate: true)
@@ -1526,7 +1530,7 @@ struct EngineReachedCorrelatedSetopTests {
       "tag": Routine(returns: .text, parameters: [.text]) { _ in .text("t") }
     ]
     try roster().expect("""
-        SELECT tag('a') FROM People UNION SELECT 1
+        SELECT tag('a') FROM People UNION VALUES (1)
         """, fails: .operand("UNION arms have irreconcilable types"),
         routines: routines)
   }

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -824,33 +824,33 @@ struct EngineSetOperationCoercionTests {
   @Test func `UNION widens a mixed integer/double column and coerces its values`() throws {
     // The unified column type is `double`, so the `integer` arm's `1` coerces
     // to `1.0` and the result column is `double` throughout.
-    try roster().expect("SELECT 1 UNION SELECT 2.5",
+    try roster().expect("VALUES (1) UNION VALUES (2.5)",
                               yields: [[1.0], [2.5]])
-    try roster().expect("SELECT 1 UNION ALL SELECT 2.5",
+    try roster().expect("VALUES (1) UNION ALL VALUES (2.5)",
                               yields: [[1.0], [2.5]])
   }
 
   @Test func `UNION dedups numerically-equal rows to the coerced double`() throws {
     // `1` coerces to `1.0`, equal to the double arm's `1.0`, so the bare UNION
     // keeps one — the emitted `double`.
-    try roster().expect("SELECT 1 UNION SELECT 1.0", yields: [[1.0]])
+    try roster().expect("VALUES (1) UNION VALUES (1.0)", yields: [[1.0]])
   }
 
   @Test func `INTERSECT and EXCEPT emit the coerced double`() throws {
     // Equality already canonicalises `1` and `1.0`, so both match/subtract; the
     // coercion makes the emitted cell carry the unified `double` type.
-    try roster().expect("SELECT 1 INTERSECT SELECT 1.0", yields: [[1.0]])
-    try roster().expect("SELECT 2 EXCEPT SELECT 1.0", yields: [[2.0]])
+    try roster().expect("VALUES (1) INTERSECT VALUES (1.0)", yields: [[1.0]])
+    try roster().expect("VALUES (2) EXCEPT VALUES (1.0)", yields: [[2.0]])
   }
 
   @Test func `a UNION of irreconcilable column types faults`() throws {
     // A text arm beside a number, or a boolean beside a number, has no common
     // type — the fold faults `SQLError.operand` (SQLSTATE 42804).
     try roster().expect(
-        "SELECT 1 UNION SELECT 'x'",
+        "VALUES (1) UNION VALUES ('x')",
         fails: .operand("UNION arms have irreconcilable types"))
     try roster().expect(
-        "SELECT TRUE UNION SELECT 1",
+        "VALUES (TRUE) UNION VALUES (1)",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -859,20 +859,20 @@ struct EngineSetOperationCoercionTests {
     // then descends into the left child `SELECT 1, 2 UNION SELECT 3` whose
     // arms differ (2 vs 1) — the fold's own guard faults `.arity` rather than
     // trapping on an out-of-bounds column index.
-    try roster().expect("SELECT 1, 2 UNION SELECT 3 UNION SELECT 4, 5",
+    try roster().expect("VALUES (1, 2) UNION VALUES (3) UNION VALUES (4, 5)",
                               fails: .arity(2, 1))
   }
 
   @Test func `a chained 3-arm UNION widens across every arm`() throws {
     // The left-associative chain folds pairwise, so the trailing `double`
     // widens the whole column and every value coerces.
-    try roster().expect("SELECT 1 UNION SELECT 2 UNION SELECT 3.5",
+    try roster().expect("VALUES (1) UNION VALUES (2) UNION VALUES (3.5)",
                               yields: [[1.0], [2.0], [3.5]])
   }
 
   @Test func `a chained UNION with an incompatible tail faults`() throws {
     try roster().expect(
-        "SELECT 1 UNION SELECT 2 UNION SELECT 'x'",
+        "VALUES (1) UNION VALUES (2) UNION VALUES ('x')",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -900,11 +900,11 @@ struct EngineSetOperationCoercionTests {
     // A `NULLIF(2, 2)` arm folds to constant NULL, so it constrains nothing (a
     // NULL unifies with any typed arm): the other arm's `double` types the
     // column, its NULL row stays NULL and the double row coerces.
-    try roster().expect("SELECT NULLIF(2, 2) UNION SELECT 2.5",
+    try roster().expect("VALUES (NULLIF(2, 2)) UNION VALUES (2.5)",
                               yields: [[nil], [2.5]])
     // A typed integer arm beside a constant-NULL arm keeps the `integer`
     // column.
-    try roster().expect("SELECT 1 UNION SELECT NULLIF(2, 2)",
+    try roster().expect("VALUES (1) UNION VALUES (NULLIF(2, 2))",
                               yields: [[1], [nil]])
   }
 
@@ -1058,10 +1058,10 @@ struct EngineUnconstrainedMaskSealTests {
     // The baseline channel — a bare projected expression folding to constant
     // NULL is unconstrained, so it unifies; a typed literal constrains and
     // faults int-vs-text.
-    try roster().expect("SELECT NULLIF('a', 'a') UNION SELECT 1",
+    try roster().expect("VALUES (NULLIF('a', 'a')) UNION VALUES (1)",
                               yields: [[nil], [1]])
     try roster().expect(
-        "SELECT 'a' UNION SELECT 1",
+        "VALUES ('a') UNION VALUES (1)",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -1138,7 +1138,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // The unregistered `missing()` is reached (a FROM-less single-row arm), so
     // the reachable typecheck raises `SQLError.function` — NOT `.operand`. The
     // fold deferring on the placeholder does not hide the missing routine.
-    try roster().expect("SELECT missing() UNION SELECT 'x'",
+    try roster().expect("VALUES (missing()) UNION VALUES ('x')",
                               fails: .function("missing"))
   }
 
@@ -1146,7 +1146,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
       throws {
     // The right-side variant: the fold defers on the placeholder either way,
     // and the reachable typecheck raises `.function` when the arm is reached.
-    try roster().expect("SELECT 1 UNION SELECT missing()",
+    try roster().expect("VALUES (1) UNION VALUES (missing())",
                               fails: .function("missing"))
   }
 
@@ -1193,7 +1193,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // and the fold defers to the text `'x'` rather than faulting `.operand`. A
     // FROM-less single-row arm is reached, so `missing()` dispatches — hence
     // the run faults `.function`, proving the deferral touches only the fold.
-    try roster().expect("SELECT COALESCE(missing(), 1) UNION SELECT 'x'",
+    try roster().expect("VALUES (COALESCE(missing(), 1)) UNION VALUES ('x')",
                               fails: .function("missing"))
   }
 
@@ -1205,7 +1205,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // genuinely irreconcilable and must fault `.operand`, not defer and leave
     // the integer `1` cell uncoerced against text.
     try roster().expect(
-        "SELECT COALESCE(1, missing()) UNION ALL SELECT 'x'",
+        "VALUES (COALESCE(1, missing())) UNION ALL VALUES ('x')",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -1229,7 +1229,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // inner `missing()` and faults `.function`.
     let routines: Routines =
         ["up": Routine(returns: .text, parameters: [.text]) { row in row[0] }]
-    try roster().expect("SELECT up(missing()) UNION SELECT 'x'",
+    try roster().expect("VALUES (up(missing())) UNION VALUES ('x')",
                               fails: .function("missing"), routines: routines)
   }
 
@@ -1253,7 +1253,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // ONLY unregistered calls, never a genuine mismatch.
     let routines: Routines =
         ["one": Routine(returns: .integer, parameters: []) { _ in .integer(1) }]
-    try roster().expect("SELECT one() + 0 UNION SELECT 'x'",
+    try roster().expect("VALUES (one() + 0) UNION VALUES ('x')",
                               fails: .operand(
                                   "UNION arms have irreconcilable types"),
                               routines: routines)
@@ -1264,7 +1264,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // call at all, so it stays constrained and faults `.operand` against the
     // text `'x'` — the recursion adds no over-suppression to a call-free tree.
     try roster().expect(
-        "SELECT 1 + 0 UNION SELECT 'x'",
+        "VALUES (1 + 0) UNION VALUES ('x')",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -1309,7 +1309,7 @@ struct EnginePlaceholderUnconstrainedClosureTests {
     // The baseline over-suppression guard: two genuine literal types still fold
     // to an irreconcilable pair and fault — the closure widens nothing.
     try roster().expect(
-        "SELECT 1 UNION SELECT 'x'",
+        "VALUES (1) UNION VALUES ('x')",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 
@@ -1415,7 +1415,7 @@ struct EngineDeferredSetopShapeTests {
     // The top level is not a shape pre-pass (`shape` is `false`), so its
     // operand fold still faults — the deferral is scoped to nested subqueries.
     try roster().expect(
-        "SELECT 'x' UNION SELECT 1",
+        "VALUES ('x') UNION VALUES (1)",
         fails: .operand("UNION arms have irreconcilable types"))
   }
 

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -721,7 +721,7 @@ struct EngineScalarSelectTests {
                         fails: .operand("operands must be numeric"))
   }
 
-  @Test func `a NULL-yielding FROM-less expression projects NULL`() throws {
+  @Test func `a NULL-yielding VALUES expression projects NULL`() throws {
     // The bare literal NULL is not in the grammar, but a NULL arises from a
     // function returning it; `nothing` yields NULL for the single row.
     let routines: Routines =
@@ -730,61 +730,8 @@ struct EngineScalarSelectTests {
     #expect(rows == [[.null]])
   }
 
-  @Test func `a FROM-less SELECT * is rejected — no relation to expand`() throws {
-    #expect(throws: SQLError.unsupported("SELECT * requires a FROM clause")) {
-      try answer("SELECT *")
-    }
-  }
-
-  @Test func `a FROM-less bare column is rejected — no column to bind`() throws {
+  @Test func `a VALUES bare column is rejected — no column to bind`() throws {
     try roster().expect("VALUES (Name)", fails: .column("Name"))
-  }
-
-  @Test func `a directly-built FROM-less select with clauses is rejected`() throws {
-    // The parser never builds a FROM-less select carrying a WHERE, GROUP BY,
-    // HAVING, or JOIN, but a direct `Select(from: nil, …)` can. The engine
-    // rejects it rather than silently drop the clause — a false predicate or
-    // HAVING would otherwise still return the scalar row. (ORDER BY and
-    // OFFSET/FETCH do apply to the single row and are covered by the VALUES
-    // FROM-less tail tests.)
-    let fault =
-        SQLError.unsupported(
-            "a WHERE, GROUP BY, HAVING, or JOIN requires a FROM clause")
-    let filtered = try EngineScalarSelectTests.select(
-        "SELECT 1 FROM People WHERE Id = 99")
-    #expect(throws: fault) {
-      try roster().run(.select(Select(projection: filtered.projection,
-                                    from: nil,
-                                    predicate: filtered.predicate)))
-    }
-    let grouped = try EngineScalarSelectTests.select(
-        "SELECT Id FROM People GROUP BY Id")
-    #expect(throws: fault) {
-      try roster().run(.select(Select(projection: grouped.projection, from: nil,
-                                    grouping: grouped.grouping)))
-    }
-    let filteredGroup = try EngineScalarSelectTests.select(
-        "SELECT Id FROM People GROUP BY Id HAVING COUNT(*) > 0")
-    #expect(throws: fault) {
-      try roster().run(.select(Select(projection: filteredGroup.projection,
-                                    from: nil,
-                                    having: filteredGroup.having)))
-    }
-    let joined = try EngineScalarSelectTests.select(
-        "SELECT Id FROM People JOIN Pets ON Pets.Owner = People.Id")
-    #expect(throws: fault) {
-      try roster().run(.select(Select(projection: joined.projection, from: nil,
-                                    joins: joined.joins)))
-    }
-  }
-
-  /// The `Select` of a parsed single-`SELECT` query — for building the FROM-less
-  /// shapes the parser will not, by re-homing a clause onto a `from: nil` select.
-  private static func select(_ text: String) throws -> Select {
-    guard case let .select(select) = try parse(text).body else {
-      throw SQLError.incomplete(expected: "a SELECT")
-    }
-    return select
   }
 
   @Test func `a VALUES arm of a UNION combines with a FROM arm`() throws {
@@ -797,8 +744,7 @@ struct EngineScalarSelectTests {
   }
 
   @Test func `an existing SELECT … FROM … query is unaffected`() throws {
-    // The FROM-optional grammar leaves a normal query parsing and running
-    // exactly as before.
+    // A normal FROM'd query parses and runs exactly as before.
     try roster().expect("SELECT Name FROM People WHERE Id = 1",
                         yields: [["Alice"]])
   }

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -674,50 +674,50 @@ struct EngineScalarSelectTests {
   @Test func `a FROM-less literal yields exactly one row`() throws {
     // No relation, so the projection runs against a single empty row; the
     // catalog is never consulted for a table.
-    try roster().expect("SELECT 42", yields: [[42]])
+    try roster().expect("VALUES (42)", yields: [[42]])
   }
 
   @Test func `a FROM-less arithmetic computes a scalar`() throws {
-    try roster().expect("SELECT 1 + 1", yields: [[2]])
+    try roster().expect("VALUES (1 + 1)", yields: [[2]])
   }
 
   @Test func `FROM-less arithmetic honours precedence`() throws {
-    try roster().expect("SELECT 2 + 3 * 4", yields: [[14]])
+    try roster().expect("VALUES (2 + 3 * 4)", yields: [[14]])
   }
 
   @Test func `a FROM-less multi-column projection yields one row of each value`() throws {
-    try roster().expect("SELECT 1, 2, 3", yields: [[1, 2, 3]])
+    try roster().expect("VALUES (1, 2, 3)", yields: [[1, 2, 3]])
   }
 
   @Test func `a FROM-less projection mixes text and integer expressions`() throws {
-    try roster().expect("SELECT 'x', 10 / 2", yields: [["x", 5]])
+    try roster().expect("VALUES ('x', 10 / 2)", yields: [["x", 5]])
   }
 
   @Test func `a FROM-less scalar call evaluates against the single row`() throws {
-    let rows = try functions("SELECT add(40, 2)")
+    let rows = try functions("VALUES (add(40, 2))")
     #expect(rows == [[.integer(42)]])
   }
 
   @Test func `a boolean literal lowers to its truth value`() throws {
-    try roster().expect("SELECT TRUE, FALSE", yields: [[true, false]])
+    try roster().expect("VALUES (TRUE, FALSE)", yields: [[true, false]])
   }
 
   @Test func `a hex blob literal lowers to its bytes`() throws {
     // The `x'53514c'` literal lexes, parses, and lowers to the three-byte
     // blob `SQL`, projected as a `Value.blob`.
-    try roster().expect("SELECT x'53514c'",
+    try roster().expect("VALUES (x'53514c')",
                         yields: [[[0x53, 0x51, 0x4c] as Array<UInt8>]])
   }
 
   @Test func `a boolean operand faults as a non-numeric type error`() throws {
     // Neither boolean nor blob is numeric, so arithmetic over either faults
     // exactly as text does — the type-checker rejects any non-numeric operand.
-    try roster().expect("SELECT TRUE + 1",
+    try roster().expect("VALUES (TRUE + 1)",
                         fails: .operand("operands must be numeric"))
   }
 
   @Test func `a blob operand faults as a non-numeric type error`() throws {
-    try roster().expect("SELECT x'00' + 1",
+    try roster().expect("VALUES (x'00' + 1)",
                         fails: .operand("operands must be numeric"))
   }
 
@@ -726,7 +726,7 @@ struct EngineScalarSelectTests {
     // function returning it; `nothing` yields NULL for the single row.
     let routines: Routines =
         ["nothing": Routine(parameters: []) { _ in .null }]
-    let rows = try roster().run(parse("SELECT nothing()"), routines)
+    let rows = try roster().run(parse("VALUES (nothing())"), routines)
     #expect(rows == [[.null]])
   }
 
@@ -737,7 +737,7 @@ struct EngineScalarSelectTests {
   }
 
   @Test func `a FROM-less bare column is rejected — no column to bind`() throws {
-    try roster().expect("SELECT Name", fails: .column("Name"))
+    try roster().expect("VALUES (Name)", fails: .column("Name"))
   }
 
   @Test func `a directly-built FROM-less select with clauses is rejected`() throws {

--- a/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
+++ b/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
@@ -309,7 +309,7 @@ func derived(_ plan: Plan) -> Plan? {
     derived(source)
   case let .aggregate(_, _, source):
     derived(source)
-  case .single, .empty, .scan, .join:
+  case .single, .values, .empty, .scan, .join:
     nil
   }
 }
@@ -347,7 +347,7 @@ func sought(_ plan: Plan) -> Bool {
     sought(source)
   case let .aggregate(_, _, source):
     sought(source)
-  case .single, .empty:
+  case .single, .values, .empty:
     false
   }
 }
@@ -382,7 +382,7 @@ func filters(_ plan: Plan) -> Bool {
     filters(source)
   case let .aggregate(_, _, source):
     filters(source)
-  case .single, .empty, .scan, .join:
+  case .single, .values, .empty, .scan, .join:
     false
   }
 }
@@ -422,7 +422,7 @@ func pushed(_ plan: Plan) -> Bool {
     pushed(source)
   case let .aggregate(_, _, source):
     pushed(source)
-  case .single, .empty, .scan:
+  case .single, .values, .empty, .scan:
     false
   }
 }
@@ -476,7 +476,7 @@ func joined(_ plan: Plan) -> Bool {
     joined(left) || joined(right)
   case let .aggregate(_, _, source):
     joined(source)
-  case .single, .empty, .scan:
+  case .single, .values, .empty, .scan:
     false
   }
 }
@@ -514,7 +514,7 @@ func residue(_ plan: Plan) -> Bool {
     residue(left) || residue(right)
   case let .aggregate(_, _, source):
     residue(source)
-  case .single, .empty, .scan:
+  case .single, .values, .empty, .scan:
     false
   }
 }
@@ -553,7 +553,7 @@ func separated(_ plan: Plan) -> Bool {
     separated(left) || separated(right)
   case let .aggregate(_, _, source):
     separated(source)
-  case .single, .empty, .scan:
+  case .single, .values, .empty, .scan:
     false
   }
 }
@@ -593,7 +593,7 @@ func stacked(_ plan: Plan) -> Bool {
     stacked(left) || stacked(right)
   case let .aggregate(_, _, source):
     stacked(source)
-  case .single, .empty, .scan:
+  case .single, .values, .empty, .scan:
     false
   }
 }
@@ -709,7 +709,7 @@ private func injected(_ plan: Plan) -> Bool {
     injected(outer)
   case let .aggregate(_, _, source):
     injected(source)
-  case .single, .empty, .scan:
+  case .single, .values, .empty, .scan:
     false
   }
 }

--- a/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
+++ b/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
@@ -1198,7 +1198,7 @@ struct EngineSetopViewMemoTests {
     // which over the swapped CTE projects `Id` ∈ {1, 2} (or mis-filters).
     let rows = try shadowed().run(Statement(parsing:
         """
-        WITH S (Val, Id) AS (SELECT 7, 1 UNION ALL SELECT 8, 2)
+        WITH S (Val, Id) AS (VALUES (7, 1) UNION ALL VALUES (8, 2))
           SELECT (SELECT Val FROM S WHERE S.Id = T.Id) AS c
             FROM T JOIN V ON V.c = 0 GROUP BY T.Id ORDER BY c
         """))

--- a/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
+++ b/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
@@ -232,7 +232,11 @@ struct EngineViewCorrelationTests {
     // `Env.k`. This is the seam the run/compile path (`resolve`/`overlay`)
     // clears elsewhere but `schema(of:)` did NOT until routed through `body`.
     let catalog = try leaked()
-    let target = try select("SELECT m FROM Proj").first
+    guard case let .select(target) = try select("SELECT m FROM Proj").body
+    else {
+      Issue.record("expected a SELECT")
+      return
+    }
     let context = try enclosing(catalog)
     var raised: SQLError?
     do {
@@ -258,7 +262,11 @@ struct EngineViewCorrelationTests {
       "Src": FixtureRelation([EngineField(name: "n", type: .integer)],
                              [[.integer(7)]] as Array<Array<Value>>),
     ], views: ["Fine": fine])
-    let target = try select("SELECT m FROM Fine").first
+    guard case let .select(target) = try select("SELECT m FROM Fine").body
+    else {
+      Issue.record("expected a SELECT")
+      return
+    }
     let context = try enclosing(catalog)
     // Eager rather than `#expect(throws:)` — a borrowed `~Escapable` catalog
     // cannot be captured by the assertion's escaping closure.

--- a/Tests/SQLTests/Queries/EngineWithTests.swift
+++ b/Tests/SQLTests/Queries/EngineWithTests.swift
@@ -88,10 +88,10 @@ struct EngineWithTests {
     // it. `1` and `1.0` then compare equal AND emit as the same coerced
     // `double`, so a bare UNION keeps one `1.0` (not the first arm's raw
     // `integer`).
-    #expect(try statement("SELECT 1 UNION SELECT 1.0", family())
+    #expect(try statement("VALUES (1) UNION VALUES (1.0)", family())
             == [[.double(1.0)]])
     // UNION ALL keeps every row, each coerced to the unified `double`.
-    #expect(try statement("SELECT 1 UNION ALL SELECT 1.0", family())
+    #expect(try statement("VALUES (1) UNION ALL VALUES (1.0)", family())
             == [[.double(1.0)], [.double(1.0)]])
   }
 

--- a/Tests/SQLTests/Queries/EngineWithTests.swift
+++ b/Tests/SQLTests/Queries/EngineWithTests.swift
@@ -31,7 +31,7 @@ struct EngineWithTests {
     // fold unifies text against text and runs — a `.integer` declared-name
     // placeholder would wrongly fault the all-text UNION as irreconcilable.
     let text = """
-        WITH a (x) AS (SELECT 'b') SELECT x FROM a UNION SELECT 'c'
+        WITH a (x) AS (VALUES ('b')) SELECT x FROM a UNION VALUES ('c')
         """
     // The schema path folds the CTE column at its body-derived type too: it
     // must report `x` as `.text` and NOT fault, the compile-time mirror of the
@@ -50,7 +50,7 @@ struct EngineWithTests {
     // are equal, so the row joins rather than being dropped by a raw-`Value`
     // key comparison.
     let rows = try statement("""
-        WITH a (x) AS (SELECT 1), b (x) AS (SELECT 1.0)
+        WITH a (x) AS (VALUES (1)), b (x) AS (VALUES (1.0))
           SELECT * FROM a JOIN b ON a.x = b.x
         """, family())
     #expect(rows == [[.integer(1), .double(1.0)]])
@@ -62,8 +62,8 @@ struct EngineWithTests {
     // promoting the integer to `Double` (both round to 2^53), so the optimized
     // join must too — a fold-double-to-Int key would drop the row.
     let rows = try statement("""
-        WITH a (x) AS (SELECT 9007199254740993),
-             b (x) AS (SELECT 9007199254740993.0)
+        WITH a (x) AS (VALUES (9007199254740993)),
+             b (x) AS (VALUES (9007199254740993.0))
           SELECT a.x FROM a JOIN b ON a.x = b.x
         """, family())
     #expect(rows == [[.integer(9007199254740993)]])
@@ -75,8 +75,8 @@ struct EngineWithTests {
     // may collide, but the residual `matches` check keeps integer equality
     // exact.
     let rows = try statement("""
-        WITH a (x) AS (SELECT 9007199254740992),
-             b (x) AS (SELECT 9007199254740993)
+        WITH a (x) AS (VALUES (9007199254740992)),
+             b (x) AS (VALUES (9007199254740993))
           SELECT a.x FROM a JOIN b ON a.x = b.x
         """, family())
     #expect(rows.isEmpty)
@@ -102,9 +102,9 @@ struct EngineWithTests {
     // three arms collapse to the one distinct `double`, the ISO
     // approximate-numeric result of a mixed-type UNION.
     let rows = try statement("""
-        SELECT 9007199254740992.0
-          UNION SELECT 9007199254740992
-          UNION SELECT 9007199254740993
+        VALUES (9007199254740992.0)
+          UNION VALUES (9007199254740992)
+          UNION VALUES (9007199254740993)
         """, family())
     #expect(rows == [[.double(9007199254740992.0)]])
   }
@@ -113,7 +113,8 @@ struct EngineWithTests {
     // The CTE column unifies to `double`, so its integer arm coerces — `3`
     // emits as `3.0` — and the ordering runs over the widened values.
     let rows = try statement("""
-        WITH a (x) AS (SELECT 3 UNION ALL SELECT 1.5) SELECT x FROM a ORDER BY x
+        WITH a (x) AS (VALUES (3) UNION ALL VALUES (1.5))
+          SELECT x FROM a ORDER BY x
         """, family())
     #expect(rows == [[.double(1.5)], [.double(3.0)]])
   }
@@ -124,9 +125,9 @@ struct EngineWithTests {
     // stays a strict weak ordering, and the greatest value is the coerced
     // `double`.
     let rows = try statement("""
-        WITH a (x) AS (SELECT 9007199254740993
-                       UNION ALL SELECT 9007199254740993.0
-                       UNION ALL SELECT 9007199254740992)
+        WITH a (x) AS (VALUES (9007199254740993)
+                       UNION ALL VALUES (9007199254740993.0)
+                       UNION ALL VALUES (9007199254740992))
           SELECT x FROM a ORDER BY x
         """, family())
     #expect(rows.count == 3)
@@ -433,7 +434,7 @@ struct EngineRecursiveTests {
     // run-vs-schema divergence cannot hide.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
-          SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1
+          VALUES (1) UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1
         ) SELECT n FROM t
         """)
     let columns = try family().columns(of: statement, validate: true)
@@ -452,7 +453,7 @@ struct EngineRecursiveTests {
     // Schema and run agree: one column `n`, fixpoint 1, 2, 3.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
-          (SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1)
+          (VALUES (1) UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1)
           ORDER BY 1
         ) SELECT n FROM t
         """)
@@ -467,7 +468,7 @@ struct EngineRecursiveTests {
       throws {
     // The carrier `ORDER BY` peeled off a recursive-CTE fixpoint is applied to
     // the materialised rows through `carried(over:)`, which records a sort key
-    // correlated to the set-op output (`EXISTS (… WHERE V = x)`) into the
+    // correlated to the set-op output (`EXISTS (… WHERE V = column1)`) into the
     // context's `Subqueries` box, and then executed — but `apply` used to
     // execute against a fresh empty box, so the executor found no recorded plan
     // and faulted `a correlated subquery plan was not compiled` (wrapped as a
@@ -486,10 +487,10 @@ struct EngineRecursiveTests {
     }
     let rows = try catalog.run(Statement(parsing: """
         WITH RECURSIVE t(n) AS (
-          SELECT 1 AS x
+          VALUES (1)
           UNION ALL
           SELECT n + 1 FROM t WHERE n < 3
-          ORDER BY CASE WHEN EXISTS (SELECT V FROM S WHERE V = x)
+          ORDER BY CASE WHEN EXISTS (SELECT V FROM S WHERE V = column1)
                         THEN 0 ELSE 1 END
         ) SELECT n FROM t
         """))
@@ -499,10 +500,10 @@ struct EngineRecursiveTests {
   @Test func `a recursive CTE carrier ORDER BY on a plain sort key still runs`()
       throws {
     // guard: the memo fix must not regress a non-correlated carrier sort key.
-    // The same fixpoint (1,2,3), ordered by the plain output column `x`
-    // descending (the set-op output takes arm-0's projection name), still runs
-    // and reorders — the shared fresh box carries no recorded plan here, and
-    // none is needed.
+    // The same fixpoint (1,2,3), ordered by the plain output column `column1`
+    // descending (the set-op output takes arm-0's default VALUES name), still
+    // runs and reorders — the shared fresh box carries no recorded plan here,
+    // and none is needed.
     let catalog = try Catalog {
       Relation("S", ["V": .integer]) {
         Row(2)
@@ -510,10 +511,10 @@ struct EngineRecursiveTests {
     }
     let rows = try catalog.run(Statement(parsing: """
         WITH RECURSIVE t(n) AS (
-          SELECT 1 AS x
+          VALUES (1)
           UNION ALL
           SELECT n + 1 FROM t WHERE n < 3
-          ORDER BY x DESC
+          ORDER BY column1 DESC
         ) SELECT n FROM t
         """))
     #expect(rows == [[.integer(3)], [.integer(2)], [.integer(1)]])
@@ -532,7 +533,7 @@ struct EngineRecursiveTests {
     #expect(throws: SQLError.column("Zzz")) {
       _ = try catalog.run(Statement(parsing: """
           WITH RECURSIVE t(n) AS (
-            SELECT 1 AS x
+            VALUES (1)
             UNION ALL
             SELECT n + 1 FROM t WHERE n < 3
             ORDER BY Zzz
@@ -762,16 +763,17 @@ struct EngineRecursiveTests {
   }
 
   @Test func `a recursive arm that is itself a set-op folds the self at the anchor type`() throws {
-    // The recursive arm `SELECT s FROM t INTERSECT SELECT 'b'` is itself a set
-    // operation, so `validate`'s recursive-arm typecheck folds its self column
+    // The recursive arm `SELECT s FROM t INTERSECT VALUES ('b')` is itself a
+    // set operation, so `validate`'s recursive-arm typecheck folds its self
+    // column
     // (`s`) before `fixpoint` rebinds it. Binding the self under the anchor's
-    // derived type (`s` is text, from `SELECT 'b'`) — not a `.integer`
+    // derived type (`s` is text, from `VALUES ('b')`) — not a `.integer`
     // placeholder — lets text INTERSECT text unify rather than faulting a text
     // arm against an integer self. The schema path must report `s` as `.text`
     // without throwing, and the run terminates yielding `b`.
     let text = """
         WITH RECURSIVE t (s) AS (
-          SELECT 'b' UNION SELECT s FROM t INTERSECT SELECT 'b'
+          VALUES ('b') UNION SELECT s FROM t INTERSECT VALUES ('b')
         )
         SELECT s FROM t
         """
@@ -843,8 +845,8 @@ struct EngineRecursiveTests {
     // carries the per-column unconstrained marker, so a bare reference to `x`
     // unifies like a fresh constant-NULL arm.
     let rows = try statement("""
-        WITH t (x) AS (SELECT NULLIF('b', 'b') UNION SELECT NULLIF(1, 1))
-          SELECT x FROM t UNION SELECT 'c'
+        WITH t (x) AS (VALUES (NULLIF('b', 'b')) UNION VALUES (NULLIF(1, 1)))
+          SELECT x FROM t UNION VALUES ('c')
         """, family())
     #expect(rows == [[.null], [.text("c")]])
   }
@@ -857,8 +859,8 @@ struct EngineRecursiveTests {
     // the `'c'` text arm (the literal-fix regression); the marker unifies it
     // either way.
     let rows = try statement("""
-        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
-          SELECT x FROM t UNION SELECT 'c'
+        WITH t (x) AS (VALUES (NULLIF(1, 1)) UNION VALUES (NULLIF('b', 'b')))
+          SELECT x FROM t UNION VALUES ('c')
         """, family())
     #expect(rows == [[.null], [.text("c")]])
   }
@@ -868,15 +870,15 @@ struct EngineRecursiveTests {
     // the enclosing UNION unifies it with the text arm — both the integer-first
     // and the text-first orderings yield the same {NULL, 'c'}.
     let forward = try statement("""
-        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('a', 'a')
-                       UNION SELECT NULLIF('b', 'b'))
-          SELECT x FROM t UNION SELECT 'c'
+        WITH t (x) AS (VALUES (NULLIF(1, 1)) UNION VALUES (NULLIF('a', 'a'))
+                       UNION VALUES (NULLIF('b', 'b')))
+          SELECT x FROM t UNION VALUES ('c')
         """, family())
     #expect(forward == [[.null], [.text("c")]])
     let reversed = try statement("""
-        WITH t (x) AS (SELECT NULLIF('b', 'b') UNION SELECT NULLIF('a', 'a')
-                       UNION SELECT NULLIF(1, 1))
-          SELECT x FROM t UNION SELECT 'c'
+        WITH t (x) AS (VALUES (NULLIF('b', 'b')) UNION VALUES (NULLIF('a', 'a'))
+                       UNION VALUES (NULLIF(1, 1)))
+          SELECT x FROM t UNION VALUES ('c')
         """, family())
     #expect(reversed == [[.null], [.text("c")]])
   }
@@ -887,9 +889,9 @@ struct EngineRecursiveTests {
     // arm and `b`'s double with the integer arm — `a` yields NULLs, `b` the
     // coerced doubles.
     let rows = try statement("""
-        WITH t (a, b) AS (SELECT NULLIF(1, 1), 1
-                          UNION SELECT NULLIF('x', 'x'), 2.5)
-          SELECT a, b FROM t UNION SELECT 'c', 3
+        WITH t (a, b) AS (VALUES (NULLIF(1, 1), 1)
+                          UNION VALUES (NULLIF('x', 'x'), 2.5))
+          SELECT a, b FROM t UNION VALUES ('c', 3)
         """, family())
     #expect(Set(rows) == [[.null, .double(1.0)], [.null, .double(2.5)],
                           [.text("c"), .double(3.0)]])
@@ -900,7 +902,7 @@ struct EngineRecursiveTests {
     // top-level select over the all-NULL CTE column runs and yields the NULL,
     // exactly as before.
     let rows = try statement("""
-        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
+        WITH t (x) AS (VALUES (NULLIF(1, 1)) UNION VALUES (NULLIF('b', 'b')))
           SELECT x FROM t
         """, family())
     #expect(rows == [[.null]])
@@ -909,7 +911,7 @@ struct EngineRecursiveTests {
   @Test func `an all-NULL CTE column filters through IS NULL`() throws {
     // `x` is NULL, so `x IS NULL` is TRUE and keeps the row.
     let rows = try statement("""
-        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
+        WITH t (x) AS (VALUES (NULLIF(1, 1)) UNION VALUES (NULLIF('b', 'b')))
           SELECT x FROM t WHERE x IS NULL
         """, family())
     #expect(rows == [[.null]])
@@ -919,7 +921,7 @@ struct EngineRecursiveTests {
     // `NULL = 'c'` is UNKNOWN under three-valued logic, so the row is filtered
     // and the result is empty.
     let rows = try statement("""
-        WITH t (x) AS (SELECT NULLIF(1, 1) UNION SELECT NULLIF('b', 'b'))
+        WITH t (x) AS (VALUES (NULLIF(1, 1)) UNION VALUES (NULLIF('b', 'b')))
           SELECT x FROM t WHERE x = 'c'
         """, family())
     #expect(rows.isEmpty)
@@ -937,7 +939,7 @@ struct EngineRecursiveTests {
     // on the schema path. Assert the shared value so a future reorder cannot
     // silently re-diverge the two paths.
     let text = """
-        WITH RECURSIVE t (a, b) AS (SELECT 1, 2 UNION SELECT Id FROM t)
+        WITH RECURSIVE t (a, b) AS (VALUES (1, 2) UNION SELECT Id FROM t)
           SELECT * FROM t
         """
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
@@ -956,7 +958,7 @@ struct EngineRecursiveTests {
     // the two-name list in the same ISO order — the sibling of the arm-mismatch
     // parity, proving the declared-list guard wins whichever arm diverges.
     let text = """
-        WITH RECURSIVE t (a, b) AS (SELECT 1 UNION SELECT Id, Id FROM t)
+        WITH RECURSIVE t (a, b) AS (VALUES (1) UNION SELECT Id, Id FROM t)
           SELECT * FROM t
         """
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
@@ -970,14 +972,15 @@ struct EngineRecursiveTests {
   @Test func `a no-list recursive CTE faults its arm alike on both paths`()
       throws {
     // With no explicit `(a, b)` list the CTE's column names come from the
-    // anchor's aliases (degree 2), so `cte.columns` is populated exactly as a
-    // declared list would be. The recursive arm's single column therefore hits
+    // anchor's columns (degree 2, the default `column1, column2`), so
+    // `cte.columns` is populated exactly as a declared list would be. The
+    // recursive arm's single column therefore hits
     // the same arm-width guard, faulting `(expected: 1, got: 2)` on both paths
     // — never reaching the `kinds`/`contributions` inter-arm throw, which is
     // consequently unreachable for a recursive CTE (its width is always checked
     // against the anchor-derived list first).
     let text = """
-        WITH RECURSIVE t AS (SELECT 1 AS a, 2 AS b UNION SELECT Id AS a FROM t)
+        WITH RECURSIVE t AS (VALUES (1, 2) UNION SELECT Id AS a FROM t)
           SELECT * FROM t
         """
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
@@ -995,16 +998,17 @@ struct EngineRecursiveTests {
     // compiled body width against the declared list count.
     #expect(throws: SQLError.columns(expected: 1, got: 2)) {
       _ = try statement("""
-          WITH t (a, b) AS (SELECT 1) SELECT a FROM t
+          WITH t (a, b) AS (VALUES (1)) SELECT a FROM t
           """, family())
     }
   }
 
   @Test func `a recursive CTE with an all-NULL anchor unifies its recursive arm`()
       throws {
-    // The reviewer's anchor-NULL case. The anchor `SELECT NULLIF(1, 1)` folds
+    // The reviewer's anchor-NULL case. The anchor `VALUES (NULLIF(1, 1))` folds
     // to a constant NULL, so the CTE column `x` is unconstrained: the recursive
-    // arm — itself a set operation `SELECT x FROM t INTERSECT SELECT 'c'` — must
+    // arm — itself a set operation `SELECT x FROM t INTERSECT VALUES ('c')` —
+    // must
     // fold the self column against the text `'c'` without faulting integer
     // against text, exactly as a bare constant-NULL arm unifies with any typed
     // arm. Because the schema-only self and the run-iteration self bind through
@@ -1013,7 +1017,7 @@ struct EngineRecursiveTests {
     // (no match), so the fixpoint terminates at the anchor's single NULL row.
     let rows = try statement("""
         WITH RECURSIVE t (x) AS (
-          SELECT NULLIF(1, 1) UNION SELECT x FROM t INTERSECT SELECT 'c'
+          VALUES (NULLIF(1, 1)) UNION SELECT x FROM t INTERSECT VALUES ('c')
         ) SELECT x FROM t
         """, family())
     #expect(rows == [[.null]])
@@ -1034,7 +1038,7 @@ struct EngineRecursiveTests {
     // without throwing, agreeing with the run's terminating rows.
     let text = """
         WITH RECURSIVE t (s) AS (
-          SELECT 'b'
+          VALUES ('b')
           UNION ALL
           SELECT s FROM (SELECT s || 'c' AS s FROM t WHERE s = 'b') AS d
         ) SELECT * FROM t
@@ -1057,7 +1061,7 @@ struct EngineRecursiveTests {
     // arithmetic-on-integer and must fault on both the schema path and the run.
     let text = """
         WITH RECURSIVE t (n) AS (
-          SELECT 1
+          VALUES (1)
           UNION ALL
           SELECT n || 'c' FROM t WHERE n < 3
         ) SELECT * FROM t
@@ -1085,7 +1089,7 @@ struct EngineRecursiveTests {
     // type, so `b` reads (and the query returns) `.double` values — the same
     // widened carrier the schema path threads with empty rows.
     let rows = try statement("""
-        WITH a(x) AS (SELECT 1 UNION SELECT 2.5),
+        WITH a(x) AS (VALUES (1) UNION VALUES (2.5)),
              b(y) AS (SELECT x FROM a)
           SELECT y FROM b ORDER BY y
         """, family())
@@ -1100,7 +1104,7 @@ struct EngineRecursiveTests {
     // of the schema derive's `.double` header.
     let rows = try statement("""
         WITH RECURSIVE t(n) AS (
-          SELECT 1 UNION ALL SELECT n + 0.5 FROM t WHERE n < 2
+          VALUES (1) UNION ALL SELECT n + 0.5 FROM t WHERE n < 2
         ) SELECT n FROM t ORDER BY n
         """, family())
     #expect(rows == [[.double(1.0)], [.double(1.5)], [.double(2.0)]])
@@ -1112,7 +1116,7 @@ struct EngineRecursiveTests {
     // arm's values to the unified type before binding, so `1` materialises as
     // `1.0` — the producer's carrier and the run's rows agree on the type.
     let rows = try statement("""
-        WITH a(x) AS (SELECT 1 UNION SELECT 2.5) SELECT x FROM a ORDER BY x
+        WITH a(x) AS (VALUES (1) UNION VALUES (2.5)) SELECT x FROM a ORDER BY x
         """, family())
     #expect(rows == [[.double(1.0)], [.double(2.5)]])
   }
@@ -1182,16 +1186,17 @@ struct EngineRecursiveTests {
 
   @Test func `a renaming recursive body orders by its first-arm output name`()
       throws {
-    // The body's set-op output is named off its FIRST arm (`SELECT 1 AS x`), so
-    // the carrier's `ORDER BY x` resolves against that output name `x`, not the
-    // CTE's declared name `n` — exactly as the non-recursive analog below does.
+    // The body's set-op output is named off its first arm (`VALUES (1)`), so
+    // the carrier's `ORDER BY column1` resolves against that default output
+    // name `column1`, not the CTE's declared name `n` — exactly as the
+    // non-recursive analog below does.
     // The fixpoint temp the carrier applies over is named by the anchor's
     // output names; the CTE-declared rename rides the returned carrier, so the
     // outer `SELECT n FROM t` still sees `n`. Assert schema AND run on the same
     // query so a run-vs-validate divergence cannot hide.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
-          SELECT 1 AS x UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY x
+          VALUES (1) UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY column1
         ) SELECT n FROM t
         """)
     let catalog = EngineMemory([:])
@@ -1204,11 +1209,11 @@ struct EngineRecursiveTests {
 
   @Test func `a non-recursive ordered CTE body orders by its output name`()
       throws {
-    // The non-recursive analog of the renaming recursive body: `ORDER BY x`
-    // resolves against the first arm's output `x`. This is the oracle the
-    // recursive form mirrors — the two paths must agree.
+    // The non-recursive analog of the renaming recursive body: `ORDER BY
+    // column1` resolves against the first arm's output `column1`. This is the
+    // oracle the recursive form mirrors — the two paths must agree.
     let statement = try Statement(parsing: """
-        WITH t (n) AS (SELECT 1 AS x UNION ALL SELECT 2 ORDER BY x)
+        WITH t (n) AS (VALUES (1) UNION ALL VALUES (2) ORDER BY column1)
         SELECT n FROM t
         """)
     let catalog = EngineMemory([:])
@@ -1218,14 +1223,15 @@ struct EngineRecursiveTests {
 
   @Test func `a recursive carrier ORDER BY of a non-output name faults`()
       throws {
-    // `ORDER BY n` names the CTE's declared name, NOT a body output (the first
-    // arm projects `x`), so the carrier — which resolves against the body's
-    // output names — faults `.column('n')` on the schema path, exactly as the
-    // run does when `apply` reapplies the carrier after the fixpoint (`run ≡
-    // columns(of:)`), and exactly as the non-recursive analog below faults.
+    // `ORDER BY n` names the CTE's declared name, not a body output (the first
+    // arm outputs `column1`), so the carrier — which resolves against the
+    // body's output names — faults `.column('n')` on the schema path, exactly
+    // as the run does when `apply` reapplies the carrier after the fixpoint
+    // (`run ≡ columns(of:)`), and exactly as the non-recursive analog below
+    // faults.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
-          SELECT 1 AS x UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY n
+          VALUES (1) UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY n
         ) SELECT n FROM t
         """)
     let catalog = EngineMemory([:])
@@ -1240,10 +1246,10 @@ struct EngineRecursiveTests {
   @Test func `a non-recursive carrier ORDER BY of a non-output name faults`()
       throws {
     // The non-recursive oracle: `ORDER BY n` (the declared name, not the first
-    // arm's output `x`) faults `.column('n')`, the behaviour the recursive form
-    // mirrors.
+    // arm's output `column1`) faults `.column('n')`, the behaviour the
+    // recursive form mirrors.
     let statement = try Statement(parsing: """
-        WITH t (n) AS (SELECT 1 AS x UNION ALL SELECT 2 ORDER BY n)
+        WITH t (n) AS (VALUES (1) UNION ALL VALUES (2) ORDER BY n)
         SELECT n FROM t
         """)
     let catalog = EngineMemory([:])
@@ -1256,15 +1262,16 @@ struct EngineRecursiveTests {
       throws {
     // The recursive validate path validates the carrier's ORDER BY keys against
     // the body's output scope, the same check an ordinary ordered set operation
-    // gets. A carrier `ORDER BY missing(n)` — where `n` IS a body output
-    // (`SELECT 1 AS n`) — faults `.function('missing')` on both the schema path
+    // gets. A carrier `ORDER BY missing(column1)` — where `column1` is a body
+    // output (`VALUES (1)`) — faults `.function('missing')` on both the schema
+    // path
     // (`columns(of:validate:true)`) AND the run (`run ≡ columns(of:)`), closing
     // the run-vs-validate gap where validate passed yet the run faulted when
     // `apply` reapplied the carrier after the fixpoint.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
-          SELECT 1 AS n UNION ALL SELECT n + 1 FROM t WHERE n < 3
-          ORDER BY missing(n)
+          VALUES (1) UNION ALL SELECT n + 1 FROM t WHERE n < 3
+          ORDER BY missing(column1)
         ) SELECT n FROM t
         """)
     let catalog = EngineMemory([:])
@@ -1277,13 +1284,13 @@ struct EngineRecursiveTests {
   }
 
   @Test func `a valid recursive carrier ORDER BY validates and runs`() throws {
-    // The positive companion: a carrier key that IS a body output (`ORDER BY n`
-    // over an anchor `SELECT 1 AS n`) validates AND runs the fixpoint, ordered
-    // by that output — the valid-key half of the run≡validate oracle.
+    // The positive companion: a carrier key that is a body output (`ORDER BY
+    // column1` over an anchor `VALUES (1)`) validates and runs the fixpoint,
+    // ordered by that output — the valid-key half of the run≡validate oracle.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
-          SELECT 1 AS n UNION ALL SELECT n + 1 FROM t WHERE n < 3
-          ORDER BY n DESC
+          VALUES (1) UNION ALL SELECT n + 1 FROM t WHERE n < 3
+          ORDER BY column1 DESC
         ) SELECT n FROM t
         """)
     let catalog = EngineMemory([:])
@@ -1321,7 +1328,7 @@ struct EngineRecursiveTests {
     // key against the same arm-0 surface and runs without faulting.
     let analog = try Statement(parsing: """
         SELECT Age * 1 AS m FROM People WHERE Age = 1
-        UNION ALL SELECT 9 ORDER BY Age * 1
+        UNION ALL VALUES (9) ORDER BY Age * 1
         """)
     #expect(try people.run(analog) == [[.integer(1)], [.integer(9)]])
   }
@@ -1383,7 +1390,7 @@ struct EngineRecursiveTests {
     // BY 1` binds the first output column, ordering the fixpoint descending.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
-          SELECT 1 AS n
+          VALUES (1)
             UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1 DESC
         ) SELECT n FROM t
         """)
@@ -1400,7 +1407,7 @@ struct EngineRecursiveTests {
     // `SQLError.relation('t')`. It now faults the precise `0A000` feature
     // diagnostic on both the run and the schema path.
     let statement = try Statement(parsing: """
-        WITH RECURSIVE t (n) AS (SELECT n FROM t EXCEPT SELECT 1)
+        WITH RECURSIVE t (n) AS (SELECT n FROM t EXCEPT VALUES (1))
           SELECT n FROM t
         """)
     let catalog = EngineMemory([:])
@@ -1417,7 +1424,7 @@ struct EngineRecursiveTests {
     // The `INTERSECT` sibling faults the same `0A000` — the guard matches any
     // non-`UNION` self-referencing setop core.
     let statement = try Statement(parsing: """
-        WITH RECURSIVE t (n) AS (SELECT n FROM t INTERSECT SELECT 1)
+        WITH RECURSIVE t (n) AS (SELECT n FROM t INTERSECT VALUES (1))
           SELECT n FROM t
         """)
     #expect(throws: SQLError.state("0A000", "recursion requires UNION [ALL]")) {
@@ -1435,7 +1442,7 @@ struct EngineRecursiveTests {
                        [[.integer(1)], [.integer(2)]] as Array<Array<Value>>),
     ])
     let statement = try Statement(parsing: """
-        WITH RECURSIVE t (n) AS (SELECT n FROM t EXCEPT SELECT 2)
+        WITH RECURSIVE t (n) AS (SELECT n FROM t EXCEPT VALUES (2))
           SELECT n FROM t
         """)
     #expect(try catalog.run(statement) == [[.integer(1)]])
@@ -1448,7 +1455,7 @@ struct EngineRecursiveTests {
     // core.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t (n) AS (
-          SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3
+          VALUES (1) UNION ALL SELECT n + 1 FROM t WHERE n < 3
         ) SELECT n FROM t
         """)
     #expect(try EngineMemory([:]).run(statement) == [[.integer(1)],

--- a/Tests/SQLTests/Queries/GroupingKeyValidationTests.swift
+++ b/Tests/SQLTests/Queries/GroupingKeyValidationTests.swift
@@ -321,12 +321,12 @@ struct GroupingKeyValidationTests {
 
   @Test func `GROUP BY of a scalar subquery resolves runs and validates`()
       throws {
-    // A scalar subquery is a scalar expression, so `GROUP BY (SELECT 1)` is a
+    // A scalar subquery is a scalar expression, so `GROUP BY (VALUES (1))` is a
     // valid grouping key — the constant `1` puts every row in one group. The
     // subquery collectors now visit `select.grouping`, so the occurrence is
     // registered and lowers exactly as the same subquery in any other clause;
     // before the fix it faulted "a subquery is not supported in this position".
-    let sql = "SELECT COUNT(*) FROM Orders GROUP BY (SELECT 1)"
+    let sql = "SELECT COUNT(*) FROM Orders GROUP BY (VALUES (1))"
     let columns = try shipments().columns(of: parse(query: sql), validate: true)
     #expect(columns.count == 1)
     try shipments().expect(sql, yields: [[2]])
@@ -357,7 +357,7 @@ struct GroupingKeyValidationTests {
     // grouping key registers once (its role is shared) — no double-register
     // or width mismatch — and groups every row into the one constant group.
     let sql = """
-        SELECT (SELECT 1) AS k, COUNT(*) FROM Orders GROUP BY (SELECT 1)
+        SELECT (VALUES (1)) AS k, COUNT(*) FROM Orders GROUP BY (VALUES (1))
         """
     let columns = try shipments().columns(of: parse(query: sql), validate: true)
     #expect(columns.count == 2)

--- a/Tests/SQLTests/Queries/GroupingSetsTests.swift
+++ b/Tests/SQLTests/Queries/GroupingSetsTests.swift
@@ -475,7 +475,7 @@ struct GroupingSetsTests {
       _ = try cat.columns(of: Statement(parsing: cte), validate: true)
     }
     // The same query as the trailing WITH query faults under the schema derive.
-    let trailing = "WITH u AS (SELECT 1 AS x) \(sql)"
+    let trailing = "WITH u AS (VALUES (1)) \(sql)"
     #expect(throws: SQLError.divide) {
       _ = try cat.run(Statement(parsing: trailing))
     }
@@ -1086,20 +1086,21 @@ struct GroupingSetsTests {
       throws {
     // A scalar subquery in a set's key must be pre-registered for every arm,
     // not only the arms whose set includes it: an `.arm` lowers the superset
-    // (to NULL an absent key), so the `()` grand-total arm lowers `(SELECT 1)`
-    // and needs it collected. The present arm groups on the constant subquery
-    // value (one group) and projects it (1); the `()` arm NULLs the absent key.
+    // (to NULL an absent key), so the `()` grand-total arm lowers the
+    // `(VALUES (1))` and needs it collected. The present arm groups on the
+    // constant subquery value (one group) and projects it (1); the `()` arm
+    // NULLs the absent key.
     let cat = try sales()
     try cat.expect("""
-        SELECT (SELECT 1)
+        SELECT (VALUES (1))
           FROM Sales
-         GROUP BY GROUPING SETS (((SELECT 1)), ())
+         GROUP BY GROUPING SETS (((VALUES (1))), ())
         """, yields: [[1], [nil]])
     // run ≡ columns(of:): the schema derive resolves the same, not a fault.
     let columns = try cat.columns(of: parse(query: """
-        SELECT (SELECT 1)
+        SELECT (VALUES (1))
           FROM Sales
-         GROUP BY GROUPING SETS (((SELECT 1)), ())
+         GROUP BY GROUPING SETS (((VALUES (1))), ())
         """), validate: true)
     #expect(columns == [OutputColumn(name: "column 1", type: .integer)])
   }

--- a/Tests/SQLTests/Queries/LateralTests.swift
+++ b/Tests/SQLTests/Queries/LateralTests.swift
@@ -120,7 +120,7 @@ struct LateralExecutionTests {
     // row whose `Id` is 1 (an INNER apply drops Ids 2 and 3, which `c` never
     // equals).
     let statement = try Statement(parsing:
-        "WITH c(x) AS (SELECT 1 AS x) SELECT d.x FROM T " +
+        "WITH c(x) AS (VALUES (1)) SELECT d.x FROM T " +
         "JOIN LATERAL (SELECT x FROM c WHERE x = T.Id) AS d ON 1 = 1")
     let columns = try fixture().columns(of: statement, validate: true)
     #expect(columns.count == 1)
@@ -229,8 +229,8 @@ struct LateralExecutionTests {
     // ever resolved it, the exact path the unified revealed base now closes.
     let sql =
         "SELECT d.x FROM T " +
-        "JOIN (SELECT 9 AS y) AS e ON 1 = 1 " +
-        "JOIN LATERAL (SELECT 0 AS x UNION ALL SELECT x FROM e) AS d ON 1 = 1"
+        "JOIN (VALUES (9)) AS e(y) ON 1 = 1 " +
+        "JOIN LATERAL (VALUES (0) UNION ALL SELECT x FROM e) AS d(x) ON 1 = 1"
     // The run faults the unknown relation the body's later arm names.
     try fixture().expect(sql, fails: .relation("e"))
     // The strict schema path faults it identically — schema and run agree.
@@ -253,8 +253,8 @@ struct LateralExecutionTests {
     // yields the CTE's row and `columns(of:validate: true)` agrees — schema,
     // compile, and execution resolve the body's `FROM` identically.
     let statement = try Statement(parsing:
-        "WITH e(x) AS (SELECT 1 AS x) SELECT T.Id, d.x FROM T " +
-        "JOIN (SELECT 2 AS x) AS e ON 1 = 1 " +
+        "WITH e(x) AS (VALUES (1)) SELECT T.Id, d.x FROM T " +
+        "JOIN (VALUES (2)) AS e(x) ON 1 = 1 " +
         "JOIN LATERAL (SELECT x FROM e WHERE x = T.Id) AS d ON 1 = 1 " +
         "ORDER BY T.Id")
     let columns = try fixture().columns(of: statement, validate: true)
@@ -337,60 +337,58 @@ struct OuterApplyTests {
 /// `Term.parameter` the apply binds per outer row; the ordinary subquery
 /// projection bar is untouched.
 struct LateralProjectionCorrelationTests {
-  @Test func `a LATERAL body projects a preceding column`() throws {
-    // `JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1` — the body's projection
-    // names the preceding `T.Id`, which ISO puts in scope throughout the body.
-    // The strict schema path derives `id` typed from `T.Id` (`.integer`), and a
-    // run yields `d.id == T.Id` for each left row — the projected preceding
-    // column bound per outer row through the apply's correlation.
+  @Test func `a LATERAL body names a preceding column`() throws {
+    // `JOIN LATERAL (VALUES (T.Id)) AS d(id) ON 1 = 1` — the constructor's row
+    // names the preceding `T.Id`, which ISO puts in scope throughout a LATERAL
+    // derived table, and the derived-column list names it `id`. The strict
+    // schema path derives `id` typed from `T.Id` (`.integer`), and a run yields
+    // `d.id == T.Id` for each left row — the correlated element bound per outer
+    // row through the apply's correlation.
     let query = try parse(query:
         "SELECT d.id FROM T " +
-        "JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1")
+        "JOIN LATERAL (VALUES (T.Id)) AS d(id) ON 1 = 1")
     let columns = try fixture().columns(of: query, validate: true)
     #expect(columns.count == 1)
     #expect(columns[0].name == "id")
     #expect(columns[0].type == .integer)
     try fixture().expect(
         "SELECT d.id FROM T " +
-        "JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1 " +
+        "JOIN LATERAL (VALUES (T.Id)) AS d(id) ON 1 = 1 " +
         "ORDER BY d.id",
         yields: [[1], [2], [3]])
   }
 
-  @Test func `a LATERAL body projects a BARE preceding column`() throws {
-    // The bare-COLUMN twin of the aliased case above: a LATERAL body projecting
-    // a preceding `T.Id` without an alias collapses to `Projection.columns` —
-    // the simpler path. The schema-derive `.columns` case must consult the same
-    // lateral correlation surface the aliased expression path does, else a bare
-    // preceding column faults `SQLError.column("Id")` at schema/run even though
-    // the aliased form works. The strict schema path derives `Id` typed from
-    // the preceding `T.Id` (`.integer`), and a run yields `d.Id == T.Id` for
-    // each left row.
+  @Test func `a LATERAL body names a bare preceding column`() throws {
+    // A LATERAL `VALUES (T.Id)` naming the preceding `T.Id`, its one column
+    // named `Id` by the derived-column list. ISO puts the preceding `T.Id` in
+    // scope throughout a LATERAL derived table, so the strict schema path
+    // derives `Id` typed from `T.Id` (`.integer`), and a run yields
+    // `d.Id == T.Id` for each left row — the correlated element bound per outer
+    // row through the apply.
     let query = try parse(query:
         "SELECT d.Id FROM T " +
-        "JOIN LATERAL (SELECT T.Id) AS d ON 1 = 1")
+        "JOIN LATERAL (VALUES (T.Id)) AS d(Id) ON 1 = 1")
     let columns = try fixture().columns(of: query, validate: true)
     #expect(columns.count == 1)
     #expect(columns[0].name == "Id")
     #expect(columns[0].type == .integer)
     try fixture().expect(
         "SELECT T.Id, d.Id FROM T " +
-        "JOIN LATERAL (SELECT T.Id) AS d ON 1 = 1 " +
+        "JOIN LATERAL (VALUES (T.Id)) AS d(Id) ON 1 = 1 " +
         "ORDER BY T.Id",
         yields: [[1, 1], [2, 2], [3, 3]])
   }
 
-  @Test func `an ordinary subquery still cannot project a BARE outer column`()
+  @Test func `an ordinary subquery still cannot name a bare outer column`()
       throws {
-    // The bare-column exemption is gated on the lateral surface, not opened for
-    // the `.columns` path generally: an ordinary (non-lateral) derived table
-    // whose body projects a bare preceding `T.Id` still faults `.unsupported`
-    // at the strict schema check — the barred projection surface of an ordinary
-    // subquery diagnoses the correlated bare column exactly as it does the
-    // aliased one. This pins the exemption to the LATERAL `everywhere` surface.
+    // The correlation exemption is gated on the lateral surface, not opened for
+    // an ordinary derived table: a non-lateral `(VALUES (T.Id))` naming a bare
+    // preceding `T.Id` still faults `.column("Id")` — off a LATERAL a `VALUES`
+    // constructor's rows are an uncorrelated surface, so the outer name is out
+    // of scope. This pins the exemption to the LATERAL surface.
     let query = try parse(query:
         "SELECT d.Id FROM T " +
-        "JOIN (SELECT T.Id) AS d ON 1 = 1")
+        "JOIN (VALUES (T.Id)) AS d(Id) ON 1 = 1")
     #expect(throws: SQLError.column("Id")) {
       _ = try fixture().columns(of: query, validate: true)
     }
@@ -427,13 +425,13 @@ struct LateralProjectionCorrelationTests {
 
   @Test func `an ordinary subquery projection still cannot correlate`() throws {
     // The bar lift is LATERAL-ONLY: an ordinary correlated scalar subquery in
-    // the projection — `SELECT (SELECT T.Id) FROM T` — still faults
+    // the projection — `SELECT (VALUES (T.Id)) FROM T` — still faults
     // `.unsupported`, since a subquery's projection is a barred clause position
     // (no evaluator for an outer column there). This pins the LATERAL-only
     // scoping — the everywhere-correlation admission is set for a LATERAL body
     // alone, never an ordinary subquery.
     try fixture().expect(
-        "SELECT (SELECT T.Id) FROM T",
+        "SELECT (VALUES (T.Id)) FROM T",
         fails: .state("0A000",
             "a correlated column is only supported in a subquery's WHERE"))
   }
@@ -441,19 +439,19 @@ struct LateralProjectionCorrelationTests {
   @Test func `an ordinary nested subquery inside a LATERAL body is not lateralised`()
       throws {
     // The LATERAL everywhere-correlation admission covers ONLY the lateral
-    // body's own projection, never a nested ordinary subquery within it. So an
-    // ordinary correlated scalar subquery in the lateral body's projection —
-    // `SELECT (SELECT T.Id) AS x` — is barred `.unsupported` at the strict
-    // schema check exactly as the non-lateral twin `SELECT (SELECT T.Id) FROM T`
-    // is, since the nested subquery builds its own Resolution with the lateral
-    // flag cleared (`everywhere: false`). Threading the lateral flag into the
-    // nested subquery instead admitted its `T.Id` everywhere and lowered it to a
-    // correlated parameter the nested subquery never wires — a wrong, mismatched
-    // fault (`no such column 'Id'`) rather than the correct barred `.unsupported`
-    // — the bug the cleared flag fixes.
+    // body's own row constructor, never a nested ordinary subquery within it.
+    // So an ordinary correlated scalar subquery inside a lateral `VALUES` row —
+    // `VALUES ((VALUES (T.Id)))` — is barred at the strict schema check exactly
+    // as the non-lateral twin `SELECT (VALUES (T.Id)) FROM T` is, since the
+    // nested subquery builds its own Resolution with the lateral flag cleared
+    // (`everywhere: false`). Threading the lateral flag into the nested
+    // subquery instead admitted its `T.Id` everywhere and lowered it to a
+    // correlated parameter the nested subquery never wires — a wrong,
+    // mismatched fault (`no such column 'Id'`) rather than the correct barred
+    // one — the bug the cleared flag fixes.
     let query = try parse(query:
         "SELECT d.x FROM T " +
-        "JOIN LATERAL (SELECT (SELECT T.Id) AS x) AS d ON 1 = 1")
+        "JOIN LATERAL (VALUES ((VALUES (T.Id)))) AS d(x) ON 1 = 1")
     #expect(throws: SQLError.state("0A000",
         "a correlated column is only supported in a subquery's WHERE")) {
       _ = try fixture().columns(of: query, validate: true)
@@ -463,11 +461,11 @@ struct LateralProjectionCorrelationTests {
   @Test func `a LATERAL VALUES projects a preceding column`() throws {
     // `JOIN LATERAL (VALUES (T.Id)) AS d ON 1 = 1` — the ISO table value
     // constructor in LATERAL position names the preceding `T.Id`, which ISO
-    // puts in scope throughout a LATERAL derived table. It is the `VALUES` twin
-    // of `LATERAL (SELECT T.Id AS id)`: the strict schema path derives the
-    // constructor's default `column1` typed from `T.Id` (`.integer`), and a run
-    // binds it per outer row through the apply's correlation — the result the
-    // FROM-less SELECT form yields.
+    // puts in scope throughout a LATERAL derived table. The strict schema path
+    // derives the constructor's default `column1` typed from `T.Id`
+    // (`.integer`), and a run binds it per outer row through the apply's
+    // correlation. The derived-column-list spelling below (`AS d(id)`) is
+    // value-equivalent.
     let query = try parse(query:
         "SELECT d.column1 FROM T " +
         "JOIN LATERAL (VALUES (T.Id)) AS d ON 1 = 1")
@@ -480,11 +478,11 @@ struct LateralProjectionCorrelationTests {
         "JOIN LATERAL (VALUES (T.Id)) AS d ON 1 = 1 " +
         "ORDER BY d.column1",
         yields: [[1], [2], [3]])
-    // The FROM-less-SELECT form yields the identical rows — the two spellings
-    // of the correlated derived table are value-equivalent.
+    // The derived-column-list spelling `AS d(id)` yields the identical rows —
+    // the two spellings of the correlated constructor are value-equivalent.
     try fixture().expect(
         "SELECT d.id FROM T " +
-        "JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1 " +
+        "JOIN LATERAL (VALUES (T.Id)) AS d(id) ON 1 = 1 " +
         "ORDER BY d.id",
         yields: [[1], [2], [3]])
   }
@@ -501,11 +499,10 @@ struct LateralProjectionCorrelationTests {
   }
 
   @Test func `a non-LATERAL VALUES cannot reference an outer column`() throws {
-    // The correlation admission is LATERAL-only, as for a FROM-less SELECT: an
-    // ordinary (non-LATERAL) `VALUES` derived table naming a preceding `T.Id`
-    // faults — a `VALUES` constructor's rows are an uncorrelated projection
-    // surface, so a bound outer name is out of scope. This pins the exemption
-    // to the LATERAL surface, the `VALUES` twin of the FROM-less-SELECT case.
+    // The correlation admission is LATERAL-only: an ordinary (non-LATERAL)
+    // `VALUES` derived table naming a preceding `T.Id` faults — a `VALUES`
+    // constructor's rows are an uncorrelated surface, so a bound outer name is
+    // out of scope. This pins the exemption to the LATERAL surface.
     let query = try parse(query:
         "SELECT d.column1 FROM T " +
         "JOIN (VALUES (T.Id)) AS d ON 1 = 1")
@@ -628,9 +625,9 @@ struct LateralAggregateCorrelationTests {
 struct LateralSetOperationStarTests {
   @Test func `a set-op SELECT * LATERAL arm resolves its arity with the prefix`()
       throws {
-    // A LATERAL arm's star arity must derive the body's projected preceding
-    // column against the preceding FROM, exactly as the per-arm compile does.
-    // Each arm is `SELECT * FROM T JOIN LATERAL (SELECT T.Id AS id) AS d` — two
+    // A LATERAL arm's star arity must derive the body's correlated element
+    // against the preceding FROM, exactly as the per-arm compile does. Each
+    // arm is `SELECT * FROM T JOIN LATERAL (VALUES (T.Id)) AS d(id)` — two
     // columns wide (`T.Id` + `d.id`). The arity check must thread the running
     // prefix scope so `T.Id` resolves; without it the lateral body derived
     // against no scope and faulted the arity check even though the per-arm
@@ -638,9 +635,9 @@ struct LateralSetOperationStarTests {
     // union's arity matches and it resolves.
     let query = try parse(query:
         "SELECT * FROM T " +
-        "JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1 " +
+        "JOIN LATERAL (VALUES (T.Id)) AS d(id) ON 1 = 1 " +
         "UNION ALL SELECT * FROM T " +
-        "JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1")
+        "JOIN LATERAL (VALUES (T.Id)) AS d(id) ON 1 = 1")
     let columns = try fixture().columns(of: query, validate: true)
     #expect(columns.map(\.name) == ["Id", "id"])
   }

--- a/Tests/SQLTests/Queries/LateralTests.swift
+++ b/Tests/SQLTests/Queries/LateralTests.swift
@@ -459,6 +459,60 @@ struct LateralProjectionCorrelationTests {
       _ = try fixture().columns(of: query, validate: true)
     }
   }
+
+  @Test func `a LATERAL VALUES projects a preceding column`() throws {
+    // `JOIN LATERAL (VALUES (T.Id)) AS d ON 1 = 1` — the ISO table value
+    // constructor in LATERAL position names the preceding `T.Id`, which ISO
+    // puts in scope throughout a LATERAL derived table. It is the `VALUES` twin
+    // of `LATERAL (SELECT T.Id AS id)`: the strict schema path derives the
+    // constructor's default `column1` typed from `T.Id` (`.integer`), and a run
+    // binds it per outer row through the apply's correlation — the result the
+    // FROM-less SELECT form yields.
+    let query = try parse(query:
+        "SELECT d.column1 FROM T " +
+        "JOIN LATERAL (VALUES (T.Id)) AS d ON 1 = 1")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.count == 1)
+    #expect(columns[0].name == "column1")
+    #expect(columns[0].type == .integer)
+    try fixture().expect(
+        "SELECT d.column1 FROM T " +
+        "JOIN LATERAL (VALUES (T.Id)) AS d ON 1 = 1 " +
+        "ORDER BY d.column1",
+        yields: [[1], [2], [3]])
+    // The FROM-less-SELECT form yields the identical rows — the two spellings
+    // of the correlated derived table are value-equivalent.
+    try fixture().expect(
+        "SELECT d.id FROM T " +
+        "JOIN LATERAL (SELECT T.Id AS id) AS d ON 1 = 1 " +
+        "ORDER BY d.id",
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `a LATERAL VALUES multi-row correlated constructor`() throws {
+    // A multi-row LATERAL `VALUES` re-evaluates its rows per outer row: each
+    // `T` row expands to two `VALUES` rows, `T.Id` and `T.Id * 10`, so the
+    // apply yields two rows per left row, the correlated column bound per row.
+    try fixture().expect(
+        "SELECT d.column1 FROM T " +
+        "JOIN LATERAL (VALUES (T.Id), (T.Id * 10)) AS d ON 1 = 1 " +
+        "ORDER BY d.column1",
+        yields: [[1], [2], [3], [10], [20], [30]])
+  }
+
+  @Test func `a non-LATERAL VALUES cannot reference an outer column`() throws {
+    // The correlation admission is LATERAL-only, as for a FROM-less SELECT: an
+    // ordinary (non-LATERAL) `VALUES` derived table naming a preceding `T.Id`
+    // faults — a `VALUES` constructor's rows are an uncorrelated projection
+    // surface, so a bound outer name is out of scope. This pins the exemption
+    // to the LATERAL surface, the `VALUES` twin of the FROM-less-SELECT case.
+    let query = try parse(query:
+        "SELECT d.column1 FROM T " +
+        "JOIN (VALUES (T.Id)) AS d ON 1 = 1")
+    #expect(throws: SQLError.column("Id")) {
+      _ = try fixture().columns(of: query, validate: true)
+    }
+  }
 }
 
 // MARK: - LATERAL aggregate body correlates a preceding-FROM column

--- a/Tests/SQLTests/Queries/OrderedSetOperationCarrierTests.swift
+++ b/Tests/SQLTests/Queries/OrderedSetOperationCarrierTests.swift
@@ -110,8 +110,8 @@ struct OrderedSetOperationCarrierTests {
     // augmenting `x` before the arm scan. Alice (Age 30) matches the arm value.
     try people().expect("""
         SELECT Id FROM People p WHERE p.Age IN
-          (SELECT V FROM (SELECT 30 AS V) AS x WHERE x.V = p.Age
-           UNION SELECT 99 ORDER BY 1)
+          (SELECT V FROM (VALUES (30)) AS x(V) WHERE x.V = p.Age
+           UNION VALUES (99) ORDER BY 1)
         """, yields: [[1]])
   }
 
@@ -121,8 +121,8 @@ struct OrderedSetOperationCarrierTests {
     // ordered form now matches it exactly.
     try people().expect("""
         SELECT Id FROM People p WHERE p.Age IN
-          (SELECT V FROM (SELECT 30 AS V) AS x WHERE x.V = p.Age
-           UNION SELECT 99)
+          (SELECT V FROM (VALUES (30)) AS x(V) WHERE x.V = p.Age
+           UNION VALUES (99))
         """, yields: [[1]])
   }
 
@@ -176,8 +176,9 @@ struct OrderedSetOperationCarrierTests {
     try people().expect("""
         SELECT Id FROM People p WHERE p.Age IN
           (SELECT V FROM S
-            UNION ALL (SELECT V FROM (SELECT 30 AS V) AS d WHERE d.V = p.Age
-                        UNION ALL SELECT 99 ORDER BY V FETCH FIRST 1 ROW ONLY))
+            UNION ALL (SELECT V FROM (VALUES (30)) AS d(V) WHERE d.V = p.Age
+                        UNION ALL VALUES (99)
+                        ORDER BY V FETCH FIRST 1 ROW ONLY))
         """, yields: [[1]])
   }
 
@@ -222,8 +223,10 @@ struct OrderedSetOperationCarrierTests {
       throws {
     // The uncorrelated form the correlated one must match: its arms are folded
     // eagerly, faulting `.operand` at run whether ordered or not.
-    try people().expect("SELECT Id FROM People WHERE Age = (SELECT 'a' UNION SELECT 1 ORDER BY 1)",
-                        fails: .operand("UNION arms have irreconcilable types"))
+    try people().expect("""
+        SELECT Id FROM People
+          WHERE Age = (VALUES ('a') UNION VALUES (1) ORDER BY 1)
+        """, fails: .operand("UNION arms have irreconcilable types"))
   }
 
   @Test func `an unreached correlated scalar ordered set op does not fault`()
@@ -464,12 +467,12 @@ struct OrderedSetOperationCarrierTests {
     // The arms select from arm-local derived tables (`d`, `e`), not `Anchor` —
     // `Anchor` only gives the catalog a base relation. Ordered = bare, sorted.
     try cat.expect("""
-        SELECT v FROM (SELECT 1 AS v) AS d WHERE v = 1
-        UNION ALL SELECT v FROM (SELECT 2 AS v) AS e ORDER BY 1
+        SELECT v FROM (VALUES (1)) AS d(v) WHERE v = 1
+        UNION ALL SELECT v FROM (VALUES (2)) AS e(v) ORDER BY 1
         """, yields: [[1], [2]])
     try cat.expect("""
-        SELECT v FROM (SELECT 1 AS v) AS d WHERE v = 1
-        UNION ALL SELECT v FROM (SELECT 2 AS v) AS e
+        SELECT v FROM (VALUES (1)) AS d(v) WHERE v = 1
+        UNION ALL SELECT v FROM (VALUES (2)) AS e(v)
         """, yields: [[1], [2]])
   }
 
@@ -486,9 +489,9 @@ struct OrderedSetOperationCarrierTests {
       Relation("Anchor", ["x": .integer]) { Row(0) }
     }
     try cat.expect("""
-        SELECT v FROM (SELECT 1 AS v) AS d WHERE v = 1
-        UNION SELECT v FROM (SELECT 1 AS v) AS e WHERE v = 1
-        UNION SELECT v FROM (SELECT 2 AS v) AS f WHERE v = 2
+        SELECT v FROM (VALUES (1)) AS d(v) WHERE v = 1
+        UNION SELECT v FROM (VALUES (1)) AS e(v) WHERE v = 1
+        UNION SELECT v FROM (VALUES (2)) AS f(v) WHERE v = 2
         ORDER BY 1 OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY
         """, yields: [[2]])
   }
@@ -504,10 +507,10 @@ struct OrderedSetOperationCarrierTests {
       Relation("Anchor", ["x": .integer]) { Row(0) }
     }
     cat.expect("""
-        SELECT v FROM NoSuchRel UNION ALL SELECT 2 AS v ORDER BY 1
+        SELECT v FROM NoSuchRel UNION ALL VALUES (2) ORDER BY 1
         """, fails: .relation("NoSuchRel"))
     cat.expect("""
-        SELECT v FROM NoSuchRel UNION ALL SELECT 2 AS v
+        SELECT v FROM NoSuchRel UNION ALL VALUES (2)
         """, fails: .relation("NoSuchRel"))
   }
 

--- a/Tests/SQLTests/Queries/OrderedSetOperationTests.swift
+++ b/Tests/SQLTests/Queries/OrderedSetOperationTests.swift
@@ -266,8 +266,8 @@ struct OrderedSetOperationTests {
     // the direct `setop` and a correlated-subquery setop use), materialising
     // each arm's derived table in its own scope: 1 then 2.
     try pair().expect("""
-        SELECT v FROM (SELECT 1 AS v) AS d
-         UNION ALL SELECT v FROM (SELECT 2 AS v) AS e ORDER BY 1
+        SELECT v FROM (VALUES (1)) AS d(v)
+         UNION ALL SELECT v FROM (VALUES (2)) AS e(v) ORDER BY 1
         """, yields: [[1], [2]])
   }
 
@@ -276,8 +276,8 @@ struct OrderedSetOperationTests {
     // The per-arm materialisation rides any set operation: an `INTERSECT` of
     // two derived arms sharing the row 1 keeps it.
     try pair().expect("""
-        SELECT v FROM (SELECT 1 AS v) AS d
-         INTERSECT SELECT v FROM (SELECT 1 AS v) AS e ORDER BY 1
+        SELECT v FROM (VALUES (1)) AS d(v)
+         INTERSECT SELECT v FROM (VALUES (1)) AS e(v) ORDER BY 1
         """, yields: [[1]])
   }
 
@@ -285,8 +285,8 @@ struct OrderedSetOperationTests {
       throws {
     // `EXCEPT` of derived arms keeps the left row absent from the right.
     try pair().expect("""
-        SELECT v FROM (SELECT 1 AS v) AS d
-         EXCEPT SELECT v FROM (SELECT 2 AS v) AS e ORDER BY 1
+        SELECT v FROM (VALUES (1)) AS d(v)
+         EXCEPT SELECT v FROM (VALUES (2)) AS e(v) ORDER BY 1
         """, yields: [[1]])
   }
 

--- a/Tests/SQLTests/Queries/ParenthesizedQueryTests.swift
+++ b/Tests/SQLTests/Queries/ParenthesizedQueryTests.swift
@@ -333,12 +333,12 @@ struct ParenthesizedQueryTests {
   }
 
   @Test func `a parenthesized scalar subquery body is a query`() throws {
-    // A scalar subquery whose body starts with `(` — `((SELECT …) UNION …)` —
+    // A scalar subquery whose body starts with `(` — `((VALUES …) UNION …)` —
     // is a subquery over the union, not a parenthesised expression that fails at
     // UNION. It yields the union's single value. A parenthesised scalar
     // expression starting with `(` still parses as an expression (the
     // speculative query parse rewinds on the trailing operator).
-    try sets().expect("SELECT ((SELECT 1) UNION SELECT 1)", yields: [[1]])
+    try sets().expect("VALUES (((VALUES (1)) UNION VALUES (1)))", yields: [[1]])
     try sets().expect("VALUES (((1) + 2))", yields: [[3]])
   }
 

--- a/Tests/SQLTests/Queries/ParenthesizedQueryTests.swift
+++ b/Tests/SQLTests/Queries/ParenthesizedQueryTests.swift
@@ -339,7 +339,7 @@ struct ParenthesizedQueryTests {
     // expression starting with `(` still parses as an expression (the
     // speculative query parse rewinds on the trailing operator).
     try sets().expect("SELECT ((SELECT 1) UNION SELECT 1)", yields: [[1]])
-    try sets().expect("SELECT ((1) + 2)", yields: [[3]])
+    try sets().expect("VALUES (((1) + 2))", yields: [[3]])
   }
 
   @Test func `an unterminated parenthesized query faults`() throws {

--- a/Tests/SQLTests/Queries/RollupCubeTests.swift
+++ b/Tests/SQLTests/Queries/RollupCubeTests.swift
@@ -361,34 +361,34 @@ struct RollupCubeTests {
 
   @Test func `a scalar-subquery unit keeps its own parenthesis`() throws {
     // A `ROLLUP`/`CUBE` unit, or a `GROUPING SETS` member, that IS a scalar
-    // subquery `(SELECT …)` must route through `expression` — the leading `(`
+    // subquery `(VALUES …)` must route through `expression` — the leading `(`
     // is the subquery's, not a composite-set delimiter, so it is not stolen
-    // (which produced `expected an identifier but found 'SELECT'`). A scalar
+    // (which produced `expected an identifier but found 'VALUES'`). A scalar
     // subquery is a valid ordinary grouping key, so it is valid as a unit too.
-    // `(SELECT 1)` is a constant, so grouping on it forms one group.
+    // `(VALUES (1))` is a constant, so grouping on it forms one group.
     try sales().expect("""
-        SELECT SUM(Qty) FROM Sales GROUP BY ROLLUP((SELECT 1))
+        SELECT SUM(Qty) FROM Sales GROUP BY ROLLUP((VALUES (1)))
         """, equals: """
         SELECT SUM(Qty) FROM Sales
-          GROUP BY GROUPING SETS (((SELECT 1)), ())
+          GROUP BY GROUPING SETS (((VALUES (1))), ())
         """)
     try sales().expect("""
-        SELECT SUM(Qty) FROM Sales GROUP BY CUBE((SELECT 1))
+        SELECT SUM(Qty) FROM Sales GROUP BY CUBE((VALUES (1)))
         """, equals: """
         SELECT SUM(Qty) FROM Sales
-          GROUP BY GROUPING SETS (((SELECT 1)), ())
+          GROUP BY GROUPING SETS (((VALUES (1))), ())
         """)
     try sales().expect("""
-        SELECT SUM(Qty) FROM Sales GROUP BY GROUPING SETS ((SELECT 1))
-        """, equals: "SELECT SUM(Qty) FROM Sales GROUP BY (SELECT 1)")
+        SELECT SUM(Qty) FROM Sales GROUP BY GROUPING SETS ((VALUES (1)))
+        """, equals: "SELECT SUM(Qty) FROM Sales GROUP BY (VALUES (1))")
     // A subquery beside an ordinary key in a composite unit still parses — the
-    // composite `(` is the delimiter, the inner `(SELECT …)` its own key.
+    // composite `(` is the delimiter, the inner `(VALUES …)` its own key.
     try sales().expect("""
         SELECT Region, SUM(Qty) FROM Sales
-          GROUP BY ROLLUP(((SELECT 1), Region))
+          GROUP BY ROLLUP(((VALUES (1)), Region))
         """, equals: """
         SELECT Region, SUM(Qty) FROM Sales
-          GROUP BY GROUPING SETS (((SELECT 1), Region), ())
+          GROUP BY GROUPING SETS (((VALUES (1)), Region), ())
         """)
     // guard: a plain composite unit `(a, b)` is unaffected — no subquery, the
     // `(` stays a set delimiter.
@@ -429,8 +429,9 @@ struct RollupCubeTests {
     try nums().expect("SELECT A + 1, SUM(V) FROM N GROUP BY (A) + 1",
                       equals: "SELECT A + 1, SUM(V) FROM N GROUP BY A + 1")
     // A top-level scalar subquery key still parses (the `(` is the subquery's).
-    try sales().expect("SELECT SUM(Qty) FROM Sales GROUP BY (SELECT 1)",
-                       equals: "SELECT SUM(Qty) FROM Sales GROUP BY (SELECT 1)")
+    try sales().expect("""
+        SELECT SUM(Qty) FROM Sales GROUP BY (VALUES (1))
+        """, equals: "SELECT SUM(Qty) FROM Sales GROUP BY (VALUES (1))")
   }
 
   @Test func `GROUP BY () is the grand total, not absent grouping`() throws {

--- a/Tests/SQLTests/Queries/ScalarSubqueryTests.swift
+++ b/Tests/SQLTests/Queries/ScalarSubqueryTests.swift
@@ -335,25 +335,6 @@ struct ScalarSubqueryCorrelationTests {
             "a correlated column is only supported in a subquery's WHERE"))
   }
 
-  @Test func `a FROM-less correlated projection subquery is unsupported`()
-      throws {
-    // A FROM-less scalar subquery in the projection that names an outer column
-    // (`SELECT (SELECT T.Id) FROM T`) is a correlated reference in a barred
-    // clause position. The cut is intrinsic to the projection entry
-    // (`Schema.terms` bars its seam), so this FROM-less projection cannot admit
-    // the correlation — run and `columns(of:)` reject it with the same fault,
-    // never lowering `T.Id` to a run-time `Term.parameter` that would (wrongly)
-    // execute.
-    let query = try parse(query: "SELECT (SELECT T.Id) FROM T")
-    #expect(throws: SQLError.self) {
-      try fixture().columns(of: query, validate: true)
-    }
-    try fixture().expect(
-        "SELECT (SELECT T.Id) FROM T",
-        fails: .state("0A000",
-            "a correlated column is only supported in a subquery's WHERE"))
-  }
-
   @Test func `a correlated WHERE subquery still admits and runs`() throws {
     // The parity case: a correlated column in the inner subquery's WHERE — an
     // admitting clause position, unchanged by the projection barring — still
@@ -1703,17 +1684,12 @@ struct CorrelatedExistsProbeLenienceTests {
   }
 }
 
-// MARK: - FROM-less scope frame (correlation across an empty frame)
+// MARK: - Immediate correlation
 
-/// A FROM-less SELECT is still a scope frame. The example
-/// `SELECT id FROM T WHERE (SELECT CASE WHEN EXISTS (SELECT 1 FROM S WHERE
-/// S.x = T.id) THEN 1 END) = 1` nests a FROM-less middle scalar subquery whose
-/// own body holds an `EXISTS` correlating to the OUTER `T` — a scope past the
-/// empty FROM-less frame. The middle plan runs over a single empty record, so
-/// `T.id` must thread through the empty frame as `.bound`, NOT bind from a
-/// `.slot` of that empty record. `S.x` ∈ {2, 3}, so the CASE is 1 exactly for
-/// `T` rows 2 and 3, which the equality `= 1` keeps.
-private func fromless() throws -> FixtureCatalog {
+/// A `T` (ids 1, 2, 3) and an `S` (x ∈ {2, 3}) for the correlation test: an
+/// inner `EXISTS (SELECT 1 FROM S WHERE S.x = T.id)` correlates to the
+/// enclosing `T`, so it holds for `T` rows 2 and 3.
+private func correlation() throws -> FixtureCatalog {
   try Catalog {
     Relation("T", ["id": .integer]) {
       Row(1)
@@ -1727,50 +1703,14 @@ private func fromless() throws -> FixtureCatalog {
   }
 }
 
-struct FromlessScopeFrameTests {
-  @Test func `a correlation across a FROM-less frame runs per outer row`()
-      throws {
-    // The middle `(SELECT CASE WHEN EXISTS (...) THEN 1 END)` is FROM-less, so
-    // its plan runs over a single empty record. The inner `EXISTS`'s `T.id`
-    // names the OUTER `T`, one frame out past the empty FROM-less frame — so it
-    // resolves `.bound` and threads through per outer `T` row, rather than
-    // binding a `.slot` of the empty record (which would trap or read wrong).
-    // `S.x` ∈ {2, 3}, so the CASE is 1 for `T` rows 2 and 3.
-    try fromless().expect(
-        """
-        SELECT id FROM T \
-        WHERE (SELECT CASE WHEN EXISTS \
-                          (SELECT 1 FROM S WHERE S.x = T.id) THEN 1 END) = 1 \
-        ORDER BY id
-        """,
-        yields: [[2], [3]])
-  }
-
-  @Test func `a correlation across a FROM-less frame validates`() throws {
-    // The schema path resolves the correlation threaded through the FROM-less
-    // frame the same as the run — no `SQLError.column` on the enclosing `T.id`.
-    let query = try parse(query:
-        """
-        SELECT id FROM T \
-        WHERE (SELECT CASE WHEN EXISTS \
-                          (SELECT 1 FROM S WHERE S.x = T.id) THEN 1 END) = 1
-        """)
-    let columns = try fromless().columns(of: query, validate: true)
-    #expect(columns.count == 1)
-  }
-}
-
-// MARK: - Immediate correlation parity (no FROM-less frame)
-
-struct ImmediateCorrelationParityTests {
+struct ImmediateCorrelationTests {
   @Test func `a directly correlated EXISTS with a real FROM stays a slot`()
       throws {
-    // parity: the same inner `EXISTS (SELECT 1 FROM S WHERE S.x = T.id)` with
-    // no FROM-less middle correlates to the immediate enclosing `T` — one real
-    // frame out — so it resolves `.slot` and reads the outer row directly. The
-    // FROM-less empty-frame rule must not over-thread this immediate case.
-    // `S.x` ∈ {2, 3}, so only `T` rows 2 and 3 satisfy the EXISTS.
-    try fromless().expect(
+    // A directly correlated `EXISTS (SELECT 1 FROM S WHERE S.x = T.id)`
+    // correlates to the immediate enclosing `T` — one frame out — so it
+    // resolves `.slot` and reads the outer row directly. `S.x` ∈ {2, 3}, so
+    // only `T` rows 2 and 3 satisfy the EXISTS.
+    try correlation().expect(
         """
         SELECT id FROM T \
         WHERE EXISTS (SELECT 1 FROM S WHERE S.x = T.id) \

--- a/Tests/SQLTests/Queries/SubqueryTests.swift
+++ b/Tests/SQLTests/Queries/SubqueryTests.swift
@@ -1379,7 +1379,7 @@ struct ViewPushdownSubqueryTests {
       throws {
     // Bug 2, the inverse direction: the VIEW body's `EXISTS (SELECT V FROM S)`
     // resolves against the view's own base `S` (here empty), and the caller's
-    // AST-identical `WITH S AS (SELECT 1)` CTE must NOT leak into that body.
+    // AST-identical `WITH S(V) AS (VALUES (1))` CTE must not leak into it.
     // Keying the run-time cache by the `Query` value alone let the caller's
     // (non-empty) CTE result win the merge, so the view body's own EXISTS
     // wrongly read the CTE and kept every row. Keying by occurrence — each
@@ -1389,7 +1389,7 @@ struct ViewPushdownSubqueryTests {
     // non-empty CTE and keeps them. The view filters correctly (its base `S` is
     // empty), so the result is empty.
     let statement = try Statement(parsing:
-        "WITH S(V) AS (SELECT 1) "
+        "WITH S(V) AS (VALUES (1)) "
         + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
     let rows = try hollow().run(statement, .standard)
     // The view body's EXISTS reads its empty base `S`, filtering every row —
@@ -1417,7 +1417,7 @@ struct ViewPushdownSubqueryTests {
     // EXISTS (base `S` non-empty) is TRUE too, so every row survives — the
     // caller's CTE result did NOT collapse the view body's base read.
     let full = try Statement(parsing:
-        "WITH S(V) AS (SELECT 1) "
+        "WITH S(V) AS (VALUES (1)) "
         + "SELECT Id FROM VN WHERE EXISTS (SELECT V FROM S)")
     let kept: Array<Array<Value>> = [[.integer(1)], [.integer(2)]]
     #expect(try nested().run(full, .standard) == kept)
@@ -1578,41 +1578,41 @@ struct CorrelatedOwnDerivationTests {
   @Test func `a correlated EXISTS binds its own derived table`() throws {
     // Pre-fix: the correlated `execute(plan, context)` ran the precompiled plan
     // under only the parent overlay, so the plan's `.scan("d")` for the derived
-    // table `(SELECT 1 AS k) AS d` faulted `SQLError.relation("d")`. Post-fix
+    // table `(VALUES (1)) AS d(k)` faulted `SQLError.relation("d")`. Post-fix
     // the execute path augments the subquery's own derived rows first, binding
     // `d`. The self-contained `d.k` is 1, correlated `= T.Id` in the subquery's
     // WHERE, so the EXISTS is TRUE only for the outer row `Id = 1`.
     try fixture().expect(
         """
         SELECT Id FROM T \
-        WHERE EXISTS (SELECT 1 FROM (SELECT 1 AS k) AS d WHERE d.k = T.Id)
+        WHERE EXISTS (SELECT 1 FROM (VALUES (1)) AS d(k) WHERE d.k = T.Id)
         """,
         yields: [[1]])
   }
 
   @Test func `a correlated scalar subquery binds its own derived table`()
       throws {
-    // The scalar variant: `(SELECT d.k FROM (SELECT 1 AS k) AS d WHERE d.k =
+    // The scalar variant: `(SELECT d.k FROM (VALUES (1)) AS d(k) WHERE d.k =
     // T.Id)` derives `d.k` (a self-contained 1) and correlates it `= T.Id` per
     // outer row, collapsing to 1 for `Id = 1` and NULL (no matching row) for
     // the rest. Pre-fix it faulted `.relation("d")`; post-fix `d` binds a row.
     try fixture().expect(
         """
-        SELECT (SELECT d.k FROM (SELECT 1 AS k) AS d WHERE d.k = T.Id) \
+        SELECT (SELECT d.k FROM (VALUES (1)) AS d(k) WHERE d.k = T.Id) \
         FROM T
         """,
         yields: [[1], [nil], [nil]])
   }
 
   @Test func `a correlated IN binds its own derived table`() throws {
-    // The `IN (Q)` variant: `Id IN (SELECT d.k FROM (SELECT 1 AS k) AS d WHERE
+    // The `IN (Q)` variant: `Id IN (SELECT d.k FROM (VALUES (1)) AS d(k) WHERE
     // d.k = T.Id)` — the correlated subquery yields its self-contained `d.k`
     // (1) only when `d.k = T.Id`, so it is TRUE for `Id = 1` alone. Pre-fix the
     // per-row execute faulted `.relation("d")`; post-fix `d` binds each row.
     try fixture().expect(
         """
         SELECT Id FROM T \
-        WHERE Id IN (SELECT d.k FROM (SELECT 1 AS k) AS d WHERE d.k = T.Id)
+        WHERE Id IN (SELECT d.k FROM (VALUES (1)) AS d(k) WHERE d.k = T.Id)
         """,
         yields: [[1]])
   }
@@ -1621,7 +1621,7 @@ struct CorrelatedOwnDerivationTests {
       throws {
     // The SET-operation shape: the correlated `EXISTS` subquery is a `UNION
     // ALL` whose LEFT arm derives its own `d` and correlates it `d.k = T.Id`,
-    // and whose RIGHT arm is a bare `SELECT 2`. Pre-fix the correlated
+    // and whose RIGHT arm is a bare `VALUES (2)`. Pre-fix the correlated
     // augment-and-execute augmented at the query level, binding no arm-local
     // `d`, so the left arm's `.scan("d")` faulted `.relation("d")`; post-fix
     // it augments each ARM, so `d` binds per outer row. The right arm always
@@ -1629,8 +1629,8 @@ struct CorrelatedOwnDerivationTests {
     try fixture().expect(
         """
         SELECT Id FROM T WHERE EXISTS ( \
-        SELECT k FROM (SELECT 1 AS k) AS d WHERE d.k = T.Id \
-        UNION ALL SELECT 2)
+        SELECT k FROM (VALUES (1)) AS d(k) WHERE d.k = T.Id \
+        UNION ALL VALUES (2))
         """,
         yields: [[1], [2], [3]])
   }
@@ -1638,16 +1638,16 @@ struct CorrelatedOwnDerivationTests {
   @Test func `a correlated IN setop keeps only the row its arm derives`()
       throws {
     // A discriminating setop: `Id IN (SELECT d.k … WHERE d.k = T.Id UNION ALL
-    // SELECT 9)`. The right arm contributes the constant 9 (never an `Id`), so
-    // the membership turns ONLY on the left arm's per-row correlated
+    // VALUES (9))`. The right arm contributes the constant 9 (never an `Id`),
+    // so the membership turns ONLY on the left arm's per-row correlated
     // derivation — `d.k` (1) is in the column iff `T.Id = 1`. So only the outer
     // row `Id = 1` is kept, proving each arm augments its own `d` under the
     // per-row correlation rather than merely not faulting.
     try fixture().expect(
         """
         SELECT Id FROM T WHERE Id IN ( \
-        SELECT d.k FROM (SELECT 1 AS k) AS d WHERE d.k = T.Id \
-        UNION ALL SELECT 9)
+        SELECT d.k FROM (VALUES (1)) AS d(k) WHERE d.k = T.Id \
+        UNION ALL VALUES (9))
         """,
         yields: [[1]])
   }
@@ -1787,32 +1787,29 @@ struct ProjectionSubqueryReachabilityTests {
   }
 }
 
-// MARK: - FROM-less scalar subqueries
+// MARK: - VALUES row constructors nesting a subquery
 
-/// A FROM-less scalar `SELECT <expr-list>` whose projection nests an
-/// uncorrelated `EXISTS`/`IN (subquery)` compiles, validates, and runs exactly
-/// as the identical projection does with a FROM clause. The scalar lowering
-/// (`projection.scalar`) is the one compile path that otherwise threads the
-/// DEFAULT unsupported subquery map, so a subquery there faulted at compile
-/// before the run-time cache was ever built; the map is now threaded through so
-/// the term lowers, and `run`'s cache (built from `query.subqueries`, which
-/// descends the projection) materialises the subquery the evaluator reads.
-struct FromlessScalarSubqueryTests {
+/// A `VALUES` row whose element nests an uncorrelated `EXISTS`/`IN (subquery)`
+/// compiles, validates, and runs — the constructor's element lowers its nested
+/// subquery the same as any value expression, and `run`'s cache (built from
+/// `query.subqueries`, which descends the constructor) materialises the
+/// subquery the evaluator reads.
+struct ValuesRowSubqueryTests {
   @Test func `a scalar EXISTS yields 1 when the subquery is non-empty`()
       throws {
-    // No outer FROM; the subquery's own `FROM T` is fine. `T` is non-empty, so
+    // The row element nests `EXISTS (SELECT Id FROM T)`; `T` is non-empty, so
     // `EXISTS` is TRUE and the CASE yields 1.
     try fixture().expect(
-        "SELECT CASE WHEN EXISTS (SELECT Id FROM T) THEN 1 ELSE 0 END",
+        "VALUES (CASE WHEN EXISTS (SELECT Id FROM T) THEN 1 ELSE 0 END)",
         yields: [[1]])
   }
 
   @Test func `a scalar EXISTS yields 0 when the subquery is empty`() throws {
     // The subquery filters to zero rows, so `EXISTS` is FALSE and the CASE
-    // yields 0 — the scalar projection runs against the single empty row.
+    // yields 0 — the constructor's single row carries it.
     try fixture().expect(
-        "SELECT CASE WHEN EXISTS (SELECT Id FROM T WHERE Id = 99) "
-        + "THEN 1 ELSE 0 END",
+        "VALUES (CASE WHEN EXISTS (SELECT Id FROM T WHERE Id = 99) "
+        + "THEN 1 ELSE 0 END)",
         yields: [[0]])
   }
 
@@ -1820,11 +1817,11 @@ struct FromlessScalarSubqueryTests {
     // Over the empty subquery `NOT EXISTS` is TRUE (yields 1); over the
     // non-empty one it is FALSE (yields 0).
     try fixture().expect(
-        "SELECT CASE WHEN NOT EXISTS (SELECT Id FROM T WHERE Id = 99) "
-        + "THEN 1 ELSE 0 END",
+        "VALUES (CASE WHEN NOT EXISTS (SELECT Id FROM T WHERE Id = 99) "
+        + "THEN 1 ELSE 0 END)",
         yields: [[1]])
     try fixture().expect(
-        "SELECT CASE WHEN NOT EXISTS (SELECT Id FROM T) THEN 1 ELSE 0 END",
+        "VALUES (CASE WHEN NOT EXISTS (SELECT Id FROM T) THEN 1 ELSE 0 END)",
         yields: [[0]])
   }
 
@@ -1833,10 +1830,10 @@ struct FromlessScalarSubqueryTests {
     // `77 IN (…)` is FALSE (yields 0) — the value-list `IN` core over the
     // subquery's single materialised column.
     try fixture().expect(
-        "SELECT CASE WHEN 10 IN (SELECT V FROM S) THEN 1 ELSE 0 END",
+        "VALUES (CASE WHEN 10 IN (SELECT V FROM S) THEN 1 ELSE 0 END)",
         yields: [[1]])
     try fixture().expect(
-        "SELECT CASE WHEN 77 IN (SELECT V FROM S) THEN 1 ELSE 0 END",
+        "VALUES (CASE WHEN 77 IN (SELECT V FROM S) THEN 1 ELSE 0 END)",
         yields: [[0]])
   }
 
@@ -1844,27 +1841,27 @@ struct FromlessScalarSubqueryTests {
       throws {
     // The `IN (Q)` single-column arity is decided from the subquery's compiled
     // width at compile — cursor-free — so a two-column subquery faults
-    // `SQLError.arity` on the FROM-less path exactly as on the FROM'd one.
+    // `SQLError.arity` in the row element exactly as it does under a FROM.
     try fixture().expect(
-        "SELECT CASE WHEN 1 IN (SELECT Id, K FROM T) THEN 1 ELSE 0 END",
+        "VALUES (CASE WHEN 1 IN (SELECT Id, K FROM T) THEN 1 ELSE 0 END)",
         fails: .arity(1, 2))
   }
 
   @Test func `columns validates a scalar EXISTS projection`() throws {
-    // The schema path compiles and type-checks the same FROM-less scalar
-    // projection, so `columns(of:validate:)` accepts exactly what the run does.
+    // The schema path compiles and type-checks the same constructor element, so
+    // `columns(of:validate:)` accepts exactly what the run does.
     let query = try parse(query:
-        "SELECT CASE WHEN EXISTS (SELECT Id FROM T) THEN 1 ELSE 0 END")
+        "VALUES (CASE WHEN EXISTS (SELECT Id FROM T) THEN 1 ELSE 0 END)")
     let columns = try fixture().columns(of: query, validate: true)
     #expect(columns.count == 1)
   }
 
   @Test func `a bad inner column in a scalar subquery faults the check`()
       throws {
-    // A bad column inside the scalar projection's subquery faults the
-    // validation exactly as a run would — the check reaches the subquery.
+    // A bad column inside the row element's subquery faults the validation
+    // exactly as a run would — the check reaches the subquery.
     let query = try parse(query:
-        "SELECT CASE WHEN EXISTS (SELECT Missing FROM T) THEN 1 ELSE 0 END")
+        "VALUES (CASE WHEN EXISTS (SELECT Missing FROM T) THEN 1 ELSE 0 END)")
     let resolve = { () throws -> Array<OutputColumn> in
       try fixture().columns(of: query, validate: true)
     }
@@ -1873,20 +1870,19 @@ struct FromlessScalarSubqueryTests {
     }
   }
 
-  @Test func `a plain scalar SELECT without a subquery is unaffected`() throws {
-    // A FROM-less scalar select carrying no subquery lowers exactly as before —
-    // the threaded map is empty and the projection is a plain constant.
-    try fixture().expect("SELECT 1 + 2", yields: [[3]])
+  @Test func `a plain VALUES row without a subquery is unaffected`() throws {
+    // A constructor element carrying no subquery lowers as a plain constant.
+    try fixture().expect("VALUES (1 + 2)", yields: [[3]])
   }
 }
 
-// MARK: - FROM-less scalar reserved-relation subqueries
+// MARK: - VALUES rows nesting a reserved-relation subquery
 
 /// A reserved `definition_schema.` relation named ONLY inside a subquery of a
-/// FROM-less scalar `SELECT` still augments and runs — the relation-name
-/// collector descends the projection's subqueries the same on this path, so the
-/// store overlay is materialised before the subquery's width compile and run.
-struct FromlessScalarReservedRelationTests {
+/// `VALUES` row element still augments and runs — the relation-name collector
+/// descends the constructor's subqueries, so the store overlay is materialised
+/// before the subquery's width compile and run.
+struct ValuesRowReservedRelationTests {
   private func fixture() throws -> FixtureCatalog {
     try Catalog {
       Relation("T", ["Id": .integer]) {
@@ -1898,13 +1894,13 @@ struct FromlessScalarReservedRelationTests {
 
   @Test func `a scalar EXISTS over definition_schema.tables runs`() throws {
     // The reserved store relation is named ONLY inside the subquery of a
-    // FROM-less scalar select; the descent still augments it, so the width
-    // compile resolves and the run materialises it. It lists `T`, so `EXISTS`
-    // is TRUE and the CASE yields 1.
+    // `VALUES` row element; the descent still augments it, so the width compile
+    // resolves and the run materialises it. It lists `T`, so `EXISTS` is TRUE
+    // and the CASE yields 1.
     try fixture().expect(
-        "SELECT CASE WHEN EXISTS "
+        "VALUES (CASE WHEN EXISTS "
         + "(SELECT table_name FROM definition_schema.tables) "
-        + "THEN 1 ELSE 0 END",
+        + "THEN 1 ELSE 0 END)",
         yields: [[1]])
   }
 
@@ -1912,9 +1908,9 @@ struct FromlessScalarReservedRelationTests {
     // The schema path shares the same augment, so `columns(of:validate:)`
     // resolves the subquery-only reserved relation exactly as the run does.
     let query = try parse(query:
-        "SELECT CASE WHEN EXISTS "
+        "VALUES (CASE WHEN EXISTS "
         + "(SELECT table_name FROM definition_schema.tables) "
-        + "THEN 1 ELSE 0 END")
+        + "THEN 1 ELSE 0 END)")
     let columns = try fixture().columns(of: query, validate: true)
     #expect(columns.count == 1)
   }

--- a/Tests/SQLTests/Queries/SubqueryTests.swift
+++ b/Tests/SQLTests/Queries/SubqueryTests.swift
@@ -830,15 +830,6 @@ struct ExistsProbeTests {
                          fails: .divide)
   }
 
-  @Test func `EXISTS over a FROM-less SELECT is TRUE`() throws {
-    // A FROM-less `SELECT 1` yields exactly one row and cannot carry a limit,
-    // so its probe is a limit-free `SELECT <constant>` — it compiles (a
-    // FROM-less select with a limit would be rejected) and yields one row, so
-    // `EXISTS` is TRUE and every outer row is admitted.
-    try fixture().expect("SELECT Id FROM T WHERE EXISTS (SELECT 1)",
-                         yields: [[1], [2]])
-  }
-
   @Test func `EXISTS honours a FETCH FIRST 0 ROWS limit as FALSE`() throws {
     // The probe keeps the subquery's original `FETCH FIRST 0 ROWS ONLY`, so the
     // row source yields zero rows and `EXISTS` is FALSE — a synthetic one-row

--- a/Tests/SQLTests/Queries/ValuesTests.swift
+++ b/Tests/SQLTests/Queries/ValuesTests.swift
@@ -317,52 +317,6 @@ struct ValuesTests {
     try store().expect("VALUES (1) FETCH FIRST 1 ROWS ONLY", yields: [[1]])
   }
 
-  @Test func `a parenthesized FROM-less operand pages before a union`() throws {
-    // A parenthesised FROM-less operand carries its own FETCH, applied before
-    // the union: `FETCH FIRST 0 ROWS ONLY` drops its single row, leaving only
-    // the other arm. The cap sits below the projection, so a throwing select
-    // list on the dropped row never runs.
-    try store().expect(
-        "(SELECT 1 FETCH FIRST 0 ROWS ONLY) UNION ALL SELECT 2",
-        yields: [[2]])
-    try store().expect(
-        "(SELECT 1 / 0 FETCH FIRST 0 ROWS ONLY) UNION ALL SELECT 2",
-        yields: [[2]])
-  }
-
-  @Test func `a FROM-less OFFSET spares an unreachable throwing projection`()
-      throws {
-    // A positive OFFSET (with no ORDER BY, non-DISTINCT) pages out the single
-    // row below the projection, so a throwing select list never evaluates: the
-    // run yields no rows AND the schema derive treats the FROM-less result as
-    // single-row, so it marks the projection unreachable and does not validate
-    // it — neither faults (run ≡ columns(of:)).
-    try store().empty("SELECT 1 / 0 OFFSET 1 ROWS")
-    let columns = try store().columns(of:
-        parse(query: "SELECT 1 / 0 OFFSET 1 ROWS"), routines: .standard,
-        validate: true)
-    #expect(columns.count == 1)
-  }
-
-  @Test func `a FROM-less DISTINCT projects below the OFFSET so it still runs`()
-      throws {
-    // DISTINCT is the exception: its plan is `Limit(Distinct(Project(single)))`,
-    // so the projection evaluates over the single row (dedup needs it) before
-    // the OFFSET pages the result. A throwing select list therefore faults at
-    // run, and the derive validates the reachable projection alike — both raise
-    // `SQLError.divide`.
-    try store().expect("SELECT DISTINCT 1 / 0 OFFSET 1 ROWS", fails: .divide)
-    var raised: SQLError? = nil
-    do {
-      _ = try store().columns(of:
-          parse(query: "SELECT DISTINCT 1 / 0 OFFSET 1 ROWS"),
-          routines: .standard, validate: true)
-    } catch let error as SQLError {
-      raised = error
-    }
-    #expect(raised == .divide)
-  }
-
   @Test func `a FROM-less ORDER BY faults on an unresolvable key`() throws {
     // With no source relation an ORDER BY key that is neither an ordinal in
     // range nor an output alias has nothing to bind, so it faults — the same

--- a/Tests/SQLTests/Queries/ValuesTests.swift
+++ b/Tests/SQLTests/Queries/ValuesTests.swift
@@ -187,18 +187,19 @@ struct ValuesTests {
     // `(VALUES (1))` is a query, so it is a first-class scalar subquery: a
     // one-row one-column constructor yields that single scalar, exactly as
     // `(SELECT …)` does. The parse must route the parenthesised `VALUES` to the
-    // query parser, not the value-expression parser.
-    let query = try parse(query: "SELECT (VALUES (1)) AS x")
-    guard case let .select(select) = query.body,
-          case let .expressions(items) = select.projection else {
-      Issue.record("expected an expression projection")
+    // query parser, not the value-expression parser — here nested as the
+    // element of an outer `VALUES` row.
+    let query = try parse(query: "VALUES ((VALUES (1)))")
+    guard case let .values(rows) = query.body, let row = rows.first,
+          row.count == 1 else {
+      Issue.record("expected a single-element VALUES row")
       return
     }
-    guard case .subquery = items[0].expression else {
+    guard case .subquery = row[0] else {
       Issue.record("expected a scalar subquery expression")
       return
     }
-    try store().expect("SELECT (VALUES (1)) AS x", yields: [[1]])
+    try store().expect("VALUES ((VALUES (1)))", yields: [[1]])
   }
 
   @Test func `VALUES is an IN-subquery`() throws {
@@ -441,7 +442,7 @@ struct ValuesTests {
     try store().expect(
         "SELECT column1 FROM (VALUES (3), (1), (2) ORDER BY 1) AS t",
         yields: [[1], [2], [3]])
-    try store().expect("SELECT (VALUES (5) ORDER BY 1) AS x", yields: [[5]])
+    try store().expect("VALUES ((VALUES (5) ORDER BY 1))", yields: [[5]])
     try roster().expect(
         "SELECT Id FROM People WHERE Id IN (VALUES (3), (1) ORDER BY 1)",
         yields: [[1], [3]])

--- a/Tests/SQLTests/Queries/ValuesTests.swift
+++ b/Tests/SQLTests/Queries/ValuesTests.swift
@@ -376,12 +376,52 @@ struct ValuesTests {
   @Test func `a standalone multi-row VALUES takes a query-expression tail`()
       throws {
     // A trailing ORDER BY / OFFSET·FETCH after a `VALUES (…), …` binds to the
-    // enclosing query expression (the multi-row constructor is a `UNION ALL`,
-    // so the tail rides an output-scoped carrier) — ordering/paging the rows.
+    // enclosing query expression — the tail rides an output-scoped carrier over
+    // the `.values` body, resolving and paging its output rows.
     try store().expect("VALUES (3), (1), (2) ORDER BY 1",
                        yields: [[1], [2], [3]])
     try store().expect("VALUES (3), (1), (2) ORDER BY 1 OFFSET 1 ROWS",
                        yields: [[2], [3]])
+  }
+
+  @Test func `a VALUES carrier orders by an output name and a direction`()
+      throws {
+    // The carrier resolves an `ORDER BY` key against the constructor's default
+    // output names (`column1, …`), and honours a per-key `DESC`, exactly as it
+    // does over a set operation's output.
+    try store().expect("VALUES (3), (1), (2) ORDER BY column1",
+                       yields: [[1], [2], [3]])
+    try store().expect("VALUES (3), (1), (2) ORDER BY column1 DESC",
+                       yields: [[3], [2], [1]])
+  }
+
+  @Test func `a VALUES carrier pages with OFFSET and FETCH`() throws {
+    // OFFSET and FETCH FIRST n ROWS slice the ordered constructor rows.
+    try store().expect(
+        "VALUES (3), (1), (2) ORDER BY 1 FETCH FIRST 2 ROWS ONLY",
+        yields: [[1], [2]])
+    try store().expect("""
+        VALUES (5), (4), (3), (2), (1) ORDER BY 1 OFFSET 1 ROWS
+        FETCH FIRST 2 ROWS ONLY
+        """, yields: [[2], [3]])
+    try store().empty("VALUES (1), (2) ORDER BY 1 FETCH FIRST 0 ROWS ONLY")
+  }
+
+  @Test func `a multi-column VALUES carrier orders by a later ordinal`()
+      throws {
+    // A two-column constructor orders on its second output column by ordinal,
+    // the carrier resolving the key over the values output slot space.
+    try store().expect("VALUES (1, 3), (2, 1), (3, 2) ORDER BY 2",
+                       yields: [[2, 1], [3, 2], [1, 3]])
+  }
+
+  @Test func `a SELECT DISTINCT over a derived VALUES deduplicates`() throws {
+    // DISTINCT collapses the constructor's duplicate rows when a `SELECT
+    // DISTINCT` reads them through a derived table, keeping the first of each.
+    try store().expect(
+        "SELECT DISTINCT column1 FROM (VALUES (1), (1), (2), (1)) AS t "
+            + "ORDER BY column1",
+        yields: [[1], [2]])
   }
 
   @Test func `a parenthesized VALUES operand carries its tail before a union`()
@@ -439,6 +479,149 @@ struct ValuesTests {
     // cell as before, so the division still faults.
     try store().expect("VALUES (1 / 0)", fails: .divide)
     try store().expect("SELECT * FROM (VALUES (1 / 0)) AS t", fails: .divide)
+  }
+
+  // MARK: - Carrier limit sparing
+
+  @Test func `a VALUES carrier limit spares a discarded row's cell`() throws {
+    // A carried `OFFSET`/`FETCH` with no ORDER BY and no DISTINCT applies its
+    // positional page at compile time, slicing the constructor's rows before
+    // their cells lower — so a row the page discards never evaluates. A
+    // `FETCH FIRST 0 ROWS` keeps none and an `OFFSET` past the sole row keeps
+    // none, so the would-fault `1 / 0` never divides and the run is empty, not
+    // a fault.
+    try store().empty("VALUES (1 / 0) FETCH FIRST 0 ROWS ONLY")
+    try store().empty("VALUES (1 / 0) OFFSET 1 ROWS")
+    // The `validate: true` derive pages the same discarded rows through the
+    // same slice, value-checking only the rows the run evaluates — so it agrees
+    // with the run and does not fault the discarded `1 / 0`. Its reachability
+    // now matches a `FETCH FIRST 0 ROWS` SELECT, whose projection is unreachable
+    // (and non-faulting) under a page that keeps no row.
+    #expect(fault(deriving:
+        try parse(query: "VALUES (1 / 0) FETCH FIRST 0 ROWS ONLY")) == nil)
+    #expect(fault(deriving:
+        try parse(query: "VALUES (1 / 0) OFFSET 1 ROWS")) == nil)
+    // The result schema is unaffected: it types the constructor's columns off
+    // all the AST rows without building the carrier plan, so a carried
+    // constructor still advertises the ISO default `column1` output at its
+    // unified type.
+    let columns = try store().columns(of:
+        parse(query: "VALUES (2), (3) FETCH FIRST 0 ROWS ONLY"),
+        routines: .standard, validate: true)
+    #expect(columns.map(\.name) == ["column1"])
+    #expect(columns.map(\.type) == [.integer])
+  }
+
+  @Test func `a VALUES carrier limit still evaluates a surviving row`()
+      throws {
+    // The sparing is the limit's, not a blanket suppression: a row the page
+    // keeps still evaluates its cells. `FETCH FIRST 1 ROW` over `(2), (1 / 0)`
+    // keeps the safe row 0 and drops the faulting row 1 — `[2]`, no fault — but
+    // over `(1 / 0), (2)` keeps the faulting row 0, so the division faults. An
+    // `OFFSET 1` over `(1 / 0), (2)` drops the faulting row 0 and keeps row 1 —
+    // `[2]`, no fault.
+    try store().expect("VALUES (2), (1 / 0) FETCH FIRST 1 ROW ONLY",
+                       yields: [[2]])
+    try store().expect("VALUES (1 / 0), (2) FETCH FIRST 1 ROW ONLY",
+                       fails: .divide)
+    try store().expect("VALUES (1 / 0), (2) OFFSET 1 ROWS", yields: [[2]])
+    // The validate derive pages the same rows and agrees row for row: it spares
+    // the discarded `1 / 0` and faults the surviving one.
+    #expect(fault(deriving:
+        try parse(query: "VALUES (2), (1 / 0) FETCH FIRST 1 ROW ONLY")) == nil)
+    #expect(fault(deriving:
+        try parse(query: "VALUES (1 / 0), (2) FETCH FIRST 1 ROW ONLY"))
+        == .divide)
+    #expect(fault(deriving:
+        try parse(query: "VALUES (1 / 0), (2) OFFSET 1 ROWS")) == nil)
+  }
+
+  @Test func `an ORDER BY VALUES carrier evaluates every row before paging`()
+      throws {
+    // An ORDER BY must materialise and sort every row before the page applies,
+    // so the compile-time slice does not engage — the eager `.values` leaf
+    // evaluates every cell. `VALUES (1 / 0) ORDER BY 1 FETCH FIRST 0 ROWS` thus
+    // still divides and faults, even though the page keeps no row.
+    try store().expect("VALUES (1 / 0) ORDER BY 1 FETCH FIRST 0 ROWS ONLY",
+                       fails: .divide)
+    // The ORDER BY carrier is eager on both paths: the validate derive stops
+    // the peel at it and value-checks every row, so it faults the division too.
+    #expect(fault(deriving: try parse(query:
+        "VALUES (1 / 0) ORDER BY 1 FETCH FIRST 0 ROWS ONLY")) == .divide)
+  }
+
+  @Test func `a DISTINCT VALUES carrier evaluates every row before paging`()
+      throws {
+    // A DISTINCT carrier must evaluate every row to deduplicate it, so the
+    // compile-time slice is gated off for it too — the `.values` leaf stays
+    // eager under the dedup. A hand-built distinct carrier (the parser emits
+    // `distinct: false`, so this is the public-AST path) over `VALUES (1 / 0)`
+    // with a `FETCH FIRST 0 ROWS` still faults, proving the sparing is
+    // DISTINCT-gated, not a general suppression of cell evaluation.
+    let query = Query(body: try parse(query: "VALUES (1 / 0)").body,
+                      carriers: [Query.Carrier(distinct: true, order: nil,
+                                               limit: Limit(count: 0),
+                                               generated: 0)])
+    #expect(fault(running: query) == .divide)
+  }
+
+  @Test func `a VALUES set operation evaluates every row`() throws {
+    // A `UNION` is a set operation, not a carrier, so its arms materialise in
+    // full — the compile-time carrier slice never reaches it. `VALUES (1 / 0)
+    // UNION VALUES (2)` therefore evaluates the faulting cell and divides,
+    // confirming the sparing is limit-carrier-gated.
+    try store().expect("VALUES (1 / 0) UNION VALUES (2)", fails: .divide)
+  }
+
+  @Test func `a VALUES carrier limit never hides a discarded row's arity`()
+      throws {
+    // The compile-time slice pages only the value-validation, never the
+    // arity/degree derivation — the ISO equal-degree rule holds over all the
+    // rows, independent of the page (the result schema is limit-independent,
+    // and the run arity-checks every row before its own slice). A `FETCH FIRST
+    // 1 ROW` that discards the malformed second row still faults the cross-row
+    // arity mismatch — a structural fault, not a value one — on both the run
+    // and the validate path, exactly as it does with no carrier.
+    try store().expect("VALUES (1), (2, 3) FETCH FIRST 1 ROW ONLY",
+                       fails: .arity(1, 2))
+    #expect(fault(deriving:
+        try parse(query: "VALUES (1), (2, 3) FETCH FIRST 1 ROW ONLY"))
+        == .arity(1, 2))
+  }
+
+  @Test func `a VALUES carrier limit trims a generated column`() throws {
+    // A public `Query.Carrier` may combine a nonzero `generated` with a limit
+    // over a wider `.values` — the parser only ever emits `generated: 0`, so
+    // this is the hand-built-AST path. The carrier's compile-time row slice
+    // pages the rows positionally, but must still trim the trailing `generated`
+    // hidden columns, exactly as the schema path does (`columns(unifying:)`
+    // drops them through `cols.prefix(real)`): the slice returns the `.values`
+    // leaf directly, so without the trim the run yields all `width` columns
+    // where `columns(of:)` advertises `width − generated` — a run ≠ schema
+    // split. Over a two-column `VALUES` with `generated: 1` and a `FETCH FIRST
+    // 1 ROW` limit, both the derive and the run resolve to one column.
+    let carrier = Query.Carrier(distinct: false, order: nil,
+                                limit: Limit(count: 1), generated: 1)
+    let query = Query(body: try parse(query: "VALUES (1, 2), (3, 4)").body,
+                      carriers: [carrier])
+    let columns = try store().columns(of: query, routines: .standard,
+                                      validate: true)
+    #expect(columns.count == 1)
+    let rows = try store().run(query, .standard)
+    // The limit keeps the first row and the trim drops its second column, so
+    // the run yields the single leading cell — the same one-column arity the
+    // derive advertises.
+    #expect(rows == [[.integer(1)]])
+    #expect(rows.first?.count == columns.count)
+
+    // The trim rides above the positional slice, not instead of it: the limit
+    // still spares a discarded row's cell. `FETCH FIRST 1 ROW` keeps only the
+    // first row, so a would-fault `1 / 0` in the dropped second row never
+    // evaluates — the run does not fault and yields the surviving leading cell.
+    let spared = Query(body: try parse(query: "VALUES (1, 2), (1 / 0, 4)").body,
+                       carriers: [carrier])
+    #expect(fault(running: spared) == nil)
+    #expect(try store().run(spared, .standard) == [[.integer(1)]])
   }
 
   // MARK: - Malformed hand-built nodes

--- a/Tests/SQLTests/Queries/ValuesTests.swift
+++ b/Tests/SQLTests/Queries/ValuesTests.swift
@@ -9,11 +9,11 @@ import func SQLTestSupport.parse
 
 // MARK: - VALUES
 
-/// The ISO `VALUES (…), …` table value constructor desugars to a `UNION ALL` of
-/// FROM-less constant `SELECT`s. These tests confirm it yields its rows in
-/// order, names the default `column1, column2, …` outputs, works standalone and
-/// as a derived table, preserves duplicate rows, composes with a set operation,
-/// and faults on a cross-row arity mismatch.
+/// The ISO `VALUES (…), …` table value constructor is a first-class query body
+/// (`Query.Body.values`). These tests confirm it parses to that node, yields
+/// its rows in order, names the default `column1, column2, …` outputs, works
+/// standalone and as a derived table, preserves duplicate rows, composes with a
+/// set operation, and faults on a cross-row arity mismatch.
 struct ValuesTests {
   /// A minimal catalog for the FROM-less `VALUES` runs — the constructor names
   /// no relation, so its single one-element relation is never scanned; the run
@@ -26,51 +26,58 @@ struct ValuesTests {
     }
   }
 
-  // MARK: - Desugar shape
-
-  @Test func `VALUES desugars to a UNION ALL of FROM-less SELECTs`() throws {
-    // `VALUES (1, 2), (3, 4)` lowers to `SELECT 1 AS column1, 2 AS column2
-    // UNION ALL SELECT 3, 4` — a `.setop(.union, …, all: true)` whose first arm
-    // is FROM-less and aliases the default output names.
-    let query = try parse(query: "VALUES (1, 2), (3, 4)")
-    guard case let .setop(kind, left, right, all) = query.body else {
-      Issue.record("expected a UNION ALL set operation")
-      return
+  /// The `SQLError` running a hand-built `query` against a fresh store raises,
+  /// or nil — the eager form the borrowed `~Escapable` catalog needs (it cannot
+  /// be captured by an `#expect(throws:)` closure).
+  private func fault(running query: Query) -> SQLError? {
+    do {
+      _ = try store().run(query, .standard)
+      return nil
+    } catch let error as SQLError {
+      return error
+    } catch {
+      return nil
     }
-    #expect(kind == .union)
-    #expect(all)
-
-    guard case let .select(head) = left.body,
-          case let .expressions(items) = head.projection else {
-      Issue.record("expected a FROM-less expression projection as the head arm")
-      return
-    }
-    #expect(head.from == nil)
-    #expect(items.map(\.alias) == ["column1", "column2"])
-    #expect(items.map(\.expression) == [.literal(.integer(1)),
-                                        .literal(.integer(2))])
-
-    // The trailing arm projects the bare expressions — a set operation names
-    // its result from the first arm alone, so a later arm carries no aliases.
-    guard case let .select(tail) = right.body,
-          case let .expressions(later) = tail.projection else {
-      Issue.record("expected a FROM-less expression projection as the tail arm")
-      return
-    }
-    #expect(tail.from == nil)
-    #expect(later.map(\.alias) == [nil, nil])
   }
 
-  @Test func `a single-row VALUES is one FROM-less SELECT`() throws {
-    // With one row there is no set operation — the desugar is the single arm.
-    let query = try parse(query: "VALUES (1, 2)")
-    guard case let .select(select) = query.body,
-          case let .expressions(items) = select.projection else {
-      Issue.record("expected a single FROM-less SELECT")
+  /// The `SQLError` deriving (validate) a hand-built `query`'s columns against
+  /// a fresh store raises, or nil.
+  private func fault(deriving query: Query) -> SQLError? {
+    do {
+      _ = try store().columns(of: query, routines: .standard, validate: true)
+      return nil
+    } catch let error as SQLError {
+      return error
+    } catch {
+      return nil
+    }
+  }
+
+  // MARK: - Node shape
+
+  @Test func `VALUES parses to a first-class values node`() throws {
+    // `VALUES (1, 2), (3, 4)` parses directly to the `.values` body — one row
+    // per parenthesised tuple, holding the bare element expressions in source
+    // order — rather than a `UNION ALL` of FROM-less selects.
+    let query = try parse(query: "VALUES (1, 2), (3, 4)")
+    guard case let .values(rows) = query.body else {
+      Issue.record("expected a values body")
       return
     }
-    #expect(select.from == nil)
-    #expect(items.map(\.alias) == ["column1", "column2"])
+    #expect(rows == [[.literal(.integer(1)), .literal(.integer(2))],
+                     [.literal(.integer(3)), .literal(.integer(4))]])
+    // Carrier-free — a bare constructor carries no query-level tail.
+    #expect(query.carriers.isEmpty)
+  }
+
+  @Test func `a single-row VALUES is a one-row values node`() throws {
+    // With one row the node holds a single tuple.
+    let query = try parse(query: "VALUES (1, 2)")
+    guard case let .values(rows) = query.body else {
+      Issue.record("expected a values body")
+      return
+    }
+    #expect(rows == [[.literal(.integer(1)), .literal(.integer(2))]])
   }
 
   // MARK: - Standalone
@@ -217,6 +224,35 @@ struct ValuesTests {
     try roster().expect(
         "SELECT Id FROM People WHERE Age = ANY (VALUES (30), (40))",
         yields: [[1], [3], [4]])
+  }
+
+  @Test func `VALUES is an EXISTS subquery`() throws {
+    // `EXISTS (VALUES (1))` tests the constructor's non-emptiness — a one-row
+    // constructor is always non-empty, so the EXISTS holds for every outer row.
+    try roster().expect(
+        "SELECT Id FROM People WHERE EXISTS (VALUES (1)) ORDER BY Id",
+        yields: [[1], [2], [3], [4], [5]])
+  }
+
+  // MARK: - CTE body
+
+  @Test func `VALUES is a CTE body`() throws {
+    // A `WITH t(a, b) AS (VALUES …)` binds the constructor's rows under the
+    // CTE's declared columns, so the trailing query reads them by name.
+    let rows = try store().run(Statement(parsing: """
+        WITH t(a, b) AS (VALUES (1, 2), (3, 4)) SELECT b, a FROM t
+        """), .standard)
+    #expect(rows == [[.integer(2), .integer(1)],
+                     [.integer(4), .integer(3)]])
+  }
+
+  @Test func `a VALUES CTE body infers the default column names`() throws {
+    // Without an explicit column list the CTE inherits the constructor's ISO
+    // default `column1, column2, …` output names.
+    let rows = try store().run(Statement(parsing: """
+        WITH t AS (VALUES (5, 6)) SELECT column1, column2 FROM t
+        """), .standard)
+    #expect(rows == [[.integer(5), .integer(6)]])
   }
 
   @Test func `an incompatible mixed VALUES column faults`() throws {
@@ -369,5 +405,68 @@ struct ValuesTests {
     try roster().expect(
         "SELECT Id FROM People WHERE Id IN (VALUES (3), (1) ORDER BY 1)",
         yields: [[1], [3]])
+  }
+
+  // MARK: - EXISTS cardinality probe
+
+  @Test func `an EXISTS VALUES probe evaluates no row cell`() throws {
+    // `EXISTS (VALUES …)` reads only the constructor's cardinality, so its cell
+    // expressions never evaluate — the probe rewrites each row to a cheap
+    // constant, preserving the row count. A would-fault `1 / 0` cell therefore
+    // never divides: the one-row constructor is non-empty, so EXISTS holds for
+    // every outer row. The schema derive types the row without evaluating it.
+    try roster().expect(
+        "SELECT Id FROM People WHERE EXISTS (VALUES (1 / 0)) ORDER BY Id",
+        yields: [[1], [2], [3], [4], [5]])
+    _ = try roster().columns(of:
+        parse(query: "SELECT Id FROM People WHERE EXISTS (VALUES (1 / 0))"),
+        routines: .standard, validate: true)
+  }
+
+  @Test func `a multi-row EXISTS VALUES probe evaluates no cell`() throws {
+    // The probe preserves the row count, not the cells: a two-row `VALUES (1 /
+    // 0), (2)` probes a two-row constant constructor — EXISTS true, no cell
+    // (neither the faulting `1 / 0` nor the `2`) evaluated.
+    try roster().expect(
+        "SELECT Id FROM People WHERE EXISTS (VALUES (1 / 0), (2)) ORDER BY Id",
+        yields: [[1], [2], [3], [4], [5]])
+  }
+
+  @Test func `a non-EXISTS VALUES still evaluates its cell and faults`()
+      throws {
+    // The probe rewrite is EXISTS-only, not a general suppression: a `VALUES (1
+    // / 0)` reached as a top-level query or as a derived table evaluates its
+    // cell as before, so the division still faults.
+    try store().expect("VALUES (1 / 0)", fails: .divide)
+    try store().expect("SELECT * FROM (VALUES (1 / 0)) AS t", fails: .divide)
+  }
+
+  // MARK: - Malformed hand-built nodes
+
+  @Test func `an empty VALUES node faults on run and validate`() throws {
+    // `Query`/`Query.Body` are public, so a caller can hand-build a `VALUES`
+    // with no rows — a shape the parser (≥ 1 row) never emits. The single
+    // deriver both the run and `columns(of: validate:)` reach rejects it with a
+    // typed `42601`, rather than silently deriving an empty relation.
+    let empty = Query(body: .values([]))
+    #expect(fault(running: empty)?.sqlstate == "42601")
+    #expect(fault(deriving: empty)?.sqlstate == "42601")
+  }
+
+  @Test func `a zero-column VALUES row faults on run and validate`() throws {
+    // A single zero-column row (`VALUES ()`, which the parser also rejects) is
+    // faulted alike — a query yielding a zero-column relation is not a valid
+    // shape — on both the run and the validate path.
+    let bare = Query(body: .values([[]]))
+    #expect(fault(running: bare)?.sqlstate == "42601")
+    #expect(fault(deriving: bare)?.sqlstate == "42601")
+  }
+
+  @Test func `a well-formed hand-built VALUES node runs`() throws {
+    // A hand-built node with rows and columns is unaffected by the guard.
+    let node = Query(body: .values([[.literal(.integer(1))],
+                                    [.literal(.integer(2))]]))
+    let rows = try store().run(node, .standard)
+    #expect(rows == [[.integer(1)], [.integer(2)]])
   }
 }

--- a/Tests/SQLTests/Schema/IntrospectionTests.swift
+++ b/Tests/SQLTests/Schema/IntrospectionTests.swift
@@ -451,7 +451,7 @@ struct IntrospectionTests {
     // The overlay sits after the CTEs: a `WITH` binding the reserved name wins,
     // so the query reads the CTE's rows, not the enumerated metadata.
     let rows = try catalog().run(Statement(parsing: """
-        WITH "information_schema.tables" (x) AS (SELECT 1)
+        WITH "information_schema.tables" (x) AS (VALUES (1))
           SELECT x FROM "information_schema.tables"
         """))
     #expect(rows == [[.integer(1)]])
@@ -1065,8 +1065,8 @@ struct IntrospectionTests {
 
   @Test func `columns(of:) rejects statically-overflowing literal arithmetic`() throws {
     let cat = MetaCatalog(["People": MetaRelation([("Age", .integer)], [])])
-    // Both operands literal, so the result overflows on every row (a FROM-less
-    // SELECT at once); the schema rejects it rather than advertise a column.
+    // Both operands literal, so the result overflows on every row (a constant
+    // folded at once); the schema rejects it rather than advertise a column.
     #expect(throws: SQLError.self) {
       let _ = try cat.columns(of:
           parse(query: "SELECT 9223372036854775807 + 1 AS x FROM People"))
@@ -1285,7 +1285,7 @@ struct IntrospectionTests {
 
   @Test func `a user CTE shadows the definition_schema store`() throws {
     let rows = try catalog().run(Statement(parsing: """
-        WITH "definition_schema.tables" (x) AS (SELECT 1)
+        WITH "definition_schema.tables" (x) AS (VALUES (1))
           SELECT x FROM "definition_schema.tables"
         """))
     #expect(rows == [[.integer(1)]])

--- a/Tests/SQLTests/Schema/OutputSchemaTests.swift
+++ b/Tests/SQLTests/Schema/OutputSchemaTests.swift
@@ -230,27 +230,27 @@ struct OutputSchemaTests {
   @Test func `a UNION widens a mixed integer/double column to double`() throws {
     // ISO unifies the result column type across the arms — an `integer` arm and
     // a `double` arm widen to `double` (the name still the first arm's).
-    let columns = try schema("SELECT 1 UNION SELECT 2.5")
+    let columns = try schema("VALUES (1) UNION VALUES (2.5)")
     #expect(columns.count == 1)
-    #expect(columns[0] == ("column 1", .double))
+    #expect(columns[0] == ("column1", .double))
   }
 
   @Test func `a chained UNION widens across every arm`() throws {
     // A left-associative 3-arm chain folds its types pairwise, so a `double`
     // tail widens the whole column even where the leading arms are `integer`.
-    let columns = try schema("SELECT 1 UNION SELECT 2 UNION SELECT 3.5")
+    let columns = try schema("VALUES (1) UNION VALUES (2) UNION VALUES (3.5)")
     #expect(columns.count == 1)
-    #expect(columns[0] == ("column 1", .double))
+    #expect(columns[0] == ("column1", .double))
   }
 
   @Test func `a UNION of irreconcilable column types faults`() throws {
     // A text arm beside a number has no common type, so the fold faults
     // `SQLError.operand` (SQLSTATE 42804) rather than typing off the first arm.
     #expect(throws: SQLError.self) {
-      try catalog().columns(of: parse(query: "SELECT 1 UNION SELECT 'x'"))
+      try catalog().columns(of: parse(query: "VALUES (1) UNION VALUES ('x')"))
     }
     #expect(throws: SQLError.self) {
-      try catalog().columns(of: parse(query: "SELECT TRUE UNION SELECT 1"))
+      try catalog().columns(of: parse(query: "VALUES (TRUE) UNION VALUES (1)"))
     }
   }
 
@@ -260,12 +260,12 @@ struct OutputSchemaTests {
     // skip, so the other arm's type wins — a `NULLIF(2, 2)` (constant NULL) arm
     // beside a `double` arm types the column `double`, not the NULLIF arm's
     // `integer`.
-    let leading = try schema("SELECT NULLIF(2, 2) UNION SELECT 2.5")
+    let leading = try schema("VALUES (NULLIF(2, 2)) UNION VALUES (2.5)")
     #expect(leading.count == 1)
     #expect(leading[0].1 == .double)
     // A typed arm beside a trailing constant-NULL arm keeps the typed arm's
     // type.
-    let trailing = try schema("SELECT 1 UNION SELECT NULLIF(2, 2)")
+    let trailing = try schema("VALUES (1) UNION VALUES (NULLIF(2, 2))")
     #expect(trailing.count == 1)
     #expect(trailing[0].1 == .integer)
   }
@@ -280,7 +280,7 @@ struct OutputSchemaTests {
     let star = try schema("""
         SELECT * FROM (SELECT NULLIF(1, 1) AS k FROM People) AS a
           JOIN (SELECT NULLIF(1, 1) AS k FROM People) AS b USING (k)
-          UNION SELECT 'x'
+          UNION VALUES ('x')
         """)
     #expect(star.count == 1)
     #expect(star[0] == ("k", .text))
@@ -291,7 +291,7 @@ struct OutputSchemaTests {
       try catalog().columns(of: parse(query: """
           SELECT * FROM (SELECT Age AS k FROM People) AS a
             JOIN (SELECT Age AS k FROM People) AS b USING (k)
-            UNION SELECT 'x'
+            UNION VALUES ('x')
           """))
     }
   }
@@ -301,7 +301,7 @@ struct OutputSchemaTests {
     // table), which carries its unified `types` from compile — the outer
     // `SELECT *` reports the widened `double` column.
     let columns =
-        try schema("SELECT * FROM (SELECT 1 UNION SELECT 2.5) AS d")
+        try schema("SELECT * FROM (VALUES (1) UNION VALUES (2.5)) AS d")
     #expect(columns.count == 1)
     #expect(columns[0].1 == .double)
   }
@@ -314,7 +314,7 @@ struct OutputSchemaTests {
     // column list). The rename applies after the fold determines the column
     // count and type, so the column is both named `a` and typed `double`.
     let columns =
-        try schema("SELECT d.a FROM (SELECT 1 UNION SELECT 2.5) AS d(a)")
+        try schema("SELECT d.a FROM (VALUES (1) UNION VALUES (2.5)) AS d(a)")
     #expect(columns.count == 1)
     #expect(columns[0] == ("a", .double))
   }
@@ -554,7 +554,7 @@ struct OutputSchemaTests {
     // a CTE `People` shadows the two-column base relation, so a `SELECT *` over
     // it names the CTE's one declared column `x`, not the base's `Name, Age`.
     let columns = try catalog().columns(of: Statement(parsing:
-        "WITH People(x) AS (SELECT 1) SELECT * FROM People"))
+        "WITH People(x) AS (VALUES (1)) SELECT * FROM People"))
     #expect(columns.count == 1)
     #expect(columns[0].name == "x")
   }
@@ -563,7 +563,7 @@ struct OutputSchemaTests {
     // A bare-column projection reads the CTE's declared columns; a two-column
     // CTE heads its two names, no base relation involved.
     let columns = try catalog().columns(of: Statement(parsing:
-        "WITH t(a, b) AS (SELECT 1, 2) SELECT a, b FROM t"))
+        "WITH t(a, b) AS (VALUES (1, 2)) SELECT a, b FROM t"))
     #expect(same(columns.map { ($0.name, $0.type) },
                  [("a", .integer), ("b", .integer)]))
   }
@@ -572,7 +572,7 @@ struct OutputSchemaTests {
     // A CTE whose name does not collide leaves the base `People` reachable — the
     // trailing `SELECT *` resolves its two real columns.
     let columns = try catalog().columns(of: Statement(parsing:
-        "WITH t(x) AS (SELECT 1) SELECT * FROM People"))
+        "WITH t(x) AS (VALUES (1)) SELECT * FROM People"))
     #expect(same(columns.map { ($0.name, $0.type) },
                  [("Name", .text), ("Age", .integer)]))
   }
@@ -664,7 +664,7 @@ struct OutputSchemaTests {
     // `Engine.with` raises before materialising — rather than advertise a schema
     // off the shadowing definition.
     let statement = try Statement(parsing:
-        "WITH t(a) AS (SELECT 1), T(b) AS (SELECT 2) SELECT * FROM t")
+        "WITH t(a) AS (VALUES (1)), T(b) AS (VALUES (2)) SELECT * FROM t")
     #expect(throws: SQLError.redefinition("T")) {
       let _ = try catalog().columns(of: statement, validate: true)
     }
@@ -677,7 +677,7 @@ struct OutputSchemaTests {
     // the CTE, and the trailing query names the CTE's declared column `n`.
     let statement = try Statement(parsing: """
         WITH RECURSIVE t(n) AS (
-          SELECT 1 UNION SELECT n + 1 FROM t
+          VALUES (1) UNION SELECT n + 1 FROM t
         ) SELECT n FROM t
         """)
     let columns = try catalog().columns(of: statement, validate: true)
@@ -740,7 +740,7 @@ struct OutputSchemaTests {
     // per-arm operand check accepts exactly what a run does.
     let statement = try Statement(parsing: """
         WITH RECURSIVE Counter(n) AS (
-          SELECT 1 UNION SELECT n + 1 FROM Counter
+          VALUES (1) UNION SELECT n + 1 FROM Counter
         ) SELECT n FROM Counter
         """)
     let columns = try catalog().columns(of: statement, validate: true)
@@ -848,7 +848,7 @@ struct CTEProducerParityTests {
     // `fixpoint` — so all three agree on one integer column `n`.
     let t = try Triple("""
         WITH RECURSIVE t(n) AS (
-          SELECT 1 UNION SELECT n + 1 FROM t WHERE n < 3
+          VALUES (1) UNION SELECT n + 1 FROM t WHERE n < 3
         ) SELECT n FROM t
         """)
     #expect(pairs(t.run).map { same($0, [("n", .integer)]) } == true)
@@ -868,7 +868,7 @@ struct CTEProducerParityTests {
     // the one integer column `n`.
     let t = try Triple("""
         WITH RECURSIVE t(n) AS (
-          SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1
+          VALUES (1) UNION ALL SELECT n + 1 FROM t WHERE n < 3 ORDER BY 1
         ) SELECT n FROM t
         """)
     #expect(pairs(t.run).map { same($0, [("n", .integer)]) } == true)
@@ -883,7 +883,7 @@ struct CTEProducerParityTests {
     // to it, the derives type the declared column at it.
     let t = try Triple("""
         WITH RECURSIVE t(n) AS (
-          SELECT 1 UNION SELECT n + 0.5 FROM t WHERE n < 3
+          VALUES (1) UNION SELECT n + 0.5 FROM t WHERE n < 3
         ) SELECT n FROM t
         """)
     #expect(pairs(t.run).map { same($0, [("n", .double)]) } == true)
@@ -896,7 +896,7 @@ struct CTEProducerParityTests {
     // A non-recursive UNION body of an `integer` and a `double` arm folds to a
     // `.double` column on every path — the producer's `kinds` fold and the
     // run's `run`-then-`kinds` re-derive read the same `merge`.
-    let t = try Triple("WITH a(x) AS (SELECT 1 UNION SELECT 2.5) " +
+    let t = try Triple("WITH a(x) AS (VALUES (1) UNION VALUES (2.5)) " +
                        "SELECT x FROM a")
     #expect(pairs(t.run).map { same($0, [("x", .double)]) } == true)
     #expect(t.run == t.lenient)
@@ -910,7 +910,8 @@ struct CTEProducerParityTests {
     // recogniser sees a non-recursive CTE and falls through to the unifying
     // fold, whose `.ordered` case peels the carrier transparently — the
     // regression guard for the fall-through side of the carrier peel.
-    let t = try Triple("WITH a(x) AS (SELECT 1 UNION SELECT 2.5 ORDER BY 1) " +
+    let t = try Triple("WITH a(x) AS " +
+                       "(VALUES (1) UNION VALUES (2.5) ORDER BY 1) " +
                        "SELECT x FROM a")
     #expect(pairs(t.run).map { same($0, [("x", .double)]) } == true)
     #expect(t.run == t.lenient)
@@ -923,7 +924,7 @@ struct CTEProducerParityTests {
     // faults `.operand` (42804) — through the producer's shared `kinds`/`merge`
     // on the derives (a fold that runs regardless of the validate gate) and the
     // run's own fold — the same on all three.
-    let t = try Triple("WITH a(x) AS (SELECT 'b' UNION SELECT 1) " +
+    let t = try Triple("WITH a(x) AS (VALUES ('b') UNION VALUES (1)) " +
                        "SELECT x FROM a")
     let fault = Outcome.fault(.operand("UNION arms have irreconcilable types"))
     #expect(t.run == fault)
@@ -978,7 +979,7 @@ struct CTEProducerParityTests {
     // A case-insensitive redefinition is rejected by the producer's ungated
     // guard — the same `.redefinition` on the run and both derives, lenient
     // included (the guard runs before any validate gate).
-    let t = try Triple("WITH a(x) AS (SELECT 1), A(y) AS (SELECT 2) " +
+    let t = try Triple("WITH a(x) AS (VALUES (1)), A(y) AS (VALUES (2)) " +
                        "SELECT * FROM a")
     let fault = Outcome.fault(.redefinition("A"))
     #expect(t.run == fault)
@@ -993,7 +994,7 @@ struct CTEProducerParityTests {
     // `.double`, so all three paths agree on one `.double` column — proving it
     // threads the growing overlay identically (types, not rows) on both.
     let t = try Triple("""
-        WITH a(x) AS (SELECT 1 UNION SELECT 2.5),
+        WITH a(x) AS (VALUES (1) UNION VALUES (2.5)),
              b(y) AS (SELECT x FROM a)
           SELECT y FROM b
         """)

--- a/Tests/SQLTests/Syntax/ParserDepthTests.swift
+++ b/Tests/SQLTests/Syntax/ParserDepthTests.swift
@@ -46,10 +46,10 @@ struct ParserDepthTests {
     // A handful of nesting levels — well under the limit — parses normally, so
     // the guard never bites a real query. A flat chain iterates rather than
     // recurses, so its length costs no depth.
-    _ = try parse(query: "SELECT " + String(repeating: "(", count: 10) + "1"
-                         + String(repeating: ")", count: 10))
+    _ = try parse(query: "VALUES (" + String(repeating: "(", count: 10) + "1"
+                         + String(repeating: ")", count: 10) + ")")
     _ = try parse(query:
-        "SELECT * FROM (SELECT * FROM (SELECT 1) AS a) AS b")
+        "SELECT * FROM (SELECT * FROM (VALUES (1)) AS a) AS b")
     _ = try parse(query: "SELECT 1 FROM t WHERE ((1 = 1 AND 2 = 2) OR (3 = 3))")
     _ = try parse(query:
         "SELECT 1 FROM t WHERE x IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)")

--- a/Tests/SQLTests/Syntax/ParserTests.swift
+++ b/Tests/SQLTests/Syntax/ParserTests.swift
@@ -36,24 +36,21 @@ private struct Quantifier: Sendable, CustomTestStringConvertible {
   internal let text: String
   internal let distinct: Bool
   internal let columns: Array<Column>?
-  internal let fromless: Bool
 
   internal var testDescription: String { name }
 }
 
 private let kQuantifiers: Array<Quantifier> = [
   Quantifier(name: "plain SELECT", text: "SELECT TypeName FROM TypeDef",
-             distinct: false, columns: nil, fromless: false),
+             distinct: false, columns: nil),
   Quantifier(name: "SELECT DISTINCT",
              text: "SELECT DISTINCT TypeName FROM TypeDef", distinct: true,
-             columns: ["TypeName"], fromless: false),
+             columns: ["TypeName"]),
   Quantifier(name: "SELECT ALL", text: "SELECT ALL TypeName FROM TypeDef",
-             distinct: false, columns: ["TypeName"], fromless: false),
+             distinct: false, columns: ["TypeName"]),
   Quantifier(name: "case-insensitive DISTINCT",
              text: "select distinct TypeName from TypeDef", distinct: true,
-             columns: nil, fromless: false),
-  Quantifier(name: "FROM-less DISTINCT", text: "SELECT DISTINCT 1",
-             distinct: true, columns: nil, fromless: true),
+             columns: nil),
 ]
 
 private struct Direction: Sendable, CustomTestStringConvertible {
@@ -164,9 +161,6 @@ struct SetQuantifierTests {
     #expect(select.distinct == test.distinct)
     if let columns = test.columns {
       #expect(select.projection == .columns(columns))
-    }
-    if test.fromless {
-      #expect(select.from == nil)
     }
   }
 }
@@ -833,50 +827,43 @@ struct ArithmeticTests {
   }
 }
 
-// MARK: - Scalar (FROM-less) SELECT
+// MARK: - SELECT requires a FROM clause
 
-struct ScalarSelectTests {
-  @Test func `parses a FROM-less SELECT with no relation`() throws {
-    let select = try parse(select: "SELECT 1")
-    #expect(select.from == nil)
-    #expect(select.joins.isEmpty)
-    #expect(select.predicate == nil)
-    #expect(select.order == nil)
-    #expect(select.projection
-                == .expressions([Projected(expression: .literal(.integer(1)))]))
-  }
+struct SelectRequiresFromTests {
+  /// The FROM-required diagnostic — a bare `SELECT` with no `FROM` is not in
+  /// the dialect; `VALUES` projects a computed row instead.
+  private static let fromRequired = SQLError.state("42601",
+      "a SELECT requires a FROM clause; use VALUES to project a computed row")
 
-  @Test func `parses a FROM-less arithmetic projection`() throws {
-    let select = try parse(select: "SELECT 1 + 1")
-    let sum = Expression.binary(.add, .literal(.integer(1)),
-                                .literal(.integer(1)))
-    #expect(select.from == nil)
-    #expect(select.projection == .expressions([Projected(expression: sum)]))
-  }
-
-  @Test func `parses a FROM-less multi-column projection`() throws {
-    let select = try parse(select: "SELECT 1, 2")
-    #expect(select.from == nil)
-    #expect(select.projection == .expressions([
-      Projected(expression: .literal(.integer(1))),
-      Projected(expression: .literal(.integer(2))),
-    ]))
-  }
-
-  @Test func `a FROM-less alias names the projected column`() throws {
-    let select = try parse(select: "SELECT 1 + 1 AS two")
-    let sum = Expression.binary(.add, .literal(.integer(1)),
-                                .literal(.integer(1)))
-    #expect(select.projection
-                == .expressions([Projected(expression: sum, alias: "two")]))
-  }
-
-  @Test func `a FROM-less query admits no trailing WHERE`() {
-    // With FROM absent there is no relation to filter, so a WHERE that follows
-    // is trailing input rather than a clause.
-    #expect(throws: SQLError.self) {
-      _ = try Statement(parsing: "SELECT 1 WHERE 1 = 1")
+  @Test func `a bare SELECT with no FROM faults FROM-required`() throws {
+    #expect(throws: SelectRequiresFromTests.fromRequired) {
+      _ = try Statement(parsing: "SELECT 1")
     }
+  }
+
+  @Test func `a SELECT star with no FROM faults FROM-required`() throws {
+    #expect(throws: SelectRequiresFromTests.fromRequired) {
+      _ = try Statement(parsing: "SELECT *")
+    }
+  }
+
+  @Test func `a multi-column SELECT with no FROM faults FROM-required`()
+      throws {
+    #expect(throws: SelectRequiresFromTests.fromRequired) {
+      _ = try Statement(parsing: "SELECT 1, 2")
+    }
+  }
+
+  @Test func `VALUES projects a computed row instead`() throws {
+    // The ISO replacement parses to a values body carrying the row's elements.
+    let query = try parse(query: "VALUES (1 + 1, 2)")
+    guard case let .values(rows) = query.body else {
+      Issue.record("expected a values body")
+      return
+    }
+    let sum = Expression.binary(.add, .literal(.integer(1)),
+                                .literal(.integer(1)))
+    #expect(rows == [[sum, .literal(.integer(2))]])
   }
 }
 

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -1379,7 +1379,8 @@ struct DatabaseSQLTests {
     DatabaseSQLTests.with { catalog in
       let shell = Shell(catalog)
       #expect(shell.headers(of:
-          "WITH TypeDef(x) AS (SELECT 1) SELECT * FROM TypeDef", [[.integer(1)]])
+          "WITH TypeDef(x) AS (VALUES (1)) SELECT * FROM TypeDef",
+          [[.integer(1)]])
           == ["x"])
     }
   }
@@ -1391,10 +1392,10 @@ struct DatabaseSQLTests {
     DatabaseSQLTests.with { catalog in
       let shell = Shell(catalog)
       #expect(shell.headers(of:
-          "WITH t(a, b) AS (SELECT 1, 2) SELECT * FROM t",
+          "WITH t(a, b) AS (VALUES (1, 2)) SELECT * FROM t",
           [[.integer(1), .integer(2)]]) == ["a", "b"])
       #expect(shell.headers(of:
-          "WITH t(a, b) AS (SELECT 1, 2) SELECT b FROM t",
+          "WITH t(a, b) AS (VALUES (1, 2)) SELECT b FROM t",
           [[.integer(2)]]) == ["b"])
     }
   }
@@ -1406,7 +1407,7 @@ struct DatabaseSQLTests {
     DatabaseSQLTests.with { catalog in
       let shell = Shell(catalog)
       #expect(shell.headers(of:
-          "WITH t(x) AS (SELECT 1) SELECT * FROM TypeDef", [])
+          "WITH t(x) AS (VALUES (1)) SELECT * FROM TypeDef", [])
           == ["Flags", "TypeName", "TypeNamespace", "Extends",
               "FieldList", "MethodList"])
     }


### PR DESCRIPTION
This pull request introduces first-class support for the SQL `VALUES` table value constructor in the query AST and compilation pipeline. The main changes extend the query representation, subquery analysis, and carrier logic to treat `VALUES` as a core query body, rather than desugaring it to a `UNION ALL` of FROM-less selects. This also removes support for FROM-less `SELECT` statements, aligning with ISO SQL. The most important changes are grouped below.

### Query AST and Interface Updates

* Added a `.values` case to the `Query` enum to represent the ISO `VALUES` table value constructor, including logic for output column naming, type unification, and arity inference. (`Sources/SQLEngine/AST.swift` [[1]](diffhunk://#diff-b028c0c659a88f917195886aa921556950f9284a42f7cec620e0dc32107a1b86R177-R186) [[2]](diffhunk://#diff-b028c0c659a88f917195886aa921556950f9284a42f7cec620e0dc32107a1b86L232-R310) [[3]](diffhunk://#diff-b028c0c659a88f917195886aa921556950f9284a42f7cec620e0dc32107a1b86L254-R324)
* Removed support for FROM-less `SELECT` statements; `Select.from` is now always required, and related logic and documentation are updated. (`Sources/SQLEngine/AST.swift` [[1]](diffhunk://#diff-b028c0c659a88f917195886aa921556950f9284a42f7cec620e0dc32107a1b86L392-R468) [[2]](diffhunk://#diff-b028c0c659a88f917195886aa921556950f9284a42f7cec620e0dc32107a1b86L428-R498)

### Subquery and Aggregation Analysis

* Extended subquery, aggregation, and role classification logic to handle `VALUES` queries, ensuring all nested expressions are analyzed correctly. (`Sources/SQLEngine/Aggregation.swift` [[1]](diffhunk://#diff-539104e989c7222dc99d8bb3fd6a6303795fc1870ae62a813aa83ac27fc69c21R313) [[2]](diffhunk://#diff-539104e989c7222dc99d8bb3fd6a6303795fc1870ae62a813aa83ac27fc69c21R327-R330) [[3]](diffhunk://#diff-539104e989c7222dc99d8bb3fd6a6303795fc1870ae62a813aa83ac27fc69c21R344-R347) [[4]](diffhunk://#diff-539104e989c7222dc99d8bb3fd6a6303795fc1870ae62a813aa83ac27fc69c21R360-R363) [[5]](diffhunk://#diff-539104e989c7222dc99d8bb3fd6a6303795fc1870ae62a813aa83ac27fc69c21R378-R421)

### Carrier and Compilation Pipeline

* Updated the carrier logic to operate on the leftmost arm as a carrier-free `Query` (not just `Select`), and to use the new `.values` support in all relevant paths. (`Sources/SQLEngine/Carrier.swift` [[1]](diffhunk://#diff-8364ae21df9d2e5ee0cbd8657a2919ba2c8946c7fa77616787b06885df9733acR60-R67) [[2]](diffhunk://#diff-8364ae21df9d2e5ee0cbd8657a2919ba2c8946c7fa77616787b06885df9733acL96-R99) [[3]](diffhunk://#diff-8364ae21df9d2e5ee0cbd8657a2919ba2c8946c7fa77616787b06885df9733acL121-R122) [[4]](diffhunk://#diff-8364ae21df9d2e5ee0cbd8657a2919ba2c8946c7fa77616787b06885df9733acL146-R147) [[5]](diffhunk://#diff-8364ae21df9d2e5ee0cbd8657a2919ba2c8946c7fa77616787b06885df9733acL210-R204) [[6]](diffhunk://#diff-8364ae21df9d2e5ee0cbd8657a2919ba2c8946c7fa77616787b06885df9733acL224-R234)
* Removed the legacy FROM-less `SELECT` scalar compilation path, as `VALUES` now covers this use case. (`Sources/SQLEngine/Compilation.swift` [Sources/SQLEngine/Compilation.swiftL6-L67](diffhunk://#diff-1d95748712863f646081c2955d16e156306cb66552cf7aa429bb5e072e81f6a0L6-L67))

These changes make the query engine more standards-compliant and simplify the handling of constant row sets by treating `VALUES` as a first-class query construct.