### PR TITLE
SQLEngine: WINDOW joins

### DIFF
--- a/Sources/SQLEngine/Aggregation.swift
+++ b/Sources/SQLEngine/Aggregation.swift
@@ -1086,95 +1086,23 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func group(_ select: Select, _ relation: Relation,
                                 _ from: Resolved, _ context: Context)
       throws(SQLError) -> Plan {
-    // The augmented `context` threads to `subquery(of:)`, which reveals the
-    // base — this select's and every enclosing select's derived aliases
-    // dropped, the CTEs and store relations kept — before lowering a nested
-    // subquery, so its FROM sees no derived alias while a CTE a same-named
-    // derived alias shadows stays visible (a grouped `ORDER BY SUM((SELECT x
-    // FROM d))` reads the CTE `d` beneath the derived `d`). Resolve every
-    // joined relation and lay the FROM relation and each joined one end to end
-    // in one combined ordinal space (as the non-aggregate join path does), so
-    // the WHERE, keys, and aggregate arguments resolve uniformly. A LATERAL
-    // join (CROSS/OUTER APPLY) is supported here too: the front half is shared
-    // with the non-aggregate path, so the apply body's output columns land in
-    // scope for the keys, aggregate arguments, HAVING, and ORDER BY, and the
-    // chain carries the correlated `apply` node the aggregate then groups.
-    let (joined, relations) = try resolve(from: relation, schema: from.schema,
-                                          joins: select.joins, context)
-    // Model the `NATURAL`/`USING` merged columns in the scope and synthesize
-    // each named-column join's lowered `on` filter, as the non-aggregate join
-    // path does — so a bare merged column groups/projects by the coalesced
-    // value.
-    let (ons, merged, merges) = try merges(over: relations, select.joins)
-    let scope = Scope(relations, merged: merged)
-
-    // Each join's ON predicate lowers to a `Filter` at its own chain level,
-    // resolved against only the prefix already in scope (as the non-aggregate
-    // path does). A `column = column` conjunct becomes a `match` hash-join key;
-    // the rest is a residual the join runs as a filter.
-    // Each join's prefix scope — the relations available at that join point,
-    // never one joined later — carries the merged columns accumulated before
-    // this join, so a chained `USING` `on` keys on the merged value.
-    let prefixes = select.joins.indices.map { index in
-      Scope(Array(relations[0 ... index + 1]), merged: merges[index])
-    }
-    // Resolve each LATERAL join's body once against the preceding FROM — the
-    // FROM relation and the joins before this one (`relations[0…index]`, one
-    // less than the prefix, which includes the join's own relation) — so a body
-    // column naming a preceding relation correlates outward and the body's plan
-    // is pre-compiled for the per-outer-row apply. A non-lateral join records
-    // nothing here (its `nil` slot). The apply is `.inner` (CROSS APPLY, which
-    // drops an unmatched outer row) or `.left` (OUTER APPLY, which NULL-extends
-    // one); `.right`/`.full` are nonsensical for a correlated body, so fault.
-    let empty: (key: Subkey, correlation: Correlation)? = nil
-    var laterals = Array(repeating: empty, count: select.joins.count)
-    for index in select.joins.indices {
-      let join = select.joins[index]
-      guard join.relation.lateral,
-          case let .derived(body) = join.relation.source else { continue }
-      guard join.kind == .inner || join.kind == .left else {
-        throw .state("0A000", "a RIGHT/FULL LATERAL join is not supported")
-      }
-      let preceding = Scope(Array(relations[0 ... index]),
-                            merged: merges[index])
-      laterals[index] = try lateral(body, against: preceding,
-                                    columns: join.relation.columns, context)
-    }
-    // Compile every nested subquery once for arity/type, ahead of lowering, and
-    // discover each one's correlation: a join `ON`'s against its prefix scope,
-    // the WHERE against the join `scope`. Every clause admits a correlated
-    // column of this query — the WHERE, join ONs, aggregations, projection,
-    // `HAVING`, and `ORDER BY` alike. `validate` gates the eager
-    // type-check of a filtered-out derived body a nested subquery names, off on
-    // the run path, on for a schema check.
-    let plans = try subquery(of: select, context, enclosing: scope,
-                             prefixes: prefixes)
-    // Validate every named window the `WINDOW` clause defines, whether or not it
-    // is referenced — the aggregate route reaches here ahead of the window and
-    // ordinary paths' checks, so an unused malformed definition (an undefined
-    // base, an unresolvable column, or an invalid frame) would otherwise slip
-    // through into a grouped compile.
-    try validate(named: select.window, against: scope, context.routines,
-                 subquery: plans.rest)
-    var matches = Array<Filter>()
-    matches.reserveCapacity(select.joins.count)
-    for index in select.joins.indices {
-      // A `NATURAL`/`USING` join's `on` is the synthesized, already-lowered
-      // filter (`ons[index]`, `nil` for a degenerate `NATURAL` join); a plain
-      // join lowers its written `ON` against the prefix scope.
-      if let on = ons[index] {
-        matches.append(on)
-      } else {
-        try matches.append(prefixes[index].on(select.joins[index].on,
-                                              context.routines,
-                                              subquery: plans.on(index)))
-      }
-    }
-    var predicate: Filter? = nil
-    if let clause = select.predicate {
-      predicate = try scope.lower(clause, context.routines,
-                                  subquery: plans.rest)
-    }
+    // Resolve the FROM/JOIN front half — the combined join `scope`, each joined
+    // relation's `Resolved`, the correlated `laterals` and lowered `matches`,
+    // the lowered WHERE `predicate`, and the nested-subquery `plans` — through
+    // the shared `source(_:_:_:_:)` seam, so the grouped path lays the FROM
+    // relation and every joined one end to end in the same combined ordinal
+    // space the non-aggregate path does, with the keys, aggregate arguments,
+    // HAVING, and ORDER BY resolving over it and a LATERAL apply body's output
+    // columns in scope. The augmented `context` threads on so a nested subquery
+    // reveals the base (this select's and every enclosing select's derived
+    // aliases dropped, the CTEs and store kept).
+    let front = try front(select, relation, from, context)
+    let scope = front.scope
+    let joined = front.joined
+    let laterals = front.laterals
+    let matches = front.matches
+    let predicate = front.predicate
+    let plans = front.plans
 
     // This select's grouping keys and — for one arm of an expanded `GROUPING
     // SETS` — the superset (the union of every set's keys, so an absent key

--- a/Sources/SQLEngine/Compilation.swift
+++ b/Sources/SQLEngine/Compilation.swift
@@ -1724,28 +1724,6 @@ extension Catalog where Self: ~Escapable {
         limit: select.limit)
   }
 
