### PR TITLE
SQLTestSupport: assert run ≡ validate on the run-faults path

### DIFF
--- a/Sources/SQLEngine/Function.swift
+++ b/Sources/SQLEngine/Function.swift
@@ -54,6 +54,21 @@ public struct Routine: Sendable {
     case defined(Term, Routines)
   }
 
+  /// An opaque per-construction identity token. Every `Routine` initializer
+  /// mints a fresh instance; copying a `Routine` value — an assignment, storing
+  /// it in a `Routines` map, carrying it through `merging(_:)` — shares the
+  /// reference, so two `Routine` values are `same(as:)` exactly when they
+  /// descend from one constructed routine. It has no state and never varies a
+  /// routine's behaviour; it exists only so a consumer can tell one shipped
+  /// routine value from a like-signatured other, which the signature cannot.
+  private final class Identity: Sendable {}
+
+  /// This routine's construction identity — a fresh token per initializer,
+  /// shared by every copy of the value. A caller cannot mint one matching
+  /// another routine's: the only route to a given routine's identity is that
+  /// routine value itself.
+  private let identity = Identity()
+
   /// The declared type of each positional argument, in order — its count the
   /// routine's arity. The static type-check validates a call against this: a
   /// wrong argument count or a definitively-wrong argument type is rejected
@@ -199,6 +214,18 @@ public struct Routine: Sendable {
       // rejects one at registration — so the subquery-free evaluate suffices.
       return try Record(arguments).evaluate(term, routines)
     }
+  }
+
+  /// Whether `other` is the very same routine value as this one — identical by
+  /// construction identity, not by signature. Two routines with matching
+  /// `parameters`/`returns` are not `same` unless one is a copy of the other;
+  /// a copy carried through a `Routines` map or `merging(_:)` is. This is the
+  /// unforgeable test of whether a set's binding for a name is a given
+  /// prelude's shipped routine (`Routines.standard[name]`) rather than a
+  /// caller's like-named replacement — a name and a protection flag cannot
+  /// distinguish those, but a fresh construction identity does.
+  public func same(as other: Routine) -> Bool {
+    identity === other.identity
   }
 }
 

