### PR TITLE
SQLEngine: admit a correlated column in every clause of a subquery

### DIFF
--- a/Sources/SQLEngine/Aggregation.swift
+++ b/Sources/SQLEngine/Aggregation.swift
@@ -1142,21 +1142,20 @@ extension Catalog where Self: ~Escapable {
     }
     // Compile every nested subquery once for arity/type, ahead of lowering, and
     // discover each one's correlation: a join `ON`'s against its prefix scope,
-    // the WHERE against the join `scope`. Only the WHERE and join ONs admit a
-    // correlated column of this query; the aggregations, projection, `HAVING`,
-    // and `ORDER BY` lower under a barred seam. `validate` gates the eager
+    // the WHERE against the join `scope`. Every clause admits a correlated
+    // column of this query — the WHERE, join ONs, aggregations, projection,
+    // `HAVING`, and `ORDER BY` alike. `validate` gates the eager
     // type-check of a filtered-out derived body a nested subquery names, off on
     // the run path, on for a schema check.
     let plans = try subquery(of: select, context, enclosing: scope,
                              prefixes: prefixes)
-    let barred = plans.rest.barred
     // Validate every named window the `WINDOW` clause defines, whether or not it
     // is referenced — the aggregate route reaches here ahead of the window and
     // ordinary paths' checks, so an unused malformed definition (an undefined
     // base, an unresolvable column, or an invalid frame) would otherwise slip
     // through into a grouped compile.
     try validate(named: select.window, against: scope, context.routines,
-                 subquery: barred)
+                 subquery: plans.rest)
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
@@ -1196,13 +1195,12 @@ extension Catalog where Self: ~Escapable {
       // binds reads its combined slot; a bare `NATURAL`/`USING` merged column
       // lowers to its `COALESCE(left, right)` value (so the aggregate node
       // groups a `RIGHT`/`FULL` join's unmatched row by the merged value, not a
-      // NULL left column); a name none binds is a candidate correlated
-      // reference (a LATERAL body grouping on a preceding column) — the
-      // `barred` surface lowers it to a `Term.parameter` the apply binds per
-      // outer row, admitting it only under the LATERAL `everywhere` seam and
-      // faulting `.unsupported` on an ordinary grouped subquery, else the
-      // genuine unknown-column `.column`. A general key lowers by `term` too.
-      try scope.term(key, context.routines, subquery: barred)
+      // NULL left column); a name none binds is a correlated reference (a
+      // LATERAL body or an ordinary grouped subquery grouping on an outer
+      // column) — admitted in every clause, it lowers to a `Term.parameter` the
+      // enclosing scope binds per outer row, else the genuine unknown-column
+      // `.column`. A general key lowers by `term` too.
+      try scope.term(key, context.routines, subquery: plans.rest)
     }
     var expressions = Array<Expression>()
     for expression in select.projection.projected {
@@ -1232,7 +1230,7 @@ extension Catalog where Self: ~Escapable {
     var aggregations = Array<Aggregation>()
     for expression in expressions {
       let aggregation = try expression.aggregation(scope, context.routines,
-                                                   subquery: barred)
+                                                   subquery: plans.rest)
       if !aggregations.contains(aggregation) {
         aggregations.append(aggregation)
       }
@@ -1312,23 +1310,23 @@ extension Catalog where Self: ~Escapable {
     // arm's projection/HAVING reference to a key this set omits NULLs by
     // resolved identity (empty for an ordinary grouped query).
     let supers = try superset.map { key throws(SQLError) -> Term in
-      try scope.term(key, context.routines, subquery: barred)
+      try scope.term(key, context.routines, subquery: plans.rest)
     }
     // Lower the projection, HAVING, and ORDER BY against the grouped slot
     // space, enforcing the projection rule (every non-aggregated column must be
     // a GROUP BY key).
     var grouped = try Grouped(scope, grouping, keys, aggregations,
-                              superset: supers, subquery: barred)
+                              superset: supers, subquery: plans.rest)
     let projection = try grouped.terms(select.projection, context.routines,
-                                       subquery: barred)
+                                       subquery: plans.rest)
     let having: Filter? = if let clause = select.having {
-      try grouped.lower(clause, context.routines, subquery: barred)
+      try grouped.lower(clause, context.routines, subquery: plans.rest)
     } else {
       nil
     }
     var order = if let clause = select.order {
       try grouped.order(clause, projection, context.routines,
-                        subquery: barred)
+                        subquery: plans.rest)
     } else {
       Array<SortKey>()
     }