-  /// Compiles a window `select` — one projecting or ordering by a window
-  /// function, with no aggregation — into `Project(Limit(Sort(Window(Select(
-  /// scan)))))`, the `Select` the WHERE over the single FROM relation and the
-  /// `Window` appending each window's result.
-  ///
-  /// The distinct windows are collected from the projection and the `ORDER BY`,
-  /// each lowered to a `Windowing` (its `PARTITION BY` keys and window `ORDER
-  /// BY` over the source scope) and deduped. The `window` node passes the
-  /// source's rows through and appends one slot per windowing; the projection
-  /// and query `ORDER BY` lower against that widened slot space through a
-  /// `Windowed`, a window reading its appended slot and an ordinary column its
-  /// own packed source slot.
-  ///
-  /// The source materialises exactly the base ordinals the windows, the WHERE,
-  /// the projection, and the `ORDER BY` read — discovered by a first lowering
-  /// over an identity source space (a window term lands past the source width,
-  /// so it names no base ordinal), then packed. A second lowering over the
-  /// packed slots yields the terms the plan carries.
-  ///
-  /// This first slice supports a single relation: a window over a join faults
-  /// the feature diagnostic (on both the run and validate paths) until the join
-  /// chain is threaded through the window source.
   /// Validates every named window `windows` defines against `scope`, resolving
   /// each spec's base (an undefined base faults `42704`) then its partition and
   /// order keys against the scope (an unknown column faults) exactly as a
@@ -1768,36 +1746,45 @@ extension Catalog where Self: ~Escapable {
     }
   }
 