--- a/Sources/SQLTestSupport/Expect.swift
+++ b/Sources/SQLTestSupport/Expect.swift
@@ -23,11 +23,167 @@ import Testing
 /// framework needs no `@testable` import.
 
 extension Catalog where Self: ~Escapable {
-  /// Runs `sql` against this catalog through the given routines and bindings.
+  /// Runs `sql` against this catalog through the given routines and bindings,
+  /// asserting the `run ≡ validate` invariant on the run-faults path (issue
+  /// #116): the validate path (`columns(of:validate:)`) must never advertise a
+  /// schema for a query the run then *structurally* rejects.
+  ///
+  /// The forbidden state is directional: a run fault the schema derive is
+  /// responsible for catching statically — an unknown relation/column/routine,
+  /// a degree/arity mismatch, a non-comparable operand, a malformed or
+  /// unsupported shape — must not coexist with a validate that *succeeded*. A
+  /// data-dependent fault (division by zero, overflow, a scalar subquery's
+  /// cardinality, a routine's own runtime check) is not a violation: validate
+  /// has no rows and rightly succeeds while the run faults on the data, so the
+  /// tripwire fires only when the run fault is `structural`.
+  ///
+  /// The check runs only with no bindings: the validate path deliberately
+  /// skips a bound `x op :parameter` (`Scope.swift`), so a bound run may fault
+  /// where the schema path correctly does not — expected, not a violation. The
+  /// query the run already parsed is reused, and `columns(of:)` is asked with
+  /// the same `routines`, so the two paths see one query and one prelude.
+  ///
+  /// A run through a native routine is exempt too (`native(_:)`): a
+  /// host-registered closure or a defined `CREATE FUNCTION` body may itself
+  /// throw a `structural`-classed fault for particular argument values, while
+  /// `columns(of:)` validates the routine's declared signature without invoking
+  /// the body and legitimately succeeds — an expected run/validate difference
+  /// whose origin is the body, not a schema-derive hole, so the tripwire does
+  /// not fire for a query carrying a non-standard routine.
   private borrowing func run(_ sql: String, routines: Routines,
-                             bindings: Bindings)
+                             bindings: Bindings,
+                             location: Testing.SourceLocation)
       throws(SQLError) -> Array<Array<Value>> {
-    try run(parse(query: sql), routines, bindings: bindings)
+    let query = try parse(query: sql, location: location)
+    do {
+      return try run(query, routines, bindings: bindings)
+    } catch let fault {
+      if bindings.isEmpty, !Self.native(routines), Self.structural(fault),
+         (try? columns(of: query, routines: routines, validate: true)) != nil {
+        Issue.record("""
+          run ≡ validate tripwire: validate accepted a query the run \
+          structurally rejects. sql: \(sql); run fault: \(fault) \
+          (\(fault.sqlstate))
+          """, sourceLocation: location)
+      }
+      throw fault
+    }
+  }
+
+  /// Whether `fault` is a fault the validate/schema path is responsible for
+  /// catching statically — a structural, cardinality-independent fault — as
+  /// opposed to a data-dependent fault a well-formed query legitimately raises
+  /// only on actual row values.
+  ///
+  /// Structural faults (the tripwire fires when a run raises one while validate
+  /// succeeded): the resolution faults a schema derive owns — an unknown
+  /// relation/column/routine, an ambiguous or duplicate name, a degree/arity
+  /// mismatch, a malformed or unsupported query shape, and the static
+  /// grouping/distinct rules. The lexer/parser faults resolve before a query
+  /// exists, so they never reach the tripwire; they are grouped here for
+  /// completeness.
+  ///
+  /// Data-dependent faults (the tripwire does not fire — validate legitimately
+  /// succeeds): a literal or arithmetic magnitude fault, a routine's rejected
+  /// argument, division by zero, a recursive definition exceeding its iteration
+  /// cap, and a scalar subquery's cardinality violation — each depends on
+  /// actual values or row counts a schema derive has none of.
+  ///
+  /// Comparability (`42804`, the datatype-mismatch family — both the arithmetic
+  /// `.operand` and the `.state("42804", …)` compare faults) is *not* firing.
+  /// The schema check catches a direct cross-kind compare, so validate and run
+  /// fault in parity there and the tripwire is never reached; but for a
+  /// subquery / quantified / `IN (Q)` operand the schema check deliberately
+  /// defers to the run (a subquery's single-column type may be a nominal-NULL
+  /// placeholder — validate stays lenient, keeping the run the authority). That
+  /// deferral is a documented soundness choice, not a run ≢ validate hole, so a
+  /// `42804` run fault beside a succeeding validate is expected, not a
+  /// violation.
+  ///
+  /// A `SQLSTATE` passthrough (`.state`) is otherwise classified by class: `42`
+  /// (syntax or access-rule violation, less the deferred `42804`) and `0A`
+  /// (feature not supported) are structural; class `22` (data exception), `54`
+  /// (program limit), and `XX` (internal) are treated as data-dependent. When
+  /// in doubt a code is left data-dependent — a missed structural code only
+  /// lowers the tripwire's sensitivity, whereas a misclassified data-dependent
+  /// code would false-positive the whole suite.
+  private static func structural(_ fault: SQLError) -> Bool {
+    switch fault {
+    case .relation, .column, .ambiguous, .function, .named,
+         .columns, .duplicate, .redefinition, .arity, .unsupported,
+         .statement, .grouping, .distinct:
+      true
+    case .character, .unterminated, .unexpected, .incomplete, .trailing:
+      true
+    case .operand, .overflow, .argument, .divide, .magnitude, .recursion,
+         .cardinality:
+      false
+    case let .state(code, _):
+      (code.hasPrefix("42") && code != "42804") || code.hasPrefix("0A")
+    }
+  }
+
+  /// Whether `routines` carries a routine the run invokes but the schema path
+  /// only validates by signature — a host-registered native closure or a
+  /// defined `CREATE FUNCTION` body, i.e. any routine beyond the standard
+  /// prelude. Such a body may throw a `structural`-classed `SQLError`
+  /// (`.function`, a `42883` / `42000` passthrough, …) for particular argument
+  /// values at run time, while `columns(of:)` validates the routine's declared
+  /// signature without invoking the body and rightly succeeds — an expected
+  /// run/validate difference whose origin is the body, not a hole the schema
+  /// derive owns. So the tripwire exempts a query run through such routines,
+  /// composing as an extra gate beside the `bindings.isEmpty` and `structural`
+  /// ones.
+  ///
+  /// The detection is keyed on the routine set rather than the call site: a
+  /// per-call walk of the query for the routines it actually invokes would need
+  /// the engine's internal expression AST, which this framework — importing
+  /// only the public surface — cannot see. It over-skips only a query that
+  /// carries a caller routine yet never calls it, a sound loss of sensitivity
+  /// confined to those tests, never a false positive.
+  ///
+  /// The set is trusted (the tripwire fires) only when every routine it binds
+  /// is the standard prelude's own shipped routine for that name — the routine
+  /// value `Routines.standard` binds to the name, tested by construction
+  /// identity (`Routine.same(as:)`), not by the name and not by the protection
+  /// set. `Routines.standard` is a `static let` built once, so the `Routine` it
+  /// vends for a name is a stable instance; a set derived from it keeps that
+  /// instance for a name it leaves alone and substitutes a fresh one for a name
+  /// it rebinds.
+  ///
+  /// Identity is the discriminator because neither cheaper proxy survives the
+  /// merge path. The standard routines are themselves native closures, so a
+  /// native-versus-defined `Routine` predicate could not tell them from a
+  /// caller's and would exempt every standard-routine query. A name-set test
+  /// misses a standard name rebound to a caller body. And protection is a set
+  /// property the merge unions, so `Routines.standard.merging(custom)` keeps a
+  /// replaced name's protection bit set while the binding under it is now the
+  /// caller's — a protection test reads that set as standard-only and fires
+  /// spuriously. Construction identity is unforgeable: every `Routine`
+  /// initializer — the public native init, the dictionary literal,
+  /// `registering(_:…)`, the replacing side of `merging(_:)` — mints a fresh
+  /// token, and the only route to a routine's identity is that routine value
+  /// itself.
+  ///
+  /// So a new name (absent from `standard`) and a standard name rebound to a
+  /// caller body — through the dictionary-literal escape hatch or through
+  /// `merging(_:)`, each a fresh identity — both read as non-standard and
+  /// exempt the query, while a set that is exactly the standard routines,
+  /// whatever its protection, reads as standard and stays subject to the
+  /// tripwire.
+  ///
+  /// The detection is keyed on the routine set rather than the call site: a
+  /// per-call walk of the query for the routines it actually invokes would need
+  /// the engine's internal expression AST, which this framework — importing
+  /// only the public surface — cannot see. It over-skips only a query that
+  /// carries a caller routine yet never calls it, a sound loss of sensitivity
+  /// confined to those tests, never a false positive.
+  private static func native(_ routines: Routines) -> Bool {
+    !routines.names.allSatisfy {
+      guard let bound = routines[$0], let shipped = Routines.standard[$0]
+      else { return false }
+      return bound.same(as: shipped)
+    }
   }
 
   /// Checks `sql` run against this catalog yields exactly `rows`, each row a