--- a/Sources/SQLEngine/Carrier.swift
+++ b/Sources/SQLEngine/Carrier.swift
@@ -212,8 +212,8 @@ extension Catalog where Self: ~Escapable {
     // `EXISTS`/`IN`/scalar sort-key subquery a plain `SELECT`'s ORDER BY
     // accepts. Threading this resolution in makes a set operation's ORDER BY
     // resolve a subquery sort key identically to a plain select's; an ORDER BY
-    // position bars a new correlation (`.barred` inside `scope.order`), so a
-    // genuinely-unsupported case still faults exactly as it does on a SELECT.
+    // position admits a correlated column (`scope.order` resolves it against
+    // the enclosing scope), exactly as it does on a SELECT.
     //
     // `roles(of:order:)` classifies a subquery by the clause it occurs in — the
     // carrier path's `ORDER BY` IS the carrier's, NOT the leftmost arm's own (a
@@ -383,7 +383,12 @@ extension Catalog where Self: ~Escapable {
         for query in subqueries {
           try self.width(query, [], context, nested, &widths, &types)
         }
-        let check = SubqueryCheck(widths, types, deferred: scalars).barred
+        // Carry the enclosing `outer` so a key that directly names an outer
+        // column — a correlated `ORDER BY T.Id` over a set operation whose
+        // output lacks `Id` — resolves against it here exactly as the run's
+        // `resolution` above does, rather than faulting `.column`.
+        let check = SubqueryCheck(widths, types, deferred: scalars,
+                                  outer: context.outer)
         for key in rewritten.keys {
           guard case let .expression(expression) = key.sort else { continue }
           try scope.aggregates(in: expression, context.routines,
@@ -430,7 +435,11 @@ extension Catalog where Self: ~Escapable {
             throw error
           }
         }
-        let check = SubqueryCheck(widths, types, deferred: scalars).barred
+        // Carry the enclosing `outer` for the same reason the validate check
+        // does: a correlated column inside a key comparison (`ORDER BY
+        // NULLIF(T.Id, k)`) resolves against the outer here as it does at run.
+        let check = SubqueryCheck(widths, types, deferred: scalars,
+                                  outer: context.outer)
         for key in rewritten.keys {
           guard case let .expression(expression) = key.sort else { continue }
           try scope.comparisons(in: expression, context.routines,

--- a/Sources/SQLEngine/Compilation.swift
+++ b/Sources/SQLEngine/Compilation.swift
@@ -386,9 +386,9 @@ extension Catalog where Self: ~Escapable {
   /// single-column type, a correlated one's runtime plan recorded into the
   /// shared box — so a scalar/`IN`/`EXISTS` in a row lowers and runs as
   /// elsewhere.
-  /// The lowering surface is barred (a projection position), so a bare column
-  /// names nothing and a correlated reference is diagnosed, as in a FROM-less
-  /// `SELECT`'s projection.
+  /// A bare column names nothing local, so it is a correlated reference
+  /// resolved against the enclosing `outer` (a name neither binds faults), as
+  /// in a FROM-less `SELECT`'s projection.
   private borrowing func compile(values rows: Array<Array<Expression>>,
                                  _ query: Query, _ context: Context)
       throws(SQLError) -> Plan {
@@ -405,7 +405,8 @@ extension Catalog where Self: ~Escapable {
         try subquery(subqueries, roles: { query.roles(of: $0, order: nil) },
                      context, within: nil)
     // Lower each row's expressions against the empty scope, as the FROM-less
-    // scalar path lowers a projection; `terms` bars the resolution surface.
+    // scalar path lowers a projection; an unbound name resolves against the
+    // enclosing `outer` the `resolution` carries.
     let schema = Schema(width: 0, extent: 0, names: [], types: [],
                         virtuals: [])
     let relation = Relation(name: "")
@@ -556,12 +557,10 @@ extension Catalog where Self: ~Escapable {
       let nested = (context.outer ?? Outer()).nested(under: within ?? Scope([]))
       // The context each nested compile/derive threads: the revealed base with
       // this frame's `nested` as the enclosing correlation stack and the
-      // shape-only lenience below. `unlateralized()` clears the LATERAL-body
-      // flag so a nested ordinary subquery within a lateral body builds its own
-      // Resolution with `everywhere: false` — the lateral everywhere-admission
-      // covers ONLY the lateral body's own projection, NOT a subquery inside
-      // it, so an ordinary correlated scalar-subquery projection is barred
-      // exactly as it is outside a lateral body.
+      // shape-only lenience below. A correlated column is admitted in every
+      // clause, so a nested subquery — ordinary or inside a lateral body —
+      // resolves its correlated references against this `nested` stack alike;
+      // there is no lateral-only admission to thread.
       // `shaping()` defers the set-operation operand-compatibility fold out of
       // this pre-pass: it records every nested subquery's width, arity, and
       // single-column type ahead of the reachability walk, so a `SELECT 'x'
@@ -569,7 +568,7 @@ extension Catalog where Self: ~Escapable {
       // while merely recording shape. A reached scalar/`IN` occurrence is re-
       // folded strictly on the walk's reached path; arity/resolution eager.
       let inner = context.with(outer: nested).validating(false)
-          .unlateralized().shaping()
+          .shaping()
       // A nested subquery's body derivation is shape ONLY, so ALWAYS lenient
       // (`validate: false`) — this pass exists to record the subquery's width,
       // arity, and correlation, never to validate its body. Validation of a
@@ -643,12 +642,12 @@ extension Catalog where Self: ~Escapable {
         }
       }
     }
-    // A LATERAL body's `Resolution` admits a correlated preceding-FROM column
-    // everywhere (`everywhere`), so its projection lowers such a column to a
-    // `Term.parameter` rather than barring it — the ISO scoping a lateral body
-    // gets and an ordinary subquery (`context.lateral == false`) does not.
+    // The `Resolution` admits a correlated column in every clause — a
+    // preceding-FROM column of a LATERAL body, or an enclosing-query column of
+    // any subquery, lowers to a `Term.parameter` the per-outer-row execution
+    // binds, in the projection/`GROUP BY`/`HAVING`/`ORDER BY` as in the WHERE.
     return Resolution(scope, widths, types, correlations,
-                      outer: context.outer, everywhere: context.lateral)
+                      outer: context.outer)
   }
 
   /// The single value a scalar subquery `query` collapses to against this
@@ -951,20 +950,18 @@ extension Catalog where Self: ~Escapable {
     // returned schema is discarded here (`resolve`/`schema(of:)` advertises the
     // columns); this call exists to run the same validation a non-lateral body
     // gets.
-    // Mark the body a LATERAL body (`lateralizing`) so its `Resolution`/
-    // `SubqueryCheck` admit a correlated preceding-FROM column everywhere,
-    // including its projection — per ISO a LATERAL body's preceding references
-    // are in scope throughout, unlike an ordinary subquery whose projection
-    // stays barred. The flag rides through the shared derived-body machinery to
-    // the projection lowering, where a projected preceding column lowers to a
-    // `Term.parameter` rather than faulting `.unsupported`.
+    // A correlated column is admitted in every clause, so the body's
+    // `Resolution`/`SubqueryCheck` resolve a correlated preceding-FROM column
+    // throughout — including its projection, where per ISO a LATERAL body's
+    // preceding references are in scope. A projected preceding column lowers to
+    // a `Term.parameter` through the shared derived-body machinery.
     // Thread the derived table's explicit `AS d(a, b)` column list into the
     // body's schema derive so this validation checks the same exposed (renamed)
     // names `schema(of:)` advertises — its arity (`SQLError.columns`) and
     // uniqueness (`SQLError.duplicate`) run against the renamed list, so a list
     // hiding a duplicate INNER name (`SELECT T.Id AS x, T.Id AS x) AS d(a, b)`)
     // passes at both seams rather than faulting only here.
-    let revealed = context.revealed().with(outer: nested).lateralizing()
+    let revealed = context.revealed().with(outer: nested)
     _ = try materialise(body, revealed, rows: false, columns: renaming)
     // Compile the body leniently for the per-outer-row apply plan (the shape
     // pass a correlated subquery's pre-pass runs), recording it under the
@@ -1466,16 +1463,16 @@ extension Catalog where Self: ~Escapable {
       // A `WINDOW` clause with no window function is dropped after compilation,
       // so validate its definitions here against the source scope first.
       try validate(named: select.window, against: enclosing, context.routines,
-                   subquery: plans.rest.barred)
+                   subquery: plans.rest)
       var filter: Filter? = nil
       if let predicate = select.predicate {
         filter = try from.schema.lower(predicate, in: relation,
                                        context.routines, subquery: plans.rest)
       }
-      // The projection and ORDER BY are barred clause positions (only the WHERE
-      // admits a correlated column of this query); `terms`/`order` bar the seam
-      // intrinsically, so passing `plans.rest` cannot admit one. A nested
-      // subquery there still lowers with its own inner correlation.
+      // The projection and ORDER BY admit a correlated column of this query as
+      // the WHERE does: passing `plans.rest` (which carries the enclosing
+      // `outer`) resolves an unbound name outward. A nested subquery there also
+      // lowers with its own inner correlation.
       let projection =
           try from.schema.terms(select.projection, in: relation,
                                 context.routines, subquery: plans.rest)
@@ -1585,7 +1582,7 @@ extension Catalog where Self: ~Escapable {
     // definition naming a joined relation's column resolves as the query's own
     // clauses do.
     try validate(named: select.window, against: scope, context.routines,
-                 subquery: plans.rest.barred)
+                 subquery: plans.rest)
     var matches = Array<Filter>()
     matches.reserveCapacity(select.joins.count)
     for index in select.joins.indices {
@@ -1606,12 +1603,10 @@ extension Catalog where Self: ~Escapable {
       predicate = try scope.lower(clause, context.routines,
                                   subquery: plans.rest)
     }
-    // The projection and ORDER BY are barred clause positions: a correlated
-    // column of this query is out of the minimal (b) cut there (only its
-    // WHERE/ON admits one), so `terms`/`order` bar the seam intrinsically and
-    // it is diagnosed rather than mis-resolved. A nested subquery in the
-    // projection still lowers — its own inner WHERE correlation was discovered
-    // in the pre-pass.
+    // The projection and ORDER BY admit a correlated column of this query as
+    // the WHERE/ON do: `plans.rest` carries the enclosing `outer`, so an
+    // unbound name resolves outward. A nested subquery in the projection also
+    // lowers — its own inner WHERE correlation was discovered in the pre-pass.
     let projection = try scope.terms(select.projection, context.routines,
                                      subquery: plans.rest)
 
@@ -1738,7 +1733,7 @@ extension Catalog where Self: ~Escapable {
   /// each spec's base (an undefined base faults `42704`) then its partition and
   /// order keys against the scope (an unknown column faults) exactly as a
   /// referenced window resolves — with `subquery` for a spec's own scalar
-  /// subquery, the same barred resolution the referenced path uses, so a
+  /// subquery, the same resolution the referenced path uses, so a
   /// definition carrying a subquery is not spuriously rejected. Every definition
   /// is validated whether or not a window function references it, so a query
   /// with a `WINDOW` clause never silently accepts an unresolvable unused one.
@@ -1765,7 +1760,6 @@ extension Catalog where Self: ~Escapable {
     }
     let scope = Scope([(relation, from.schema)])
     let plans = try subquery(of: select, context, enclosing: scope)
-    let barred = plans.rest.barred
     let routines = context.routines
 
     // Validate every named window the clause defines, including one no window
@@ -1773,7 +1767,7 @@ extension Catalog where Self: ~Escapable {
     // inlined use below, but an unused definition would otherwise be dropped
     // unchecked.
     try validate(named: select.window, against: scope, routines,
-                 subquery: barred)
+                 subquery: plans.rest)
 
     // The WHERE lowers below the window node, in the source's base-ordinal
     // space; a correlated column of this query is admitted here, as the run's
@@ -1817,11 +1811,13 @@ extension Catalog where Self: ~Escapable {
     let identity =
         Dictionary(uniqueKeysWithValues: (0 ..< space).map { ($0, $0) })
     var probe = Windowed(scope, identity, width: space)
-    let probed = try probe.terms(select.projection, routines, subquery: barred)
+    let probed = try probe.terms(select.projection, routines,
+                                 subquery: plans.rest)
     var references = Set<Int>()
     for term in probed { term.references(into: &references) }
     if let clause = select.order {
-      for key in try probe.order(clause, probed, routines, subquery: barred) {
+      for key in try probe.order(clause, probed, routines,
+                                 subquery: plans.rest) {
         key.term.references(into: &references)
       }
     }
@@ -1838,10 +1834,11 @@ extension Catalog where Self: ~Escapable {
     // over the source slot space, so windowing `j` reads packed source cells.
     var windowed = Windowed(scope, slot, width: ordinals.count)
     let projection = try windowed.terms(select.projection, routines,
-                                        subquery: barred)
+                                        subquery: plans.rest)
     var order = Array<SortKey>()
     if let clause = select.order {
-      order = try windowed.order(clause, projection, routines, subquery: barred)
+      order = try windowed.order(clause, projection, routines,
+                                 subquery: plans.rest)
     }
     // Under DISTINCT every `ORDER BY` key must be a select-list value (see
     // `distinct`); the keys and projection are in the window's output slot

--- a/Sources/SQLEngine/Context.swift
+++ b/Sources/SQLEngine/Context.swift
@@ -65,17 +65,6 @@ internal struct Context {
   /// recording the correlation. `nil` at the top level (no enclosing query).
   internal let outer: Outer?
 
-  /// Whether the query being resolved is a LATERAL derived table's body — set
-  /// only by `lateral(_:against:_:)` as it derives/compiles the body. Per ISO
-  /// 9075 a `LATERAL` body's preceding-FROM references are in scope throughout
-  /// its query expression, including the select list, so the body admits a
-  /// correlated column everywhere (not only its `WHERE`/`ON`). This flag
-  /// threads into the `Resolution`/`SubqueryCheck` the body's lowering and
-  /// validation build (`everywhere`), lifting the projection-correlation bar
-  /// for the lateral body alone — an ordinary subquery's projection stays
-  /// barred (`false`).
-  internal let lateral: Bool
-
   /// Whether the query being resolved is a nested-subquery shape pre-pass — the
   /// cursor-free derive that records a nested subquery's width, arity, and
   /// single-column type ahead of the reachability walk. Set only at the
@@ -117,7 +106,7 @@ internal struct Context {
                 subqueries: Subqueries = Subqueries(),
                 visited: Set<String> = [], validate: Bool = true,
                 subscope: Subscope = .caller, outer: Outer? = nil,
-                lateral: Bool = false, shape: Bool = false,
+                shape: Bool = false,
                 comparability: Bool = false) {
     self.relations = relations
     self.routines = routines
@@ -127,7 +116,6 @@ internal struct Context {
     self.validate = validate
     self.subscope = subscope
     self.outer = outer
-    self.lateral = lateral
     self.shape = shape
     self.comparability = comparability
   }
@@ -139,7 +127,7 @@ internal struct Context {
   internal func scoping(_ relations: ScopedRelations) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            subscope: subscope, outer: outer, shape: shape,
             comparability: comparability)
   }
 
@@ -176,7 +164,7 @@ internal struct Context {
   internal func binding(_ bindings: Bindings) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            subscope: subscope, outer: outer, shape: shape,
             comparability: comparability)
   }
 
@@ -187,7 +175,7 @@ internal struct Context {
   internal func resolving(_ subqueries: Subqueries) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            subscope: subscope, outer: outer, shape: shape,
             comparability: comparability)
   }
 
@@ -222,7 +210,7 @@ internal struct Context {
     return Context(relations: relations, routines: routines,
                    bindings: bindings, subqueries: subqueries,
                    visited: visited, validate: validate, subscope: subscope,
-                   outer: outer, lateral: lateral, shape: shape,
+                   outer: outer, shape: shape,
                    comparability: comparability)
   }
 
@@ -232,7 +220,7 @@ internal struct Context {
   internal func validating(_ flag: Bool) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: flag,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            subscope: subscope, outer: outer, shape: shape,
             comparability: comparability)
   }
 
@@ -245,7 +233,7 @@ internal struct Context {
   internal func shaping() -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: true,
+            subscope: subscope, outer: outer, shape: true,
             comparability: comparability)
   }
 
@@ -258,7 +246,7 @@ internal struct Context {
   internal func comparing() -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            subscope: subscope, outer: outer, shape: shape,
             comparability: true)
   }
 
@@ -268,7 +256,7 @@ internal struct Context {
   internal func scoped(as subscope: Subscope) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
+            subscope: subscope, outer: outer, shape: shape,
             comparability: comparability)
   }
 
@@ -287,21 +275,7 @@ internal struct Context {
   internal func with(outer: Outer?) -> Context {
     Context(relations: relations, routines: routines, bindings: bindings,
             subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: lateral, shape: shape,
-            comparability: comparability)
-  }
-
-  /// A copy of this context marking the query it resolves as a LATERAL derived
-  /// table's body (`lateral`) — the single seam `lateral(_:against:_:)` routes
-  /// its body's schema derivation and plan compile through, so the body's
-  /// `Resolution`/`SubqueryCheck` admit a correlated preceding-FROM column
-  /// everywhere, including the projection, per ISO. Every other field is
-  /// preserved; the flag is scoped to the body's own lowering (a nested
-  /// non-lateral body clears it through `body(_:)`).
-  internal func lateralizing() -> Context {
-    Context(relations: relations, routines: routines, bindings: bindings,
-            subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: true, shape: shape,
+            subscope: subscope, outer: outer, shape: shape,
             comparability: comparability)
   }
 
@@ -312,23 +286,9 @@ internal struct Context {
   /// site; a derived table is uncorrelated), so an unbound column in either
   /// must fault rather than bind outward to the caller. Every other field —
   /// the relation overlay, routines, bindings, subquery results, the visited
-  /// guard, the validate gate, and the subscope — is preserved; `outer` resets
-  /// to `nil` (restoring the top-level default) and the LATERAL-body flag
-  /// clears, so a non-lateral body nested inside a lateral one does NOT inherit
-  /// the everywhere-correlation admission.
+  /// guard, the validate gate, and the subscope — is preserved; only `outer`
+  /// resets to `nil`, restoring the top-level default.
   internal func uncorrelated() -> Context {
-    with(outer: nil).unlateralized()
-  }
-
-  /// A copy of this context with the LATERAL-body flag cleared — the reset
-  /// `uncorrelated()`/`body(_:)` fold in, and the seam a nested ordinary
-  /// subquery within a lateral body compiles under, so a body that must NOT
-  /// correlate against the caller (a view or a non-lateral derived table) does
-  /// not carry an enclosing lateral body's everywhere-correlation admission.
-  internal func unlateralized() -> Context {
-    Context(relations: relations, routines: routines, bindings: bindings,
-            subqueries: subqueries, visited: visited, validate: validate,
-            subscope: subscope, outer: outer, lateral: false, shape: shape,
-            comparability: comparability)
+    with(outer: nil)
   }
 }

--- a/Sources/SQLEngine/Grouped.swift
+++ b/Sources/SQLEngine/Grouped.swift
@@ -109,9 +109,8 @@ internal struct Grouped {
       // it occupies grouped slot `index` as a `.parameter` key (in `group`'s
       // keys array) with no ordinal→slot entry — the projection reads it via
       // the same correlation, never through this key dict. A genuinely unknown
-      // column re-throws the `.column` fault; a barred surface diagnoses a
-      // bound outer column `.unsupported`. `correlated` records nothing, so it
-      // stays idempotent against `group`'s own correlation. A general
+      // column re-throws the `.column` fault. `correlated` records nothing, so
+      // it stays idempotent against `group`'s own correlation. A general
       // (non-column) key takes no ordinal entry; it matches by term in `term`.
       guard case let .column(column) = grouping[index],
           column.qualifier == nil ? scope.merges(column.name) == nil : true
@@ -188,10 +187,10 @@ internal struct Grouped {
     // coalesced value, not a NULL left column.
     //
     // A bare plain column is skipped here and falls to the ordinal path below,
-    // which additionally distinguishes a genuine unknown column, a correlated
-    // reference (a LATERAL body's `everywhere` seam), and a barred grouped
-    // surface — cases a bare merged column and a general expression never
-    // reach. A merged column that matches no key faults `.grouping`; a general
+    // which additionally distinguishes a genuine unknown column from a
+    // correlated reference (a LATERAL body or an enclosing query's column) —
+    // cases a bare merged column and a general expression never reach. A merged
+    // column that matches no key faults `.grouping`; a general
     // expression that matches none falls through so its operands are each
     // checked (`Amount + 2` faults on the bare non-key `Amount`). An aggregated
     // expression (`SUM(x) + 1`) is skipped too: `scope.term` faults on an
@@ -228,11 +227,10 @@ internal struct Grouped {
       // `Scope.term`'s `.column`: a name a local relation binds must be a
       // `GROUP BY` key (the standard grouping rule), else `SQLError.grouping`.
       // A name none binds is a candidate correlated reference — consult the
-      // surface, which admits it (a `Term.parameter` the apply binds per outer
-      // row) only for a LATERAL body's `everywhere` seam and diagnoses it
-      // `.unsupported` on an ordinary barred grouped surface. The final
-      // `ordinal(of:)` re-throws the genuine unknown-column `.column` fault,
-      // exactly as `Scope.term` does.
+      // surface, which admits it in every clause (a `Term.parameter` the
+      // enclosing scope binds per outer row). The final `ordinal(of:)`
+      // re-throws the genuine unknown-column `.column` fault, exactly as
+      // `Scope.term` does.
       if let ordinal = try scope.find(column) {
         if let slot = keys[ordinal] { return .slot(slot) }
         // A bare column another set groups on but this arm's set omits is a
@@ -431,10 +429,9 @@ internal struct Grouped {
                                _ routines: Routines = [:],
                                subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<Term> {
-    // A grouped projection is a barred clause position (see `Schema.terms`):
-    // the entry bars the seam so it cannot admit a correlated column of this
-    // query.
-    let subquery = subquery.barred
+    // A grouped projection admits a correlated column of this query as every
+    // clause does (see `Schema.terms`): an unbound name resolves against the
+    // enclosing `outer` that `subquery` carries.
     switch projection {
     case .all:
       throw .state("0A000",
@@ -508,8 +505,8 @@ internal struct Grouped {
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
-    // A grouped ORDER BY is barred, as the projection is (see `Schema.order`).
-    let subquery = subquery.barred
+    // A grouped ORDER BY admits a correlated column, as the projection does
+    // (see `Schema.order`).
     var resolved = Array<SortKey>()
     resolved.reserveCapacity(order.keys.count)
     for key in order.keys {

--- a/Sources/SQLEngine/OutputColumn.swift
+++ b/Sources/SQLEngine/OutputColumn.swift
@@ -195,10 +195,10 @@ extension Scope {
   /// for a name no local relation binds, from the correlation `subquery`
   /// surface (`resolved(for:)` — carrying the outer column's mask, so a
   /// correlated all-NULL column stays unconstrained), mirroring the expression
-  /// path's `derive`. Under a LATERAL body's admitting (`everywhere`) surface a
-  /// preceding-FROM column types as its outer column; under an ordinary barred
-  /// surface it faults `.unsupported`. A genuinely unknown name re-throws the
-  /// `.column` fault.
+  /// path's `derive`. A correlated column is admitted in every clause, so a
+  /// preceding-FROM or enclosing-query column types as its outer column here.
+  /// A genuinely unknown name — one no local relation and no `outer` binds —
+  /// re-throws the `.column` fault.
   internal func output(of column: Column,
                        subquery: Resolution = .unsupported)
       throws(SQLError) -> ResolvedColumn {

--- a/Sources/SQLEngine/Resolution.swift
+++ b/Sources/SQLEngine/Resolution.swift
@@ -246,13 +246,12 @@ extension Dictionary where Key == String, Value == Source {
 /// so the same occurrence lowered on the run and the schema paths accretes into
 /// one map.
 ///
-/// A name no enclosing scope binds either stays the ordinary unknown-column
-/// fault (the local surface already raised `SQLError.column`); this only
-/// intercepts a name the OUTER scope binds. Correlation is admitted ONLY where
-/// a synthetic bound param is a valid lowering — a `WHERE`/`ON` term — so a
-/// scope with no admitted position (a projection / `GROUP BY` / `HAVING`
-/// surface) carries no `Outer` and the outer column stays unresolved, diagnosed
-/// as unsupported rather than mis-bound.
+/// A name no enclosing scope binds stays the ordinary unknown-column fault (the
+/// local surface already raised `SQLError.column`); this only intercepts a name
+/// the outer scope binds. Correlation is admitted in every clause of a subquery
+/// — a projection, `GROUP BY`, `HAVING`, and `ORDER BY` as well as a
+/// `WHERE`/`ON` — since the per-outer-row re-execution binds the synthetic
+/// parameter for the whole subquery, whichever clause names the outer column.
 internal final class Outer {
   /// The enclosing scopes, outermost first — a column resolves against the
   /// nearest enclosing (last) that binds it, matching lexical scoping. The last
@@ -563,40 +562,23 @@ internal struct Resolution {
   /// this select is itself a subquery, so a column its relations do not bind
   /// resolves against the outer query and lowers to a `Term.parameter`. `nil`
   /// for a top-level select (no enclosing scope), leaving an unbound column the
-  /// ordinary fault.
+  /// ordinary fault. A correlated column is admitted in every clause of a
+  /// subquery — its projection, `GROUP BY`, `HAVING`, and `ORDER BY` as well as
+  /// its `WHERE`/`ON` — since the per-outer-row re-execution binds the named
+  /// cell before evaluating any of them (ISO 9075 puts an outer reference in
+  /// scope throughout the subquery).
   private let outer: Outer?
-
-  /// Whether this lowering surface admits a correlated column — TRUE for the
-  /// inner `WHERE`/`ON` (a synthetic bound param is a valid lowering there),
-  /// FALSE for the projection / `GROUP BY` / `HAVING` (the minimal (b) cut has
-  /// no evaluator for an outer column there). A barred surface diagnoses a
-  /// correlated column as unsupported rather than mis-resolving it.
-  private let admits: Bool
-
-  /// Whether the surface admits a correlated column everywhere — in the barred
-  /// clause positions (the projection / `GROUP BY` / `HAVING`) as well as the
-  /// `WHERE`/`ON` — set ONLY when lowering a LATERAL derived table's body. Per
-  /// ISO 9075 a `LATERAL` body's preceding-FROM references are in scope
-  /// throughout its query expression, including the select list, so a lateral
-  /// body correlates everywhere while an ordinary subquery's projection stays
-  /// barred. When `true`, `barred` is a no-OP — it keeps `admits`, so a
-  /// projected preceding column still lowers to a `Term.parameter` — and the
-  /// per-outer-row apply binds it exactly as a `WHERE`-correlated one.
-  private let everywhere: Bool
 
   internal init(_ scope: Subscope = .caller,
                 _ widths: Dictionary<Query, Int> = [:],
                 _ types: Dictionary<Query, ResolvedColumn> = [:],
                 _ correlations: Dictionary<Query, Correlation> = [:],
-                outer: Outer? = nil, admits: Bool = true,
-                everywhere: Bool = false) {
+                outer: Outer? = nil) {
     self.scope = scope
     self.widths = widths
     self.types = types
     self.correlations = correlations
     self.outer = outer
-    self.admits = admits
-    self.everywhere = everywhere
   }
 
   /// A `Resolution` for a lowering surface with no catalog — a schema-only
@@ -606,40 +588,14 @@ internal struct Resolution {
     Resolution()
   }
 
-  /// This seam with correlation barred — the surface a projection / `GROUP BY`
-  /// / `HAVING` lowers under, where an outer column is out of the minimal (b)
-  /// cut. It keeps the widths/types/correlations (nested subqueries there still
-  /// lower and carry their own inner correlation) but rejects a correlated
-  /// column of this query as unsupported.
-  ///
-  /// A LATERAL body's surface (`everywhere`) is the exception: ISO puts the
-  /// preceding-FROM references in scope throughout the body including the
-  /// select list, so `barred` is a no-OP there — the projection keeps admitting
-  /// a correlated column, which lowers to a `Term.parameter` the apply binds
-  /// per outer row.
-  internal var barred: Resolution {
-    if everywhere { return self }
-    return Resolution(scope, widths, types, correlations, outer: outer,
-                      admits: false, everywhere: everywhere)
-  }
-
   /// The synthetic bound-parameter name a correlated reference to `column`
   /// lowers to, or `nil` when no enclosing scope binds it (the ordinary
-  /// unknown-column fault stands). A `.column` lowering consults this ONLY
-  /// after its own relations fail to bind the name.
-  ///
-  /// On a barred surface (a projection / `GROUP BY` / `HAVING`) an outer column
-  /// IS out of the minimal (b) cut, so a name the enclosing scope binds is
-  /// diagnosed `SQLError.unsupported` rather than mis-resolved — the same fault
-  /// on the run and the schema paths, keeping typecheck↔run parity.
+  /// unknown-column fault stands). A `.column` lowering consults this only
+  /// after its own relations fail to bind the name. Admitted in every clause: a
+  /// correlated column becomes a `Term.parameter` the per-outer-row
+  /// re-execution binds before evaluating any of the subquery's clauses.
   internal func correlate(_ column: Column) throws(SQLError) -> String? {
-    guard let name = try outer?.parameter(for: column) else { return nil }
-    guard admits else {
-      throw .state("0A000",
-                   "a correlated column is only supported in a subquery's " +
-                   "WHERE")
-    }
-    return name
+    try outer?.parameter(for: column)
   }
 
   /// The resolved outer column a correlated reference to `column` contributes
@@ -647,22 +603,11 @@ internal struct Resolution {
   /// `nil` when no enclosing scope binds it. Every type/mask reader is a thin
   /// accessor over this one resolver, so a correlated column's type and mask
   /// cannot diverge (the fix for a correlated all-NULL column losing its mask
-  /// through the LATERAL surface).
-  ///
-  /// A barred surface (a projection / `GROUP BY` / `HAVING` of an ordinary
-  /// subquery) still diagnoses a bound name `SQLError.unsupported` — the same
-  /// fault the run's lowering raises, keeping typecheck↔run parity — so this
-  /// widens nothing: a lateral body's projection (`everywhere`) admits it,
-  /// while an ordinary subquery's projection faults exactly as before.
+  /// through the LATERAL surface). Types the reference as the outer column in
+  /// every clause, matching the run's lowering (typecheck↔run parity).
   internal func correlated(_ column: Column) throws(SQLError)
       -> ResolvedColumn? {
-    guard let resolved = try outer?.resolved(for: column) else { return nil }
-    guard admits else {
-      throw .state("0A000",
-                   "a correlated column is only supported in a subquery's " +
-                   "WHERE")
-    }
-    return resolved
+    try outer?.resolved(for: column)
   }
 
   /// The correlation of the nested `query` — its synthetic outer bindings —
@@ -1042,32 +987,16 @@ internal struct SubqueryCheck {
   /// keeping typecheck↔run parity. `nil` for a top-level select.
   private let outer: Outer?
 
-  /// Whether this surface admits a correlated column — the inner `WHERE`/`ON`
-  /// (TRUE) versus a projection / `GROUP BY` / `HAVING` (FALSE, diagnosed) —
-  /// the analog of `Resolution.admits`, so validation faults the unsupported
-  /// correlated-projection case exactly where the run does.
-  private let admits: Bool
-
-  /// Whether the surface admits a correlated column everywhere — a LATERAL
-  /// body's validation surface, the analog of `Resolution.everywhere` — so
-  /// `barred` is a no-OP and the projection/`HAVING` walk of a lateral body
-  /// validates a correlated preceding column rather than faulting, matching the
-  /// run's lowering (typecheck↔run parity).
-  private let everywhere: Bool
-
   internal init(_ widths: Dictionary<Query, Int> = [:],
                 _ types: Dictionary<Query, ValueType> = [:],
                 deferred: Set<Query> = [],
                 reached: ReachedScalars = ReachedScalars(),
-                outer: Outer? = nil, admits: Bool = true,
-                everywhere: Bool = false) {
+                outer: Outer? = nil) {
     self.widths = widths
     self.types = types
     self.deferred = deferred
     self.reached = reached
     self.outer = outer
-    self.admits = admits
-    self.everywhere = everywhere
   }
 
   /// A checker for a surface with no catalog — validating a subquery needs one,
@@ -1075,18 +1004,6 @@ internal struct SubqueryCheck {
   /// subquery unvalidated.
   internal static var unsupported: SubqueryCheck {
     SubqueryCheck()
-  }
-
-  /// This checker with correlation barred — the surface a projection / `GROUP
-  /// BY` / `HAVING` type-checks under, where an outer column is out of the (b)
-  /// cut and is diagnosed rather than resolved. Mirrors `Resolution.barred` —
-  /// including the LATERAL-body exception (`everywhere`), where it is a no-OP
-  /// so the projection/`HAVING` walk keeps admitting the correlated preceding
-  /// column the run's lowering binds.
-  internal var barred: SubqueryCheck {
-    if everywhere { return self }
-    return SubqueryCheck(widths, types, deferred: deferred, reached: reached,
-                         outer: outer, admits: false, everywhere: everywhere)
   }
 
   /// This checker over a fresh `reached` box, carrying `outer` — the surface a
@@ -1104,19 +1021,11 @@ internal struct SubqueryCheck {
 
   /// The outer type `column` correlates to, or `nil` when no enclosing scope
   /// binds it — the validation-side `Resolution.correlate`: it resolves against
-  /// `outer`, faulting `.unsupported` on a barred surface (a projection /
-  /// `GROUP BY` / `HAVING`) so validation rejects the unsupported
-  /// correlated-projection case exactly as the run's lowering does, and returns
-  /// the outer column's type so `validate` types the reference as that column.
-  /// Consulted ONLY after the local relations fail to bind the name.
+  /// `outer` and returns the outer column's type so `validate` types the
+  /// reference as that column, in every clause, exactly as the run's lowering
+  /// binds it. Consulted only after the local relations fail to bind the name.
   internal func correlated(_ column: Column) throws(SQLError) -> ValueType? {
-    guard let type = try outer?.type(for: column) else { return nil }
-    guard admits else {
-      throw .state("0A000",
-                   "a correlated column is only supported in a subquery's " +
-                   "WHERE")
-    }
-    return type
+    try outer?.type(for: column)
   }
 
   /// Asserts the inner `query` was compiled in the pre-pass — a query the

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -267,9 +267,9 @@ extension Catalog where Self: ~Escapable {
     // its width and single-column type, each discovering its correlation
     // against this select's own scope (`enclosing`) — and pass it to the
     // projection walk so an output type for a `(SELECT …)` matches the type the
-    // run advertises. The projection walk is barred (a correlated column of
-    // this query in the projection is diagnosed, as the run's projection
-    // lowering bars it). Resolve over the augmented context so a subquery
+    // run advertises. The projection walk admits a correlated column of this
+    // query, resolving it against the enclosing scope as the run's projection
+    // lowering does. Resolve over the augmented context so a subquery
     // naming this select's own arm-local derived alias binds it, while
     // `subquery(of:)` reveals the base so the subquery's own FROM sees no
     // derived alias (a CTE a same-named derived alias shadows resolved beneath
@@ -289,11 +289,11 @@ extension Catalog where Self: ~Escapable {
     // one walk yields each column's name, type, AND `unconstrained` mask
     // together — a constant-NULL projection or a reference to an unconstrained
     // (local or correlated) source column carries the mask through the same
-    // resolution as the type, so the two cannot diverge. The projection walk is
-    // barred (a correlated column of this query in the projection is diagnosed,
-    // as the run's projection lowering bars it).
+    // resolution as the type, so the two cannot diverge. The projection walk
+    // admits a correlated column of this query, resolving it against the
+    // enclosing scope as the run's projection lowering does.
     return try scope.columns(of: select.projection, augmented.routines,
-                             subquery: plans.rest.barred)
+                             subquery: plans.rest)
   }
 
   /// The output columns of `query`, type-unified across every set-operation arm
@@ -390,7 +390,7 @@ extension Catalog where Self: ~Escapable {
         }
         let typed = try Scope([]).columns(of: .expressions(items),
                                           context.routines,
-                                          subquery: resolution.barred)
+                                          subquery: resolution)
         if let current = folded {
           folded = try current.indices.map { index throws(SQLError) in
             try merge(current[index], typed[index], shape: context.shape)
@@ -835,12 +835,11 @@ extension Catalog where Self: ~Escapable {
     }
     // Carry this select's own enclosing scope `context.outer` so its WHERE
     // type-check (`walk`) resolves a correlated column of this query against
-    // the outer, matching the run's lowering; the projection/`HAVING` walk uses
-    // `.barred` — a no-OP for a LATERAL body (`everywhere`), whose projection
-    // ISO puts the preceding references in scope for, so validation admits the
-    // projected correlated column exactly as the run's lowering does.
+    // the outer, matching the run's lowering; validation admits a correlated
+    // column in every clause (projection/`GROUP BY`/`HAVING`/`ORDER BY` as well
+    // as `WHERE`/`ON`) exactly as the run's lowering binds it per outer row.
     return SubqueryCheck(widths, types, deferred: deferred,
-                         outer: context.outer, everywhere: context.lateral)
+                         outer: context.outer)
   }
 
   /// Records the cursor-free width and single-column type of `query` into
@@ -1022,11 +1021,11 @@ extension Catalog where Self: ~Escapable {
   /// counterpart of the former `UNION ALL` of FROM-less selects, so a run and a
   /// `columns(of:)` derive fault a `VALUES` alike.
   ///
-  /// The rows are a barred surface (an empty scope, `Scope([])`), so a row's
-  /// expression resolves only its literals, calls, and subqueries — a bare
-  /// column names nothing and faults, and a correlated reference is barred,
-  /// exactly as a FROM-less `SELECT`'s projection is. Each row subquery's
-  /// cursor-free width and single-column type derive against the enclosing
+  /// The rows resolve over an empty local scope (`Scope([])`) carrying the
+  /// enclosing `outer`, so a row's expression resolves its literals, calls, and
+  /// subqueries, and a bare column — naming nothing local — is a correlated
+  /// reference resolved against `outer` (a name neither binds faults). Each row
+  /// subquery's cursor-free width and single-column type derive against that
   /// `outer` (a `VALUES` in subquery position), then in validate mode each row
   /// expression's reachable operands and calls are checked (`aggregates`/
   /// `validate`) and each reached subquery body recursed, and in the run's
@@ -1034,12 +1033,10 @@ extension Catalog where Self: ~Escapable {
   /// (`comparisons`) and each reached body recursed — the same discipline the
   /// carrier `ORDER BY` and the plain arm use.
   ///
-  /// A LATERAL `VALUES` constructor (`context.lateral`) is the exception, the
-  /// counterpart of a LATERAL FROM-less `SELECT`'s projection: ISO puts the
-  /// preceding FROM references in scope throughout the constructor, so the
-  /// `SubqueryCheck` carries the enclosing `outer` and admits a correlated
-  /// preceding column everywhere (`everywhere`) — `barred` a no-op there —
-  /// while a non-LATERAL constructor stays barred, its correlation faulted.
+  /// A correlated column is admitted throughout the constructor whether or not
+  /// the `VALUES` sits in a LATERAL position: ISO puts a LATERAL body's
+  /// preceding FROM references in scope, and an ordinary subquery's `VALUES`
+  /// likewise names its enclosing query's columns — both bind per outer row.
   private borrowing func typecheck(values rows: Array<Array<Expression>>,
                                    _ query: Query, _ context: Context)
       throws(SQLError) {
@@ -1089,8 +1086,7 @@ extension Catalog where Self: ~Escapable {
         }
       }
       let check = SubqueryCheck(widths, types, deferred: scalars,
-                                outer: nested,
-                                everywhere: context.lateral).barred
+                                outer: nested)
       for expression in expressions {
         try scope.comparisons(in: expression, context.routines, subquery: check)
       }
@@ -1116,8 +1112,7 @@ extension Catalog where Self: ~Escapable {
         try width(query, [], context, nested, &widths, &types)
       }
       let check = SubqueryCheck(widths, types, deferred: scalars,
-                                outer: nested,
-                                everywhere: context.lateral).barred
+                                outer: nested)
       for expression in expressions {
         try scope.aggregates(in: expression, context.routines, subquery: check)
         _ = try scope.validate(expression, context.routines, subquery: check)
@@ -1282,9 +1277,9 @@ extension Catalog where Self: ~Escapable {
                               _ context: Context, subquery: SubqueryCheck)
       throws(SQLError) {
     let routines = context.routines
-    // The WHERE admits a correlated column of this query; the projection,
-    // `HAVING`, GROUP BY, and `ORDER BY` bar it (`barred`).
-    let barred = subquery.barred
+    // Every clause admits a correlated column of this query — the WHERE, the
+    // projection, `HAVING`, GROUP BY, and `ORDER BY` alike — each resolving it
+    // through the enclosing `outer` that `subquery` carries.
     if let predicate = select.predicate {
       try scope.comparisons(in: predicate, routines, subquery: subquery)
       // A false WHERE filters every row, so a GROUP BY forms no group and a
@@ -1317,14 +1312,14 @@ extension Catalog where Self: ~Escapable {
           if reachable, case let .expressions(items) = select.projection {
             for item in items {
               try fold(comparisonsIn: item.expression, scope, routines,
-                                subquery: barred)
+                                subquery: subquery)
             }
           }
           // The sort sits below the limit, so its keys fold over the empty
           // group unconditionally.
           for expression in select.orderKeys {
             try fold(comparisonsIn: expression, scope, routines,
-                        subquery: barred)
+                        subquery: subquery)
           }
         }
         return
@@ -1336,18 +1331,18 @@ extension Catalog where Self: ~Escapable {
     if case let .expressions(items) = select.projection {
       for item in items {
         try scope.comparisons(aggregatesIn: item.expression, routines,
-                              subquery: barred)
+                              subquery: subquery)
       }
     }
     for expression in select.orderKeys {
       try scope.comparisons(aggregatesIn: expression, routines,
-                            subquery: barred)
+                            subquery: subquery)
     }
     // Each GROUP BY key is evaluated over the input rows to form the groups,
     // before HAVING, projection, and any limit — so find its comparisons
     // unconditionally in this reachable path.
     for expression in select.grouping.expressions {
-      try scope.comparisons(in: expression, routines, subquery: barred)
+      try scope.comparisons(in: expression, routines, subquery: subquery)
     }
     if let having = select.having {
       // A HAVING aggregate is collected and folded by the group node before the
@@ -1357,8 +1352,8 @@ extension Catalog where Self: ~Escapable {
       // Check them unconditionally, ahead of the reachability-aware scalar
       // walk, exactly as the projection and sort aggregates above and as the
       // validate walk's `aggregates(in:)` does.
-      try scope.comparisons(aggregatesIn: having, routines, subquery: barred)
-      try scope.comparisons(in: having, routines, subquery: barred)
+      try scope.comparisons(aggregatesIn: having, routines, subquery: subquery)
+      try scope.comparisons(in: having, routines, subquery: subquery)
       // A false HAVING filters every group before the projection, so the
       // projection's non-aggregate work is unreachable.
       if scope.constant(having, routines) == false { return }
@@ -1373,14 +1368,14 @@ extension Catalog where Self: ~Escapable {
     if !reachable { reachable = !drops(select.limit, single: sole) }
     if reachable, case let .expressions(items) = select.projection {
       for item in items {
-        try scope.comparisons(in: item.expression, routines, subquery: barred)
+        try scope.comparisons(in: item.expression, routines, subquery: subquery)
       }
     }
     // The sort sits below the limit, so every ORDER BY key runs over the input
     // rows before the cap pages them — its comparisons are checked
     // unconditionally.
     for expression in select.orderKeys {
-      try scope.comparisons(in: expression, routines, subquery: barred)
+      try scope.comparisons(in: expression, routines, subquery: subquery)
     }
   }
 
@@ -1459,11 +1454,9 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) {
     let routines = context.routines
     let scope = try scope(of: select, context)
-    // The WHERE admits a correlated column of this query (`subquery`); the
-    // projection, `HAVING`, and `ORDER BY` bar it (`barred`), diagnosing the
-    // unsupported correlated-projection/HAVING case exactly as the run's
-    // lowering does.
-    let barred = subquery.barred
+    // Every clause admits a correlated column of this query (`subquery`) — the
+    // WHERE, projection, `HAVING`, and `ORDER BY` alike — resolving it against
+    // the enclosing `outer` exactly as the run's lowering does.
     // An `ORDER BY` ordinal names a 1-based SELECT-list position; one outside
     // `1 ... width` names no output column and faults `SQLError.column`
     // (spelled as the ordinal), exactly as the compile path's ordinal
@@ -1533,7 +1526,7 @@ extension Catalog where Self: ~Escapable {
           if !reachable { reachable = !drops(select.limit, single: true) }
           if reachable, case let .expressions(items) = select.projection {
             for item in items {
-              try scope.fold(item.expression, routines, subquery: barred)
+              try scope.fold(item.expression, routines, subquery: subquery)
             }
           }
           // The lone empty group is sorted below the limit — the shape is
@@ -1545,7 +1538,7 @@ extension Catalog where Self: ~Escapable {
           // projection term reached only via the sort is checked even where the
           // projection block above is skipped.
           for expression in select.orderKeys {
-            try scope.fold(expression, routines, subquery: barred)
+            try scope.fold(expression, routines, subquery: subquery)
           }
         }
         return
@@ -1560,11 +1553,11 @@ extension Catalog where Self: ~Escapable {
     // projection or `HAVING` aggregate's.
     if case let .expressions(items) = select.projection {
       for item in items {
-        try scope.aggregates(in: item.expression, routines, subquery: barred)
+        try scope.aggregates(in: item.expression, routines, subquery: subquery)
       }
     }
     for expression in select.orderKeys {
-      try scope.aggregates(in: expression, routines, subquery: barred)
+      try scope.aggregates(in: expression, routines, subquery: subquery)
     }
     // Each GROUP BY key is evaluated over the input rows to form the groups,
     // before the HAVING, the projection, and any limit — so validate every key
@@ -1579,11 +1572,11 @@ extension Catalog where Self: ~Escapable {
     // exactly as the run evaluates it, closing the gap where `group` lowers the
     // key structurally (no evaluation) so `compile` alone never surfaces it.
     for expression in select.grouping.expressions {
-      _ = try scope.validate(expression, routines, subquery: barred)
+      _ = try scope.validate(expression, routines, subquery: subquery)
     }
     if let having = select.having {
-      try scope.aggregates(in: having, routines, subquery: barred)
-      try scope.check(having, routines, subquery: barred)
+      try scope.aggregates(in: having, routines, subquery: subquery)
+      try scope.check(having, routines, subquery: subquery)
       // A false HAVING filters every group before the projection, so the
       // projection's non-aggregate work is unreachable.
       if scope.constant(having, routines) == false { return }
@@ -1605,7 +1598,7 @@ extension Catalog where Self: ~Escapable {
     if !reachable { reachable = !drops(select.limit, single: sole) }
     if reachable, case let .expressions(items) = select.projection {
       for item in items {
-        _ = try scope.validate(item.expression, routines, subquery: barred)
+        _ = try scope.validate(item.expression, routines, subquery: subquery)
       }
     }
     // The sort sits below the limit — the shape is `Project(Limit(Sort(…)))`
@@ -1620,7 +1613,7 @@ extension Catalog where Self: ~Escapable {
     // projection term no sort key reaches stays correctly unchecked (the
     // projection never runs under a row-dropping limit).
     for expression in select.orderKeys {
-      _ = try scope.validate(expression, routines, subquery: barred)
+      _ = try scope.validate(expression, routines, subquery: subquery)
     }
   }
 
@@ -1693,10 +1686,10 @@ extension Catalog where Self: ~Escapable {
     // `USING` merged key (which binds no single ordinal) is matched by term —
     // the same lowering the run's `group` computes.
     let keys = try grouping.map { key throws(SQLError) -> Term in
-      try scope.term(key, routines, subquery: subquery.barred)
+      try scope.term(key, routines, subquery: subquery)
     }
     let supers = try superset.map { key throws(SQLError) -> Term in
-      try scope.term(key, routines, subquery: subquery.barred)
+      try scope.term(key, routines, subquery: subquery)
     }
     // Build the grouping and lower the projection through it to record each
     // output name (an alias, else a group column's own name) — the surface an
@@ -1767,18 +1760,17 @@ extension Catalog where Self: ~Escapable {
         case .sets: ([], [])
         }
     let keys = try grouping.map { key throws(SQLError) -> Term in
-      try scope.term(key, routines, subquery: subquery.barred)
+      try scope.term(key, routines, subquery: subquery)
     }
     let supers = try superset.map { key throws(SQLError) -> Term in
-      try scope.term(key, routines, subquery: subquery.barred)
+      try scope.term(key, routines, subquery: subquery)
     }
     var grouped = try Grouped(scope, grouping, keys, aggregations,
                               superset: supers, subquery: subquery)
     let terms = try grouped.terms(select.projection, routines,
                                   subquery: subquery)
-    let barred = subquery.barred
     return (terms, { expression throws(SQLError) in
-      try grouped.resolve(expression, routines, subquery: barred)
+      try grouped.resolve(expression, routines, subquery: subquery)
     })
   }
 
@@ -1819,21 +1811,22 @@ extension Catalog where Self: ~Escapable {
     //
     // Per ISO a LATERAL body's preceding-FROM references are in scope
     // throughout its query expression, including the SELECT list, so its output
-    // shape is NOT correlation-independent — a projected preceding column
+    // shape is not correlation-independent — a projected preceding column
     // (`SELECT T.Id AS id`) types from that outer column. So the schema derive
-    // threads the `preceding` scope as the correlation stack (`with(outer:)`)
-    // and marks the body a lateral one (`lateralizing`), the same
-    // revealed-base-with-outer context `compile(select)`'s `lateral` compiles
-    // it under — schema, validation, and compile share it, so a projected
+    // threads the `preceding` scope as the correlation stack (`with(outer:)`),
+    // the same revealed-base-with-outer context `compile(select)` compiles the
+    // body under — schema, validation, and compile share it, so a projected
     // preceding column derives its type here exactly as the run lowers it to a
-    // bound parameter. `validate: false` keeps the derive lenient; the strict
-    // operand/function type-check rides through `compile(select)`'s `lateral`
-    // path where the `validate` gate is honoured, so it is not duplicated here.
+    // bound parameter. Correlation is admitted in every clause, so the
+    // projected preceding column needs no special lateral admission. `validate:
+    // false` keeps the derive lenient; the strict operand/function type-check
+    // rides through `compile(select)` where the `validate` gate is honoured, so
+    // it is not duplicated here.
     if relation.lateral, case let .derived(query) = relation.source {
       let stack = context.outer ?? Outer()
       let nested = stack.nested(under: preceding ?? Scope([]))
       let scope = context.revealed().with(outer: nested)
-          .lateralizing().validating(false)
+          .validating(false)
       return try materialise(query, scope, rows: false,
                              columns: relation.columns).schema()
     }

--- a/Sources/SQLEngine/Scope.swift
+++ b/Sources/SQLEngine/Scope.swift
@@ -55,20 +55,17 @@ extension Schema {
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<Term> {
-    // A projection is a barred clause position: a correlated column of this
-    // query has no evaluator here (only WHERE/ON/HAVING admit one). The cut is
-    // intrinsic to the entry, so a caller cannot pass an admitting seam into a
-    // projection — the FROM-less scalar path included — keeping the run's
+    // A correlated column of this query is admitted in the projection as in
+    // every other clause: `subquery` carries the enclosing `outer` scope, so a
+    // name the local relations do not bind resolves outward, keeping the run's
     // lowering and the schema `columns(of:)` derive in lockstep.
-    let subquery = subquery.barred
     switch projection {
     case .all:
       return (0 ..< width).map { .slot($0) }
     case let .columns(columns):
       // Lower each bare column through `term`, so a name this relation does not
-      // bind consults the `subquery` surface: a correlated reference on the
-      // barred projection surface is diagnosed unsupported (parity with the
-      // schema path) rather than faulting `SQLError.column`.
+      // bind consults the `subquery` surface: a correlated reference resolves
+      // against the enclosing `outer` rather than faulting `SQLError.column`.
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
       for column in columns {
@@ -211,9 +208,9 @@ extension Schema {
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
-    // An ORDER BY is barred, as the projection is: a correlated column of this
-    // query is out of the cut here, so the entry bars the seam by construction.
-    let subquery = subquery.barred
+    // An ORDER BY admits a correlated column of this query as every clause
+    // does: an unbound name lowers through `term` and resolves against the
+    // enclosing `outer` that `subquery` carries.
     return try SQLEngine.order(order, projection, names) {
       expression throws(SQLError) in
       try term(expression, in: relation, routines, subquery: subquery)
@@ -3276,10 +3273,9 @@ internal struct Scope {
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported) throws(SQLError)
       -> Array<Term> {
-    // A projection is a barred clause position (see `Schema.terms`): the entry
-    // bars the seam, so no join-scope projection can admit a correlated column
-    // of this query.
-    let subquery = subquery.barred
+    // A correlated column of this query is admitted in a join-scope projection
+    // as in every clause (see `Schema.terms`): an unbound name resolves through
+    // the enclosing `outer` that `subquery` carries.
     switch projection {
     case .all:
       // The `NATURAL`/`USING` merged columns FIRST (ISO 9075 7.10), each as its
@@ -3292,8 +3288,8 @@ internal struct Scope {
     case let .columns(columns):
       // Lower each bare column through `term`, so a name none of this scope's
       // relations bind consults the `subquery` surface: a correlated reference
-      // on the barred projection surface is diagnosed unsupported (parity with
-      // the schema path) rather than faulting `SQLError.column`.
+      // resolves against the enclosing `outer` rather than faulting
+      // `SQLError.column`.
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)
       for column in columns {
@@ -3461,8 +3457,8 @@ internal struct Scope {
                       _ names: Array<String?>, _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
-    // An ORDER BY is barred, as the projection is (see `Schema.order`).
-    let subquery = subquery.barred
+    // An ORDER BY admits a correlated column, as the projection does (see
+    // `Schema.order`).
     return try SQLEngine.order(order, projection, names) {
       expression throws(SQLError) in
       try term(expression, routines, subquery: subquery)

--- a/Sources/SQLEngine/Windowed.swift
+++ b/Sources/SQLEngine/Windowed.swift
@@ -1149,9 +1149,9 @@ internal struct Windowed {
                                _ routines: Routines = [:],
                                subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<Term> {
-    // A window-query projection is a barred clause position (a correlated
-    // column of this query is diagnosed there, as the run's projection bars it).
-    let subquery = subquery.barred
+    // A window-query projection admits a correlated column of this query, as
+    // every clause does: an unbound name resolves against the enclosing `outer`
+    // that `subquery` carries.
     switch projection {
     case .all:
       throw .state("0A000",
@@ -1187,8 +1187,7 @@ internal struct Windowed {
                       _ routines: Routines = [:],
                       subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
-    // A query ORDER BY is barred, as the projection is.
-    let subquery = subquery.barred
+    // A query ORDER BY admits a correlated column, as the projection does.
     var resolved = Array<SortKey>()
     resolved.reserveCapacity(order.keys.count)
     for key in order.keys {

--- a/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
+++ b/Tests/SQLTests/Queries/EngineValueAndSetTests.swift
@@ -970,16 +970,12 @@ struct EngineCorrelatedNullUnificationTests {
         yields: [[30], [25], [40]])
   }
 
-  @Test func `a barred ordinary subquery projection still faults 0A000`() throws {
-    // The parity guard: the read-side resolution keeps the `admits` bar, so an
-    // ordinary (non-lateral) correlated subquery in a projection is still
-    // diagnosed `.unsupported` — the unification does not widen acceptance. The
-    // barred surface faults the same on the run and schema paths.
-    let people = try roster()
-    #expect(throws: SQLError.state("0A000",
-        "a correlated column is only supported in a subquery's WHERE")) {
-      _ = try people.run(parse("SELECT (VALUES (P.Age)) FROM People AS P"))
-    }
+  @Test func `an ordinary subquery projection correlates`() throws {
+    // A correlated column is admitted in a subquery's projection, not only its
+    // WHERE: `(VALUES (P.Age))` names the outer row's `Age`, bound per
+    // re-execution, so each row projects its own age.
+    try roster().expect("SELECT (VALUES (P.Age)) FROM People AS P",
+                        yields: [[30], [25], [30], [40], [25]])
   }
 }
 

--- a/Tests/SQLTests/Queries/LateralTests.swift
+++ b/Tests/SQLTests/Queries/LateralTests.swift
@@ -423,39 +423,26 @@ struct LateralProjectionCorrelationTests {
     #expect(columns.map(\.type) == [.integer, .integer])
   }
 
-  @Test func `an ordinary subquery projection still cannot correlate`() throws {
-    // The bar lift is LATERAL-ONLY: an ordinary correlated scalar subquery in
-    // the projection — `SELECT (VALUES (T.Id)) FROM T` — still faults
-    // `.unsupported`, since a subquery's projection is a barred clause position
-    // (no evaluator for an outer column there). This pins the LATERAL-only
-    // scoping — the everywhere-correlation admission is set for a LATERAL body
-    // alone, never an ordinary subquery.
-    try fixture().expect(
-        "SELECT (VALUES (T.Id)) FROM T",
-        fails: .state("0A000",
-            "a correlated column is only supported in a subquery's WHERE"))
+  @Test func `an ordinary subquery projection correlates`() throws {
+    // A correlated column is admitted in every subquery clause, not only its
+    // WHERE: `SELECT (VALUES (T.Id)) FROM T` names the outer `T.Id` in the
+    // scalar subquery's projection, bound per outer row, so each row projects
+    // its own `Id`.
+    try fixture().expect("SELECT (VALUES (T.Id)) FROM T",
+                         yields: [[1], [2], [3]])
   }
 
-  @Test func `an ordinary nested subquery inside a LATERAL body is not lateralised`()
+  @Test func `a nested subquery inside a LATERAL body correlates the outer`()
       throws {
-    // The LATERAL everywhere-correlation admission covers ONLY the lateral
-    // body's own row constructor, never a nested ordinary subquery within it.
-    // So an ordinary correlated scalar subquery inside a lateral `VALUES` row —
-    // `VALUES ((VALUES (T.Id)))` — is barred at the strict schema check exactly
-    // as the non-lateral twin `SELECT (VALUES (T.Id)) FROM T` is, since the
-    // nested subquery builds its own Resolution with the lateral flag cleared
-    // (`everywhere: false`). Threading the lateral flag into the nested
-    // subquery instead admitted its `T.Id` everywhere and lowered it to a
-    // correlated parameter the nested subquery never wires — a wrong,
-    // mismatched fault (`no such column 'Id'`) rather than the correct barred
-    // one — the bug the cleared flag fixes.
-    let query = try parse(query:
+    // A correlated column is admitted in every subquery clause, so a nested
+    // ordinary scalar subquery inside a lateral `VALUES` row —
+    // `VALUES ((VALUES (T.Id)))` — resolves its `T.Id` to the outer `T` row the
+    // lateral body ranges over, as the lateral body's own constructor does.
+    // Each `T` row projects its own `Id` through `d.x`.
+    try fixture().expect(
         "SELECT d.x FROM T " +
-        "JOIN LATERAL (VALUES ((VALUES (T.Id)))) AS d(x) ON 1 = 1")
-    #expect(throws: SQLError.state("0A000",
-        "a correlated column is only supported in a subquery's WHERE")) {
-      _ = try fixture().columns(of: query, validate: true)
-    }
+        "JOIN LATERAL (VALUES ((VALUES (T.Id)))) AS d(x) ON 1 = 1",
+        yields: [[1], [2], [3]])
   }
 
   @Test func `a LATERAL VALUES projects a preceding column`() throws {
@@ -588,17 +575,72 @@ struct LateralAggregateCorrelationTests {
         yields: [[1, 2], [2, 1], [3, 0]])
   }
 
-  @Test func `an ordinary grouped subquery projection still cannot correlate`()
-      throws {
-    // The grouped bar lift is LATERAL-ONLY: an ordinary correlated grouped
-    // scalar subquery that projects an outer column — `SELECT (SELECT T.Id FROM S
-    // GROUP BY S.k) FROM T` — STILL faults `.unsupported`, since a subquery's
-    // grouped projection is a barred clause position. This pins the exemption on
-    // the LATERAL `everywhere` surface, never opened for every grouped subquery.
+  @Test func `an ordinary grouped subquery projection correlates`() throws {
+    // A correlated column is admitted in a grouped subquery's projection: the
+    // inner `SELECT T.Id FROM S WHERE S.k = T.Id GROUP BY S.k` collapses `S` to
+    // the single group matching the outer row and projects that row's `T.Id`.
+    // Id 1 and Id 2 each match one group; Id 3 matches no `S` row, so the empty
+    // grouped subquery yields NULL.
     try fixture().expect(
-        "SELECT (SELECT T.Id FROM S GROUP BY S.k) FROM T",
-        fails: .state("0A000",
-            "a correlated column is only supported in a subquery's WHERE"))
+        "SELECT (SELECT T.Id FROM S WHERE S.k = T.Id GROUP BY S.k) FROM T",
+        yields: [[1], [2], [nil]])
+  }
+
+  @Test func `a correlated column resolves in a subquery's ORDER BY`() throws {
+    // A correlated column is admitted in a subquery's ORDER BY: the inner
+    // `EXISTS` body orders by the outer `T.Id`, bound per outer row. `S` has a
+    // matching `k` for Id 1 and Id 2 but none for Id 3.
+    try fixture().expect(
+        "SELECT T.Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM S WHERE S.k = T.Id ORDER BY T.Id)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `a correlated column resolves in a subquery's HAVING`() throws {
+    // A correlated column is admitted in a subquery's HAVING: the grouped
+    // `EXISTS` body compares each group's `SUM(S.x)` against the outer `T.Id`.
+    // Group k=1 sums to 201, k=2 to 200. Id 1 keeps both groups, Id 2 keeps
+    // k=1 alone, Id 3 keeps neither, so the subquery is empty and no row shows.
+    try fixture().expect(
+        "SELECT T.Id FROM T WHERE EXISTS " +
+        "(SELECT S.k FROM S GROUP BY S.k HAVING SUM(S.x) > T.Id * 100)",
+        yields: [[1], [2]])
+  }
+
+  @Test func `a correlated column resolves as a subquery's GROUP BY key`()
+      throws {
+    // A correlated column is admitted as a GROUP BY key: the outer `T.Id` joins
+    // the grouping columns of the `EXISTS` body. `S` is non-empty for every
+    // outer row, so each grouped subquery has a row and `EXISTS` holds.
+    try fixture().expect(
+        "SELECT T.Id FROM T " +
+        "WHERE EXISTS (SELECT 1 FROM S GROUP BY S.k, T.Id)",
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `a set-op carrier ORDER BY correlates the outer column`() throws {
+    // A correlated column drives a set operation's carrier `ORDER BY`: the
+    // scalar subquery's `UNION` output lacks `Id`, so `ORDER BY T.Id` names the
+    // enclosing `T` row. The run resolves the key against the enclosing scope,
+    // and `columns(of:validate:)` must admit it identically rather than
+    // rejecting it as an unknown column. Both arms yield `MAX(S.k)` (2), so the
+    // `UNION` collapses to one row and the scalar is well-formed.
+    let sql = "SELECT (SELECT MAX(S.k) FROM S UNION SELECT MAX(S.k) FROM S " +
+              "ORDER BY T.Id) FROM T"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
+    try fixture().expect(sql, yields: [[2], [2], [2]])
+  }
+
+  @Test func `a set-op carrier ORDER BY correlates inside a comparison`()
+      throws {
+    // The comparability pass over the run's carrier `ORDER BY` must resolve a
+    // correlated column nested in a comparison (`T.Id > 1`) against the same
+    // enclosing scope, so a correlated key faults nowhere the run does not.
+    try fixture().expect(
+        "SELECT (SELECT MAX(S.k) FROM S UNION SELECT MAX(S.k) FROM S " +
+        "ORDER BY CASE WHEN T.Id > 1 THEN 0 ELSE 1 END) FROM T",
+        yields: [[2], [2], [2]])
   }
 
   @Test func `a LATERAL join under an aggregate is now supported`() throws {

--- a/Tests/SQLTests/Queries/ScalarSubqueryTests.swift
+++ b/Tests/SQLTests/Queries/ScalarSubqueryTests.swift
@@ -319,20 +319,17 @@ struct ScalarSubqueryCorrelationTests {
         yields: [[10], [20], [30]])
   }
 
-  @Test func `a correlated column in the inner projection is unsupported`()
-      throws {
-    // The minimal (b) cut admits a correlated column ONLY in the inner
-    // subquery's WHERE. One in the inner projection (`SELECT T.V …`) needs the
-    // general outer-row evaluator, so it is diagnosed unsupported at both
-    // `columns(of:)` and run rather than mis-resolved.
-    let query = try parse(query: "SELECT (SELECT T.V FROM S) FROM T")
-    #expect(throws: SQLError.self) {
-      try fixture().columns(of: query, validate: true)
-    }
+  @Test func `a correlated column in the inner projection resolves`() throws {
+    // A correlated column is admitted in every clause, not only the inner
+    // WHERE: `SELECT T.V` in the inner projection binds the outer row's `V` per
+    // re-execution. The inner `WHERE S.V = T.V` collapses it to one row so the
+    // scalar subquery yields the outer `V` itself.
+    let query = try parse(query:
+        "SELECT (SELECT T.V FROM S WHERE S.V = T.V) FROM T")
+    #expect(try fixture().columns(of: query, validate: true).count == 1)
     try fixture().expect(
-        "SELECT (SELECT T.V FROM S) FROM T",
-        fails: .state("0A000",
-            "a correlated column is only supported in a subquery's WHERE"))
+        "SELECT (SELECT T.V FROM S WHERE S.V = T.V) FROM T",
+        yields: [[10], [20], [30]])
   }
 
   @Test func `a correlated WHERE subquery still admits and runs`() throws {


### PR DESCRIPTION
ISO 9075 puts an outer reference in scope throughout a subquery, so a correlated column may name the enclosing query in the projection, GROUP BY, HAVING, and ORDER BY, not only the WHERE and join ON. The engine had gated correlation to WHERE/ON: a `Resolution`/`SubqueryCheck` carried an `admits` flag (false off the WHERE/ON seam) and a `.barred` copy that faulted `0A000, "a correlated column is only supported in a subquery's WHERE"` when any other clause named an outer column. A LATERAL body lifted the bar through a second flag, `everywhere`, set by a `Context.lateral` that `lateralizing()`/`unlateralized()` threaded.

The executor and the validate path already bound and typed a correlated column in every clause with parity; the flag only rejected queries the runtime handled correctly. Remove the gate rather than widen it: drop `admits`, `everywhere`, and `.barred` from both `Resolution` and `SubqueryCheck` so `correlate`/`correlated`/`type` resolve against the enclosing `outer` uniformly, and drop the now-dead `Context.lateral`, `lateralizing()`, and `unlateralized()` — a lateral body's preceding-FROM correlation is ordinary correlation once the bar is gone. The `.barred` call sites collapse to the plain `subquery` they aliased.

Convert the six tests that pinned the bar (an ordinary or grouped subquery projection, a nested subquery in a LATERAL body, the VALUES projection) to assert the query now resolves and runs, and add positive tests for correlation in a subquery's ORDER BY, HAVING, and GROUP BY key. Rewrite the comments that described the removed barring.

Closes the last of the ISO-SQL correlation coverage gaps (#127).