+  /// Compiles a window `select` — one projecting or ordering by a window
+  /// function, with no aggregation — into `Project(Limit(Sort(Window(Select(
+  /// source)))))`, the `Select` the WHERE over the source and the `Window`
+  /// appending each window's result. The source is the FROM relation's scan or,
+  /// when the query joins, the left-deep join chain the plain join path builds
+  /// (INNER/OUTER/CROSS·OUTER APPLY) — so a window partitions and orders over
+  /// the joined rows exactly as it does over a single relation's.
+  ///
+  /// The distinct windows are collected from the projection and the `ORDER BY`,
+  /// each lowered to a `Windowing` (its `PARTITION BY` keys and window `ORDER
+  /// BY` over the source scope) and deduped. The `window` node passes the
+  /// source's rows through and appends one slot per windowing; the projection
+  /// and query `ORDER BY` lower against that widened slot space through a
+  /// `Windowed`, a window reading its appended slot and an ordinary column its
+  /// own packed source slot.
+  ///
+  /// The source materialises exactly the combined base ordinals the windows,
+  /// the WHERE, the join matches, the LATERAL correlations, the projection, and
+  /// the `ORDER BY` read — discovered by a first lowering over an identity
+  /// combined source space (a window term lands past the source width, so it
+  /// names no base ordinal), then packed per relation. A second lowering over
+  /// the packed slots yields the terms the plan carries.
   internal borrowing func windowed(_ select: Select, _ relation: Relation,
                                    _ from: Resolved, _ context: Context)
       throws(SQLError) -> Plan {
-    guard select.joins.isEmpty else {
-      throw .state("0A000",
-                   "a window function with a join is not yet supported")
-    }
-    let scope = Scope([(relation, from.schema)])
-    let plans = try subquery(of: select, context, enclosing: scope)
+    // The FROM/JOIN front half — the combined join `scope`, each joined
+    // relation's `Resolved`, the correlated `laterals`, the lowered join
+    // `matches` and WHERE `predicate`, and the nested-subquery `plans` (which
+    // also validates the WINDOW clause) — shared with the grouped and plain
+    // join paths.
+    let front = try front(select, relation, from, context)
+    let scope = front.scope
+    let predicate = front.predicate
     let routines = context.routines
 
-    // Validate every named window the clause defines, including one no window
-    // function references — a referenced window is also resolved through its
-    // inlined use below, but an unused definition would otherwise be dropped
-    // unchecked.
-    try validate(named: select.window, against: scope, routines,
-                 subquery: plans.rest)
-
-    // The WHERE lowers below the window node, in the source's base-ordinal
-    // space; a correlated column of this query is admitted here, as the run's
-    // WHERE lowering allows.
-    var predicate: Filter? = nil
-    if let clause = select.predicate {
-      predicate = try scope.lower(clause, routines, subquery: plans.rest)
-    }
-
     // The distinct windows the query computes, in first-appearance order,
-    // gathered from the projection and the `ORDER BY` and resolved to
-    // base-ordinal windowings. An unsupported function faults the feature
-    // diagnostic in parity with the schema type derive.
+    // gathered from the projection and the `ORDER BY`. An unsupported function
+    // or frame faults the feature diagnostic in parity with the schema type
+    // derive.
     var expressions = Array<Expression>()
     for expression in select.projection.projected {
       expression.collect(windows: &expressions)
@@ -1818,44 +1805,70 @@ extension Catalog where Self: ~Escapable {
       }
     }
 
-    // First pass: lower the projection and `ORDER BY` over an identity source
-    // space. This both discovers the base ordinals they read — a window term
-    // lands at or past the source width, so it contributes no base ordinal — and
-    // gathers the query's windowings, which the `Windowed` appends as it first
-    // meets each (sharing a deterministic window, keeping a non-deterministic one
-    // distinct). Their partition/order references, and the WHERE's, join those.
+    // First pass: lower the projection and `ORDER BY` over an identity combined
+    // source space (the FROM relation and every joined one end to end). This
+    // discovers the base ordinals they read — a window term lands at or past
+    // the source width, contributing no base ordinal — and gathers the query's
+    // windowings, which the `Windowed` appends as it first meets each (sharing
+    // a deterministic window, keeping a non-deterministic one distinct). Their
+    // partition/order references, the WHERE's, each join match's, and each
+    // LATERAL apply's correlation slots join the referenced set.
     let space = scope.layout.reduce(0) { $0 + $1.extent }
     let identity =
         Dictionary(uniqueKeysWithValues: (0 ..< space).map { ($0, $0) })
     var probe = Windowed(scope, identity, width: space)
     let probed = try probe.terms(select.projection, routines,
-                                 subquery: plans.rest)
+                                 subquery: front.plans.rest)
     var references = Set<Int>()
     for term in probed { term.references(into: &references) }
     if let clause = select.order {
       for key in try probe.order(clause, probed, routines,
-                                 subquery: plans.rest) {
+                                 subquery: front.plans.rest) {
         key.term.references(into: &references)
       }
     }
     for windowing in probe.windowings { windowing.references(into: &references) }
     predicate?.references(into: &references)
+    for match in front.matches { match.references(into: &references) }
+    // A LATERAL apply reads its correlation's outer ordinals from the left
+    // chain's record, so those preceding-relation ordinals must be materialised
+    // even when no clause references them.
+    for lateral in front.laterals {
+      references.formUnion(lateral?.correlation.slots ?? [])
+    }
     // The window results occupy slots at or past the source width; only the
-    // base ordinals (below it) name columns the scan materialises.
-    let ordinals = references.filter { $0 < space }.sorted()
-    let slot = invert(ordinals)
+    // base ordinals (below it) name columns the source materialises. Pack them
+    // per relation in chain order — relation `i`'s referenced ordinals take a
+    // contiguous slot run after every earlier relation's — building the
+    // combined-ordinal → slot map and each relation's leaf ordinals. For a
+    // single relation this is the flat `invert(ordinals)` the old path used.
+    let combined = references.filter { $0 < space }.sorted()
+    var slot = Dictionary<Int, Int>(minimumCapacity: combined.count)
+    var locals = Array<Array<Int>>()
+    var packed = 0
+    for (offset, extent) in scope.layout {
+      let local = combined.compactMap {
+        offset <= $0 && $0 < offset + extent ? $0 - offset : nil
+      }
+      for index in local.indices {
+        slot[offset + local[index]] = packed + index
+      }
+      locals.append(local)
+      packed += local.count
+    }
 
     // Second pass: lower against the packed source slots — a window reads its