@@ -40,7 +196,8 @@ extension Catalog where Self: ~Escapable {
                                   #_sourceLocation)
       throws {
     let expected = rows.map { $0.map { $0?.value ?? .null } }
-    let actual = try run(sql, routines: routines, bindings: bindings)
+    let actual = try run(sql, routines: routines, bindings: bindings,
+                         location: location)
     #expect(actual == expected, sourceLocation: location)
   }
 
@@ -50,7 +207,8 @@ extension Catalog where Self: ~Escapable {
                               location: Testing.SourceLocation =
                                   #_sourceLocation)
       throws {
-    let actual = try run(sql, routines: routines, bindings: bindings)
+    let actual = try run(sql, routines: routines, bindings: bindings,
+                         location: location)
     #expect(actual.isEmpty, sourceLocation: location)
   }
 
@@ -65,7 +223,8 @@ extension Catalog where Self: ~Escapable {
       location: Testing.SourceLocation = #_sourceLocation) {
     let raised: SQLError?
     do {
-      _ = try run(sql, routines: routines, bindings: bindings)
+      _ = try run(sql, routines: routines, bindings: bindings,
+                  location: location)
       raised = nil
     } catch let fault {
       raised = fault
@@ -81,8 +240,10 @@ extension Catalog where Self: ~Escapable {
                                location: Testing.SourceLocation =
                                   #_sourceLocation)
       throws {
-    let left = try run(lhs, routines: routines, bindings: bindings)
-    let right = try run(rhs, routines: routines, bindings: bindings)
+    let left = try run(lhs, routines: routines, bindings: bindings,
+                       location: location)
+    let right = try run(rhs, routines: routines, bindings: bindings,
+                        location: location)
     #expect(left == right, sourceLocation: location)
   }
 }

--- a/Tests/SQLTests/Queries/EngineFunctionTests.swift
+++ b/Tests/SQLTests/Queries/EngineFunctionTests.swift
@@ -147,6 +147,76 @@ struct EngineFunctionTests {
         try functions("SELECT Name FROM People WHERE add(Id, 10) = 12")
     #expect(rows == [[.text("Bob")]])
   }
+
+  @Test func `a native routine's own structural fault stays off the run-validate tripwire`() throws {
+    // A host-registered native routine may throw a structural-classed fault
+    // from its own body — here `detonate` unconditionally raises `.function`,
+    // a structural code — while the schema path validates only its declared
+    // signature: a valid INTEGER argument (`Id`) against an INTEGER parameter,
+    // which succeeds without invoking the body. The run then invokes the body
+    // and it faults. The `run ≡ validate` tripwire (`Expect.swift`) must read
+    // this as the expected run/validate difference it is — the fault
+    // originates in the routine body, not a hole the schema derive owns — and
+    // stay silent, so this observes only the raw fault, no recorded issue. The
+    // tripwire fires without its native-routine exemption (drop `native(_:)`
+    // from the guard to see it record a spurious issue on this query).
+    let routines = try Routines.standard
+        .registering("detonate", parameters: [.integer]) {
+          _ throws(SQLError) in throw .function("detonate always faults")
+        }
+    try roster().expect("SELECT detonate(Id) FROM People WHERE Id = 1",
+                        fails: .function("detonate always faults"),
+                        routines: routines)
+  }
+
+  @Test func `a native routine replacing a standard name stays off the tripwire`() throws {
+    // The same exemption when the native body is installed under a *standard*
+    // name rather than a new one. A dictionary-literal `Routines` carries no
+    // protection, so it may bind `upper` — a name `registering(_:…)` refuses to
+    // shadow — to an arbitrary native body; here it always raises `.function`,
+    // a structural code. The schema path validates only the declared signature
+    // (a `TEXT` argument against `upper`'s `TEXT` parameter) and succeeds
+    // without invoking the body, while the run invokes it and it faults. The
+    // exemption must not key on the name — `upper` is a standard name, so a
+    // name-set test reads this set as standard-only and would record a spurious
+    // issue — but on the bound routine's construction identity: this `upper` is
+    // a freshly built routine value, not the one `Routines.standard` ships, so
+    // the `run ≡ validate` tripwire stays silent and this observes only the raw
+    // fault.
+    let routines: Routines = [
+      "upper": Routine(returns: .text, parameters: [.text]) {
+        _ throws(SQLError) in throw .function("upper always faults")
+      }
+    ]
+    try roster().expect("SELECT upper(Name) FROM People WHERE Id = 1",
+                        fails: .function("upper always faults"),
+                        routines: routines)
+  }
+
+  @Test func `a native routine merged over a standard name stays off the tripwire`() throws {
+    // The exemption must survive the merge path, where the earlier
+    // protection-based gate failed. `Routines.standard.merging(custom)` binds
+    // the caller's `upper` — the right-hand side of a merge wins — yet unions
+    // both sides' protected names, so `upper` stays protected though the
+    // routine under it is now the caller's body, which here always raises
+    // `.function`, a structural code. The schema path validates only the
+    // declared signature (`upper`'s `TEXT` parameter) and succeeds without
+    // invoking the body, while the run invokes it and it faults. A gate keyed
+    // on protection reads this set as standard-only and records a spurious
+    // issue; the identity gate sees this `upper` is a fresh routine value, not
+    // the one `Routines.standard` ships — while every unreplaced standard name
+    // keeps the shipped value — so the `run ≡ validate` tripwire stays silent
+    // and this observes only the raw fault.
+    let custom: Routines = [
+      "upper": Routine(returns: .text, parameters: [.text]) {
+        _ throws(SQLError) in throw .function("upper always faults")
+      }
+    ]
+    let routines = Routines.standard.merging(custom)
+    try roster().expect("SELECT upper(Name) FROM People WHERE Id = 1",
+                        fails: .function("upper always faults"),
+                        routines: routines)
+  }
 }
 
 // MARK: - Defined function (CREATE FUNCTION) tests


### PR DESCRIPTION
The schema/validate path (`columns(of:validate:)`) and the run path (`Catalog.run`) must agree in the safe direction: validate must never advertise a result schema for a query the run then structurally rejects. Issue #116's finder closed the live holes; this wires a tripwire into the test harness so a regression cannot re-introduce one silently.

The string-based expectation helpers all funnel through the private `run` overload. It now reuses the query it already parsed and, on the run-faults path, evaluates `columns(of:routines:validate:)` against the same query and prelude. When the run fault is one the schema derive owns — an unknown relation/column/routine, an ambiguous or duplicate name, a degree/arity mismatch, a malformed or unsupported shape, or the static grouping/distinct rules — and validate nonetheless succeeded, the harness records an issue at the call site naming the sql and the run fault.

A data-dependent fault is not a violation: validate has no rows and rightly succeeds while the run faults on the data, so a magnitude fault, a rejected routine argument, division by zero, a non-terminating recursive definition, and a scalar subquery's cardinality violation are left non-firing. A SQLSTATE passthrough is classified by class — 42 (less 42804) and 0A are structural; 22, 54, and XX are data-dependent — leaving a code data-dependent when in doubt so an over-broad classification cannot false-positive the suite.

Comparability (42804, both the arithmetic operand and the compare passthrough) is deliberately non-firing: the schema check catches a direct cross-kind compare so run and validate fault in parity there, but for a subquery, quantified, or `IN (Q)` operand the check defers to the run by design (a subquery's single-column type may be a nominal-NULL placeholder). That deferral is a documented soundness choice, not a hole.

The check runs only with no bindings — the validate path exempts a bound `x op :parameter`, so a bound run may fault where the schema path correctly does not. The `@testable` plan-shape tests assemble `Query`/`Plan` values and call the internal APIs directly rather than these string helpers, so they are naturally outside the tripwire.