-    // appended slot (source width plus its index), an ordinary column its packed
-    // slot. It gathers the same windowings (the same walk and sharing rule) now
-    // over the source slot space, so windowing `j` reads packed source cells.
-    var windowed = Windowed(scope, slot, width: ordinals.count)
+    // appended slot (packed source width plus its index), an ordinary column
+    // its packed slot. It gathers the same windowings (the same walk and
+    // sharing rule) over the packed slot space, so windowing `j` reads packed
+    // source cells.
+    var windowed = Windowed(scope, slot, width: combined.count)
     let projection = try windowed.terms(select.projection, routines,
-                                        subquery: plans.rest)
+                                        subquery: front.plans.rest)
     var order = Array<SortKey>()
     if let clause = select.order {
       order = try windowed.order(clause, projection, routines,
-                                 subquery: plans.rest)
+                                 subquery: front.plans.rest)
     }
     // Under DISTINCT every `ORDER BY` key must be a select-list value (see
     // `distinct`); the keys and projection are in the window's output slot
@@ -1864,7 +1877,30 @@ extension Catalog where Self: ~Escapable {
       order = try distinct(clause.keys, order, projection)
     }
 
-    var chain = from.leaf(ordinals)
+    // The left-deep source chain (as the plain join path builds it): from the
+    // FROM relation's leaf, each join folds in the next relation — an INNER
+    // join a `Select` on its ON over the product, an OUTER join an `outer`
+    // node, a LATERAL join a correlated `apply`. The WHERE then filters the
+    // whole chain below the window node, so window functions see the post-WHERE
+    // rows (ISO).
+    var chain = from.leaf(locals[0])
+    for index in select.joins.indices {
+      let on = front.matches[index].remapped(through: slot)
+      if let lateral = front.laterals[index] {
+        chain = .apply(chain, key: lateral.key,
+                       correlation: lateral.correlation.remapped(through: slot),
+                       ordinals: locals[index + 1], on: on,
+                       kind: select.joins[index].kind)
+        continue
+      }
+      let leaf = front.joined[index].leaf(locals[index + 1])
+      switch select.joins[index].kind {
+      case .inner:
+        chain = .select(on, .product(chain, leaf))
+      case .left, .right, .full:
+        chain = .outer(chain, leaf, on: on, kind: select.joins[index].kind)
+      }
+    }
     if let predicate {
       chain = .select(predicate.remapped(through: slot), chain)
     }

--- a/Sources/SQLEngine/Compilation.swift
+++ b/Sources/SQLEngine/Compilation.swift
@@ -12,6 +12,26 @@ internal struct Resolved {
   let leaf: (Array<Int>) -> Plan
 }
 
+/// The resolved FROM/JOIN front half a join-bearing compile shares — built once
+/// by `front(_:_:_:_:)` and consumed by the grouped, windowed, and plain join
+/// paths so the three cannot drift. `joined` is each joined relation's
+/// `Resolved` (for its leaf, in join order); `scope` lays the FROM relation and
+/// every joined one end to end in one combined ordinal space (carrying the
+/// NATURAL/USING merged columns); `laterals[i]` is a LATERAL join's
+/// pre-compiled apply data (its body occurrence `key` and correlation), `nil`
+/// for a plain join; `matches[i]` is join `i`'s lowered `ON` (a `column =
+/// column` conjunct a hash-join key, the rest a residual); `predicate` is the
+/// lowered `WHERE`; and `plans` is the nested-subquery pre-pass the clause
+/// lowering reads.
+internal struct Front {
+  let joined: Array<Resolved>
+  let scope: Scope
+  let laterals: Array<(key: Subkey, correlation: Correlation)?>
+  let matches: Array<Filter>
+  let predicate: Filter?
+  let plans: Plans
+}
+
 /// The sorted, deduplicated ordinals a query references: the union of the
 /// ordinals its `projection` terms read, the columns its `filter` reads, and
 /// every column its `order` keys read. The projection terms hold ordinals at
@@ -1345,6 +1365,85 @@ extension Catalog where Self: ~Escapable {
           merged: try merged(through: count, over: relations, joins))
   }
 
+  /// Resolves `select`'s FROM/JOIN front half into a `Front` — the combined
+  /// join scope and the lowered join filters, subquery plans, and WHERE the
+  /// grouped, windowed, and plain join compile paths all build over. Extracted
+  /// verbatim from those paths so a single seam resolves the joins.
+  internal borrowing func front(_ select: Select, _ relation: Relation,
+                                _ from: Resolved, _ context: Context)
+      throws(SQLError) -> Front {
+    // Resolve every joined relation and lay the FROM relation first, then each
+    // joined one in source order, end to end in one combined ordinal space. The
+    // helper threads each join's preceding FROM as its resolve scope, so a
+    // LATERAL arm's schema derives against the relations before it.
+    let (joined, relations) = try resolve(from: relation, schema: from.schema,
+                                          joins: select.joins, context)
+    // Model each NATURAL/USING join's merged columns (ISO 9075 7.10) in the
+    // scope and synthesize each named-column join's lowered `left.c = right.c`
+    // filter — a no-op (empty merged set, all-`nil` `ons`) for a chain with
+    // none, so an ordinary compile is unchanged.
+    let (ons, merged, merges) = try merges(over: relations, select.joins)
+    let scope = Scope(relations, merged: merged)
+    // Each join's prefix scope — the FROM relation and joins `0…index`, never
+    // one joined later — carries the merged columns accumulated before this
+    // join, so a chained `USING` `on` keys on the merged value.
+    let prefixes = select.joins.indices.map { index in
+      Scope(Array(relations[0 ... index + 1]), merged: merges[index])
+    }
+    // Resolve each LATERAL join's body once against the preceding FROM so a
+    // body column naming a preceding relation correlates outward and its plan
+    // is pre-compiled for the per-outer-row apply. A non-lateral join records
+    // `nil`. The apply is `.inner` (CROSS APPLY) or `.left` (OUTER APPLY);
+    // `.right`/`.full` are nonsensical for a correlated body, so fault.
+    let empty: (key: Subkey, correlation: Correlation)? = nil
+    var laterals = Array(repeating: empty, count: select.joins.count)
+    for index in select.joins.indices {
+      let join = select.joins[index]
+      guard join.relation.lateral,
+          case let .derived(body) = join.relation.source else { continue }
+      guard join.kind == .inner || join.kind == .left else {
+        throw .state("0A000", "a RIGHT/FULL LATERAL join is not supported")
+      }
+      let preceding = Scope(Array(relations[0 ... index]),
+                            merged: merges[index])
+      laterals[index] = try lateral(body, against: preceding,
+                                    columns: join.relation.columns, context)
+    }
+    // Compile every nested subquery once for arity/type, ahead of lowering, and
+    // discover each one's correlation: a join `ON`'s against its prefix scope,
+    // the WHERE against the join `scope`. `validate` gates the eager type-check
+    // of a filtered-out derived body a nested subquery names.
+    let plans = try subquery(of: select, context, enclosing: scope,
+                             prefixes: prefixes)
+    // A WINDOW clause with no window function is dropped after compilation, so
+    // validate its definitions here — against the whole join `scope`, so a
+    // definition naming a joined relation's column resolves as the query's own
+    // clauses do.
+    try validate(named: select.window, against: scope, context.routines,
+                 subquery: plans.rest)
+    var matches = Array<Filter>()
+    matches.reserveCapacity(select.joins.count)
+    for index in select.joins.indices {
+      // A NATURAL/USING join's `on` is the synthesized, already-lowered filter
+      // (`ons[index]`, `nil` for a degenerate shared-column-less join); a plain
+      // join lowers its written `ON` against the prefix scope.
+      if let on = ons[index] {
+        matches.append(on)
+      } else {
+        try matches.append(prefixes[index].on(select.joins[index].on,
+                                              context.routines,
+                                              subquery: plans.on(index)))
+      }
+    }
+    var predicate: Filter? = nil
+    if let clause = select.predicate {
+      predicate = try scope.lower(clause, context.routines,
+                                  subquery: plans.rest)
+    }
+    return Front(joined: joined, scope: scope, laterals: laterals,
+                 matches: matches, predicate: predicate, plans: plans)
+  }
+
   /// Compiles `select` over this catalog into a logical operator tree in slot
   /// space.
   ///
@@ -1510,99 +1609,17 @@ extension Catalog where Self: ~Escapable {
           limit: select.limit)
     }
 
-    // Resolve every joined relation and lay all relations — the FROM relation
-    // first, then each joined one in source order — end to end in one combined
-    // ordinal space. The helper builds the running `relations` incrementally
-    // and threads each join's preceding FROM as its resolve scope, so a LATERAL
-    // arm's schema derives against the relations before it.
-    let (joined, relations) = try resolve(from: relation, schema: from.schema,
-                                          joins: select.joins, context)
-    // Model each `NATURAL`/`USING` join's merged columns (ISO 9075 7.10) in the
-    // join scope, and synthesize each named-column join's lowered `left.c =
-    // right.c` `on` filter — a no-op yielding an empty merged set and all-`nil`
-    // `ons` for a chain with none, so an ordinary compile is unchanged. The
-    // scope carries the merged columns so the ordinary `terms`/`term`/order/
-    // `Grouping` machinery consumes them; a named-column join's `ons[index]`
-    // filter replaces its placeholder always-true `on`.
-    let (ons, merged, merges) = try merges(over: relations, select.joins)
-    let scope = Scope(relations, merged: merged)
-
-    // Each join's ON predicate lowers to a `Filter` at its own chain level,
-    // resolved against only the prefix already in scope plus the relation that
-    // join introduces — the FROM relation and joins `0…index` — never a
-    // relation joined later. Since `Scope` lays relations at cumulative offsets
-    // from 0, a prefix scope yields the same global combined ordinals as the
-    // full-chain scope, so the ON ordinals remap through `slot` as before;
-    // resolving against the prefix rejects a reference to a not-yet-joined
-    // relation (`SQLError.column`) and judges ambiguity only within the prefix.
-    // A `column = column` conjunct lowers to a `match` hash-join key; any
-    // inequality or expression equality lowers to a residual the join filters.
-    // The WHERE and ORDER lower against the whole chain, which legitimately
-    // sees every relation. Each join's prefix scope — the FROM relation and
-    // joins `0…index`, the relations available at that join point, never one
-    // joined later — carries the merged columns accumulated before this join
-    // (`merges[index]`), so a chained `USING` `on` keys on the merged value and
-    // an `ON` subquery's bare merged operand resolves.
-    let prefixes = select.joins.indices.map { index in
-      Scope(Array(relations[0 ... index + 1]), merged: merges[index])
-    }
-    // Resolve each LATERAL join's body once against the preceding FROM — the
-    // FROM relation and the joins before this one (`relations[0…index]`, one
-    // less than the prefix, which includes the join's own relation) — so a body
-    // column naming a preceding relation correlates outward and the body's plan
-    // is pre-compiled for the per-outer-row apply. A non-lateral join records
-    // nothing here (its `nil` slot). The apply is `.inner` (CROSS APPLY, which
-    // drops an unmatched outer row) or `.left` (OUTER APPLY, which NULL-extends
-    // one); `.right`/`.full` are nonsensical for a correlated body, so fault.
-    let empty: (key: Subkey, correlation: Correlation)? = nil
-    var laterals = Array(repeating: empty, count: select.joins.count)
-    for index in select.joins.indices {
-      let join = select.joins[index]
-      guard join.relation.lateral,
-          case let .derived(body) = join.relation.source else { continue }
-      guard join.kind == .inner || join.kind == .left else {
-        throw .state("0A000", "a RIGHT/FULL LATERAL join is not supported")
-      }
-      let preceding = Scope(Array(relations[0 ... index]),
-                            merged: merges[index])
-      laterals[index] = try lateral(body, against: preceding,
-                                    columns: join.relation.columns, context)
-    }
-    // Compile every nested subquery once for arity/type, ahead of lowering,
-    // into a map the join ONs, WHERE, projection, and ORDER BY lowering reads —
-    // and discover each one's correlation. A join `ON`'s subquery correlates
-    // against its prefix scope; the WHERE/projection/ORDER against the whole
-    // join `scope`. This select's own columns correlate outward through
-    // `outer`. `validate` gates a nested filtered-out derived body's eager
-    // type-check.
-    let plans = try subquery(of: select, context, enclosing: scope,
-                             prefixes: prefixes)
-    // A `WINDOW` clause with no window function is dropped after compilation, so
-    // validate its definitions here — against the whole join `scope`, so a
-    // definition naming a joined relation's column resolves as the query's own
-    // clauses do.
-    try validate(named: select.window, against: scope, context.routines,
-                 subquery: plans.rest)
-    var matches = Array<Filter>()
-    matches.reserveCapacity(select.joins.count)
-    for index in select.joins.indices {
-      // A `NATURAL`/`USING` join's `on` is the synthesized, already-lowered
-      // `left.c = right.c` filter (`ons[index]`, `nil` for a degenerate
-      // shared-column-less `NATURAL` join — an always-true `CROSS` product);
-      // a plain join lowers its written `ON` against the prefix scope.
-      if let on = ons[index] {
-        matches.append(on)
-      } else {
-        try matches.append(prefixes[index].on(select.joins[index].on,
-                                              context.routines,
-                                              subquery: plans.on(index)))
-      }
-    }
-    var predicate: Filter? = nil
-    if let clause = select.predicate {
-      predicate = try scope.lower(clause, context.routines,
-                                  subquery: plans.rest)
-    }
+    // Resolve the FROM/JOIN front half — the combined join `scope`, each joined
+    // relation's `Resolved`, the correlated `laterals` and lowered `matches`,
+    // the lowered WHERE `predicate`, and the nested-subquery `plans` — shared
+    // with the grouped and windowed paths so the three cannot drift.
+    let front = try front(select, relation, from, context)
+    let scope = front.scope
+    let joined = front.joined
+    let laterals = front.laterals
+    let matches = front.matches
+    let predicate = front.predicate
+    let plans = front.plans
     // The projection and ORDER BY admit a correlated column of this query as
     // the WHERE/ON do: `plans.rest` carries the enclosing `outer`, so an
     // unbound name resolves outward. A nested subquery in the projection also

--- a/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -1680,3 +1680,139 @@ struct WindowNonDeterminismTests {
     #expect(counter.count == 6)
   }
 }
+
+@Suite("Window functions over a join")
+struct WindowOverJoinTests {
+  // `T.id` 4 has no `U` match, so an inner join (and a CROSS APPLY) drops it
+  // while a LEFT join keeps it NULL-extended; `T.g` groups ids 1,2 and 3,4.
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["id": .integer, "g": .integer]) {
+        Row(1, 10)
+        Row(2, 10)
+        Row(3, 20)
+        Row(4, 20)
+      }
+      Relation("U", ["id": .integer, "v": .integer]) {
+        Row(1, 100)
+        Row(2, 200)
+        Row(3, 500)
+      }
+    }
+  }
+
+  @Test func `ROW_NUMBER over an inner join orders by a joined column`()
+      throws {
+    // The inner join drops `id` 4; the window ranks the three surviving rows by
+    // the joined `U.v` descending (500, 200, 100), and the output keeps the
+    // join (source) order, each row carrying its rank.
+    try fixture().expect(
+        "SELECT T.id, ROW_NUMBER() OVER (ORDER BY U.v DESC) " +
+        "FROM T JOIN U ON T.id = U.id",
+        yields: [[1, 3], [2, 2], [3, 1]])
+  }
+
+  @Test func `SUM partitions a window by a joined column`() throws {
+    // Partition by `T.g`: g=10 sums U.v 100 + 200 = 300, g=20 has only id 3's
+    // 500 (id 4 dropped by the inner join). Each partition row gains its total.
+    try fixture().expect(
+        "SELECT T.id, SUM(U.v) OVER (PARTITION BY T.g) " +
+        "FROM T JOIN U ON T.id = U.id",
+        yields: [[1, 300], [2, 300], [3, 500]])
+  }
+
+  @Test func `run and validate agree on a window over a join`() throws {
+    // The schema path types the same two-column shape the run produces — the
+    // parity `compile` gates: no join-specific rejection survives.
+    let sql = "SELECT T.id, SUM(U.v) OVER (PARTITION BY T.g) " +
+              "FROM T JOIN U ON T.id = U.id"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    try fixture().expect(sql, yields: [[1, 300], [2, 300], [3, 500]])
+  }
+
+  @Test func `COUNT(*) over a LEFT join counts the NULL-extended row`() throws {
+    // The LEFT join keeps `id` 4 (no `U` match, NULL-extended), so the whole-
+    // partition `COUNT(*)` is 4 — the window sees every post-join row.
+    try fixture().expect(
+        "SELECT T.id, COUNT(*) OVER () FROM T LEFT JOIN U ON T.id = U.id",
+        yields: [[1, 4], [2, 4], [3, 4], [4, 4]])
+  }
+
+  @Test func `ROW_NUMBER over a CROSS APPLY orders by the apply body`() throws {
+    // A correlated CROSS APPLY body projects each row's matching `U.v`; `id` 4
+    // matches none and is dropped, and the window ranks the survivors by `d.v`
+    // descending over the apply-bearing chain.
+    try fixture().expect(
+        "SELECT T.id, ROW_NUMBER() OVER (ORDER BY d.v DESC) FROM T " +
+        "JOIN LATERAL (SELECT U.v FROM U WHERE U.id = T.id) AS d ON 1 = 1",
+        yields: [[1, 3], [2, 2], [3, 1]])
+  }
+
+  @Test func `a window in the outer ORDER BY sorts the joined output`() throws {
+    // The query orders by the window rank itself (`U.v` descending), so the
+    // output rows come out id 3, 2, 1 rather than in join order.
+    try fixture().expect(
+        "SELECT T.id FROM T JOIN U ON T.id = U.id " +
+        "ORDER BY ROW_NUMBER() OVER (ORDER BY U.v DESC)",
+        yields: [[3], [2], [1]])
+  }
+
+  @Test func `two windows over a join compute independently`() throws {
+    // A ranking and a grand-total aggregate window share the join source, each
+    // appending its own slot: rank by `U.v` ascending, and the total 800.
+    try fixture().expect(
+        "SELECT T.id, ROW_NUMBER() OVER (ORDER BY U.v), SUM(U.v) OVER () " +
+        "FROM T JOIN U ON T.id = U.id",
+        yields: [[1, 1, 800], [2, 2, 800], [3, 3, 800]])
+  }
+
+  @Test func `the WHERE filters the join before the window`() throws {
+    // `U.v > 100` drops id 1 below the window, so `COUNT(*) OVER ()` counts the
+    // two surviving post-join rows, not all three.
+    try fixture().expect(
+        "SELECT T.id, COUNT(*) OVER () FROM T JOIN U ON T.id = U.id " +
+        "WHERE U.v > 100",
+        yields: [[2, 2], [3, 2]])
+  }
+
+  @Test func `a running frame accumulates over the join`() throws {
+    // A `ROWS UNBOUNDED PRECEDING → CURRENT ROW` frame over the join, ordered
+    // by `U.v`, runs the cumulative sum 100, 300, 800.
+    try fixture().expect(
+        """
+        SELECT T.id, SUM(U.v) OVER (ORDER BY U.v
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        FROM T JOIN U ON T.id = U.id
+        """,
+        yields: [[1, 100], [2, 300], [3, 800]])
+  }
+
+  @Test func `a window partitions by a USING merged column`() throws {
+    // `USING (id)` merges the join key to one column; partitioning the window
+    // by that merged `id` makes each row its own partition, so the count is 1.
+    try fixture().expect(
+        "SELECT id, COUNT(*) OVER (PARTITION BY id) FROM T JOIN U USING (id)",
+        yields: [[1, 1], [2, 1], [3, 1]])
+  }
+
+  @Test func `a window in a join ON is still rejected`() throws {
+    // Broadening the window source to a join does not admit a window function
+    // in a join ON — it has no per-row meaning there, on a join as on one
+    // relation.
+    try fixture().expect(
+        "SELECT T.id FROM T JOIN U ON ROW_NUMBER() OVER () = 1",
+        fails: .state("0A000",
+            "a window function is allowed only in SELECT and ORDER BY"))
+  }
+
+  @Test func `a window in an aggregate query over a join is still rejected`()
+      throws {
+    // A window beside an aggregate routes to the grouped path (which does not
+    // yet support windows) whether or not the query joins — the join does not
+    // change the routing.
+    try fixture().expect(
+        "SELECT SUM(U.v), ROW_NUMBER() OVER () FROM T JOIN U ON T.id = U.id",
+        fails: .state("0A000", "a window function is not supported"))
+  }
+}


### PR DESCRIPTION
This pull request refactors the SQL engine’s compilation pipeline to unify and share the logic for resolving the FROM/JOIN “front half” across the grouped, windowed, and plain join compilation paths. By extracting this logic into a new `front` helper function and a `Front` struct, the code eliminates duplication, ensures consistent behavior across query types, and lays the groundwork for supporting window functions over joins.

The most important changes are:

**Core Refactoring and Code Sharing:**

* Introduced a new `Front` struct in `Compilation.swift` to encapsulate the resolved state of the FROM/JOIN front half, including joined relations, scope, laterals, join filters, WHERE predicate, and subquery plans.
* Added the `front(_:_:_:_:)` helper function to build and return a `Front` instance, consolidating logic previously duplicated in grouped, windowed, and plain join code paths.

**Grouped and Plain Join Compilation:**

* Refactored the grouped (`Aggregation.swift`) and plain join (`Compilation.swift`) compilation paths to use the new `front` function, removing duplicated code and ensuring both paths resolve joins, laterals, and filters identically. [[1]](diffhunk://#diff-539104e989c7222dc99d8bb3fd6a6303795fc1870ae62a813aa83ac27fc69c21L1089-R1105) [[2]](diffhunk://#diff-1d95748712863f646081c2955d16e156306cb66552cf7aa429bb5e072e81f6a0L1513-R1622)

**Window Function Support Over Joins:**

* Updated the windowed query compilation path to use the shared `front` logic, enabling window functions to operate over joins (removes previous limitation and error). The windowed path now materializes the correct combined ordinal space for all join types.

**Documentation and Comment Updates:**

* Updated and clarified documentation throughout to reflect the new shared join resolution mechanism and to describe the behavior for windowed queries over joins. [[1]](diffhunk://#diff-1d95748712863f646081c2955d16e156306cb66552cf7aa429bb5e072e81f6a0L1710-L1731) [[2]](diffhunk://#diff-1d95748712863f646081c2955d16e156306cb66552cf7aa429bb5e072e81f6a0R1749-R1787)

This refactor ensures that all query types (grouped, windowed, joins) share a single, consistent mechanism for resolving the FROM/JOIN structure, reducing maintenance burden and enabling new SQL features.