### PR TITLE
SQLEngine: add an EXPLAIN plan-inspection facility

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -22,6 +22,12 @@
 public enum Statement: Hashable, Sendable {
   /// A `SELECT` query — one `SELECT`, or several combined with `UNION`.
   case select(Query)
+  /// An `EXPLAIN <query>` — the diagnostic plan-inspection statement carrying
+  /// the `query` whose optimised physical plan to render rather than run. It is
+  /// a non-ISO extension (like the shell's metacommands), so a consumer that
+  /// runs it yields the plan tree as a single-column relation of text lines
+  /// rather than the query's own rows.
+  case explain(Query)
   /// A `CREATE VIEW name AS query`: the view's `name` and the `View` it binds
   /// — the stored `query` and the column names (explicit or inferred from the
   /// projection). A consumer registers the `View` under `name` in a catalog so

--- a/Sources/SQLEngine/Engine.swift
+++ b/Sources/SQLEngine/Engine.swift
@@ -101,105 +101,13 @@ extension Catalog where Self: ~Escapable {
                                  types: types)
       return combined.map(\.values)
     }
-    // Thread a fresh lazy subquery cache — a shared box — through both compile
-    // and execute. The executor's row evaluator runs each nested subquery into
-    // it on first reach (where the borrowing catalog IS in scope; a schema-only
-    // path never reaches it, so opens no cursor): an uncorrelated occurrence
-    // runs once and memoises, while a correlated one re-executes per outer row
-    // against the correlated bindings, bypassing the memo. Compile stashes each
-    // correlated occurrence's inner plan here (compiled once with its enclosing
-    // scope, so its correlated columns are bound `Term.parameter`s), so the
-    // evaluator re-executes that plan rather than recompiling the inner query
-    // with no outer scope.
-    let context = context.resolving(Subqueries())
-    // Compile from the un-augmented `context` (idempotently augmented inside
-    // `compile`, which reveals the base for a nested subquery) — this query's
-    // derived aliases are invisible to a subquery's FROM, and a CTE a
-    // same-named derived alias shadows stays visible beneath the revealed base.
-    // Compile validates the whole query (schema-only, `rows: false`) before any
-    // row materialises below, so an invalid query — an unknown column resolving
-    // over a `FROM (SELECT tick() …) AS d` — faults without ever executing the
-    // derived body's stateful routine. A materialise ahead of this compile
-    // would run the body for a query that cannot run.
-    //
-    // `validate: false` gates the derived-body type-check off: the preflight
-    // proves the OUTER query runnable and resolves its relations, but a data-
-    // dependent body expression a filter drops (`FROM (SELECT Label + 1 AS x
-    // FROM K WHERE k = 0) AS d`) must NOT be rejected here — execution faults
-    // ONLY on an expression a surviving row reaches, exactly as the non-derived
-    // `SELECT Label + 1 FROM K WHERE k = 0` runs to zero rows. The eager body
-    // type-check stays for the explicit schema path (`columns` `validate:
-    // true`).
-    let logical = try compile(query, context.validating(false)).pushdown()
-    // The compile proved the query runnable but deferred every operand fault to
-    // execution (`validate: false`), including the ISO comparability rule — a
-    // number against a string is a data-type mismatch, not a FALSE row. The run
-    // enforces that rule per reachable row through `matches`, but a comparison
-    // the optimiser hashes into disjoint buckets, pushes below an empty
-    // product, or drops with a constant-false fold is never evaluated, so its
-    // fault would silently vanish; and a comparison over an empty input is
-    // never reached at all. Walk the query now for the comparability rule alone
-    // — reachability-, NULL-, and subquery-aware, so a short-circuited leg or a
-    // NULL/subquery operand still defers — so a statically-typed cross-kind
-    // comparison faults at compile regardless of cardinality, before the
-    // optimiser (or an empty scan) can hide it, while every other operand fault
-    // stays deferred to execution. Its derived-table bodies and set-operation
-    // arms are walked through the same gate the `augment` and `typecheck`
-    // recursion carry.
-    try typecheck(query, context.validating(false).comparing())
-    // Now that `compile` proved the query runnable, extend the overlay with any
-    // `definition_schema.` store relation the query names (resolved lazily —
-    // the overlay after the CTEs, before the base catalog) AND materialise this
-    // query's derived tables (`rows: true`, executing each body once). Every
-    // phase reads the extended map, so a reserved store relation resolves,
-    // plans, and materialises exactly as a common table expression does; a
-    // portable `information_schema.` view over the store resolves through the
-    // ordinary view machinery. The routines ride in so a store `data_type` row
-    // types a view's scalar-call column (`GUID(...)`) by its declared return
-    // type.
-    //
-    // `validate: false` — this run materialise executes each body's rows, but a
-    // nested derived body's schema is still derived schema-only inside
-    // `materialise` (to name the inner alias's columns); `validate: true` there
-    // would eager-type-check a doubly-nested filtered-out body on the run path.
-    // The run stays lenient at every depth (the outer query already compiled,
-    // and a reached operand still faults at execution).
-    let augmented = try augment(context.validating(false), for: query,
-                                rows: true)
-    // Record the caller's overlay under `.caller` so a subquery lowered under
-    // it (even one a pushdown moved INTO a view) re-runs against the caller's
-    // relations, not the view's base. reveal the base first — this query's
-    // derived-table aliases are SELECT-scoped, invisible to a subquery's FROM,
-    // while the CTEs and `definition_schema.` store relations a `.caller`
-    // subquery's FROM resolves against are kept, so a subquery `FROM d` reads a
-    // CTE `d` a same-named derived alias shadows rather than the derived rows.
-    // The shared box survives from the un-augmented compile into execution.
-    augmented.subqueries.record(overlay: augmented.revealed().relations,
-                                for: .caller)
-    // Rewrite each decorrelatable correlated CROSS APPLY into a set-based join
-    // before the physical `optimise`/`nest`, so the emitted `select`-over-
-    // `product` folds to a hash equi-join. The pass reads the compiled body
-    // plans recorded above into the shared subquery box; a non-decorrelatable
-    // apply is left verbatim, so a plan with none is unchanged.
-    let decorrelated = try decorrelate(logical, augmented)
-    // A query-level `ORDER BY`/`DISTINCT`/`OFFSET`·`FETCH` over a set operation
-    // — an `ordered` carrier whose `core` is a `.setop` — optimises per ARM,
-    // mirroring the view carrier path (`optimise(_:_:_:)` at the `.ordered`
-    // view seam): the generic optimiser would rewrite both arms under the same
-    // carrier-level `augmented` context, which does NOT bind an arm-owned
-    // derived alias (arms are SELECT-scoped), so its `seek` rewrite faults
-    // `.relation` on a `FROM (SELECT …) AS d WHERE …` arm before the per-arm
-    // `execute(…carrying:)` below can augment each arm under its own overlay.
-    // Descending the carrier to the setop leaf and augmenting each arm under
-    // its own context resolves the arm-local alias. The `case .setop = core`
-    // guard keeps a plain query (and an ordered carrier over a bare `SELECT`,
-    // not a setop) on the generic optimiser.
-    let plan: Plan
-    if !query.carriers.isEmpty, case .setop = query.body {
-      plan = try optimise(decorrelated, query.core, augmented)
-    } else {
-      plan = try optimise(decorrelated, augmented)
-    }
+    // Build the optimised physical plan, then run it. `optimised` is the single
+    // source of the compile → pushdown → decorrelate → optimise walk, so
+    // `EXPLAIN` (`plan(of:)`) inspects exactly the plan this execute runs — the
+    // two cannot drift. It returns the augmented context alongside the plan so
+    // the execute below reads the same materialised derived tables and shared
+    // subquery box the plan was built against.
+    let (plan, augmented) = try optimised(query, context, rows: true)
     // A query-level `ORDER BY`/`DISTINCT`/`OFFSET`·`FETCH` over a set operation
     // — the `ordered` carrier — must run its inner union per ARM, as the direct
     // `run(.setop)` above does: each arm augments its own arm-local derived
@@ -220,6 +128,97 @@ extension Catalog where Self: ~Escapable {
     return try execute(plan, augmented).map(\.values)
   }
 
+  /// Builds the optimised physical `Plan` for `query` under `context`, running
+  /// the full compile → pushdown → decorrelate → optimise pipeline the executor
+  /// uses — the single source of that walk, shared by `run` and by the
+  /// diagnostic `plan(of:)` (so `EXPLAIN` inspects exactly the plan a run
+  /// executes).
+  ///
+  /// It threads a fresh subquery cache — a shared box — through compile and
+  /// the returned context, so the executor's row evaluator (which runs a nested
+  /// subquery on first reach, memoising an uncorrelated occurrence and
+  /// re-executing a correlated one per outer row) reads the correlated inner
+  /// plans compile stashed. Compile validates the whole query schema-only
+  /// (`rows: false`, `validate: false`) before any row materialises; the
+  /// comparability walk faults a statically cross-kind comparison the optimiser
+  /// could otherwise hide; `augment` extends the overlay with any
+  /// `definition_schema.` store relation and — when `rows` — materialises this
+  /// query's derived tables; `decorrelate` rewrites a decorrelatable correlated
+  /// CROSS APPLY into a set-based join; and `optimise` rewrites scans into
+  /// seeks and products into index-nested-loop/hash joins.
+  ///
+  /// `rows` is `true` for `run` (the execute below reads the materialised
+  /// derived tables) and `false` for the diagnostic `plan(of:)`, which must not
+  /// execute: materialising a derived table calls `run` on its body, so a
+  /// stateful routine or a throwing derived expression would fire under
+  /// `EXPLAIN` — which stops before execution. The plan shape is identical
+  /// either way (the physical pass reads base-table cursors and derived
+  /// schemas, never materialised derived rows).
+  ///
+  /// A set operation — bare or under a carrier — optimises per arm
+  /// (`optimise(_:_:_:)`), since each arm scans its own arm-local derived
+  /// aliases the top-level scope does not bind; every other shape uses the
+  /// generic optimiser. `run` reaches this with a set-operation query only
+  /// under a carrier (it runs a bare set operation's arms directly, above); the
+  /// plan-only `plan(of:)` reaches it with a bare set operation too, so both
+  /// take the per-arm path here. The augmented context is returned beside the
+  /// plan so a caller's execute reads the same materialised tables and subquery
+  /// box.
+  internal borrowing func optimised(_ query: Query, _ context: Context,
+                                    rows: Bool)
+      throws(SQLError) -> (plan: Plan, augmented: Context) {
+    let context = context.resolving(Subqueries())
+    let logical = try compile(query, context.validating(false)).pushdown()
+    try typecheck(query, context.validating(false).comparing())
+    let augmented = try augment(context.validating(false), for: query,
+                                rows: rows)
+    augmented.subqueries.record(overlay: augmented.revealed().relations,
+                                for: .caller)
+    // A carrier-free set operation runs each arm separately under its own
+    // augmented scope — arms are SELECT-scoped, binding arm-local derived
+    // aliases the shared context does not — so decorrelate and optimise it per
+    // arm too: recurse through `optimised` (the same pipeline `run` drives per
+    // arm) and recombine with the compiled unified types and widened mask.
+    // Decorrelating on the shared context instead would bail on an arm's
+    // correlated subquery, the arm alias unbound, where a per-arm run
+    // decorrelates it — so the inspected plan would differ from the executed
+    // one. `run` reaches a bare set operation through its own per-arm path and
+    // never through this helper, so this affects only the plan-only path.
+    if query.carriers.isEmpty,
+        case let .setop(kind, left, right, all) = query.body,
+        case let .setop(_, _, _, _, types, widened) = logical {
+      let leftPlan = try optimised(left, context, rows: rows).plan
+      let rightPlan = try optimised(right, context, rows: rows).plan
+      return (.setop(kind, leftPlan, rightPlan, all: all, types: types,
+                     widened: widened), augmented)
+    }
+    let decorrelated = try decorrelate(logical, augmented)
+    let plan: Plan
+    if case .setop = query.body {
+      plan = try optimise(decorrelated, query.core, augmented)
+    } else {
+      plan = try optimise(decorrelated, augmented)
+    }
+    return (plan, augmented)
+  }
+
+  /// The optimised physical `Plan` for `query` under `context` — the plan the
+  /// executor would run, built without executing it. This is the testable
+  /// plan-inspection entry `EXPLAIN` renders: it runs the same compile →
+  /// pushdown → decorrelate → optimise pipeline as `run`, sharing `optimised`,
+  /// but stops short of the final `execute`.
+  ///
+  /// A `GROUP BY GROUPING SETS` query is expanded first (idempotent), as
+  /// `run`/`compile` normalise it, so the inspected plan matches the run's.
+  ///
+  /// Augments schema-only (`rows: false`): unlike `run`, inspecting a plan must
+  /// not materialise a derived table (which would `run` its body), so a
+  /// stateful routine or a throwing derived expression never fires here.
+  internal borrowing func plan(of query: Query, _ context: Context)
+      throws(SQLError) -> Plan {
+    try optimised(query.expanded, context, rows: false).plan
+  }
+
   /// Runs a `Statement` against this catalog, returning its result rows.
   ///
   /// A `select` runs its query directly; a `with` materialises its common table
@@ -236,6 +235,8 @@ extension Catalog where Self: ~Escapable {
     return switch statement {
     case let .select(query):
       try run(query, context)
+    case let .explain(query):
+      try explain(query, context)
     case let .with(ctes, query):
       try with(ctes, query, context)
     case .create:

--- a/Sources/SQLEngine/Explain.swift
+++ b/Sources/SQLEngine/Explain.swift
@@ -1,0 +1,520 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// The `EXPLAIN` plan renderer — a stable pretty-printer for the optimised
+/// physical `Plan`.
+///
+/// `EXPLAIN <query>` builds the plan through the ordinary compile → pushdown →
+/// decorrelate → optimise pipeline (`Catalog.plan(of:)`) and renders it here,
+/// one operator per line, laid out as an indented tree with box-drawing
+/// connectors (`├─`/`└─`/`│`) — the same tree idiom the CLI's table output
+/// draws its frames in. Each line names an operator and annotates the
+/// optimiser-relevant fields: a scan's referenced ordinals and seek range, a
+/// join's kind and seek key, an elided-or-kept DISTINCT, a decorrelated apply's
+/// correlation, and so on. The render is a pure function of the `Plan` — no
+/// addresses, no set/dictionary iteration order — so a test may pin it.
+///
+/// It renders the plan node faithfully as the optimiser shaped it: a `.join` is
+/// an index-nested-loop equi-join in shape, and the render says so, but it does
+/// not simulate the executor's runtime hash-vs-seek choice (which depends on
+/// the inner column's live seekability). The physical node is the ground truth.
+
+extension Plan {
+  /// The optimised plan rendered as an indented operator tree — one line per
+  /// node, the root unindented and each child hung under its parent with a
+  /// box-drawing connector. This is what `EXPLAIN` yields, one text row per
+  /// line.
+  internal func render() -> Array<String> {
+    var lines = Array<String>()
+    render(prefix: "", leading: "", into: &lines)
+    return lines
+  }
+
+  /// Appends this node's label line (prefixed by `leading`) and then each
+  /// child's subtree, hung under a `├─`/`└─` connector with the running
+  /// `prefix` extended by `│  ` (a middle child's descendants) or three spaces
+  /// (the last child's), so the tree's spine draws correctly at every depth.
+  private func render(prefix: String, leading: String,
+                      into lines: inout Array<String>) {
+    lines.append(leading + label)
+    let nodes = children
+    for index in nodes.indices {
+      let last = index == nodes.count - 1
+      let branch = prefix + (last ? "└─ " : "├─ ")
+      let onward = prefix + (last ? "   " : "│  ")
+      nodes[index].render(prefix: onward, leading: branch, into: &lines)
+    }
+  }
+
+  /// This operator's sub-plans, in draw order — the children the tree hangs
+  /// under it. A `join`'s inner relation is named and re-materialised per outer
+  /// record rather than being a sub-plan, so it is annotated in the `label`,
+  /// not listed here; likewise an `apply`'s correlated body (looked up by key).
+  private var children: Array<Plan> {
+    switch self {
+    case .single, .values, .empty, .scan:
+      []
+    case let .derived(_, plan, _, _):
+      [plan]
+    case let .select(_, source), let .project(_, source),
+         let .sort(_, source), let .distinct(source),
+         let .aggregate(_, _, source), let .window(_, source),
+         let .limit(_, _, source), let .join(source, _, _, _, _, _, _),
+         let .apply(source, _, _, _, _, _):
+      [source]
+    case let .product(left, right), let .outer(left, right, _, _),
+         let .semijoin(left, right, _, _), let .setop(_, left, right, _, _, _):
+      [left, right]
+    }
+  }
+
+  /// The single-line label for this operator — its kind plus the
+  /// optimiser-relevant fields the render annotates.
+  private var label: String {
+    switch self {
+    case .single:
+      return "single"
+    case let .values(rows, types):
+      return "values  rows \(rows.count)  columns \(types.count)"
+    case let .empty(slots):
+      return "empty  slots \(slots)"
+    case let .scan(name, ordinals, seek):
+      return "scan \(escaped(name))  reads \(list(ordinals))"
+          + rendered(seek: seek)
+    case let .derived(name, _, ordinals, seek):
+      return "derived \(escaped(name))  reads \(list(ordinals))"
+          + rendered(seek: seek)
+    case let .select(filter, _):
+      return "select  \(filter.rendered)"
+    case let .project(terms, _):
+      return "project [" + terms.map(\.rendered).joined(separator: ", ") + "]"
+    case let .sort(keys, _):
+      let rendered = keys.map {
+        "\($0.term.rendered) \($0.ascending ? "ASC" : "DESC")"
+      }
+      return "sort  " + rendered.joined(separator: ", ")
+    case .product:
+      return "product (nested loop)"
+    case let .join(_, name, ordinals, base, column, keys, filter):
+      var label = "join (index nested loop)  inner \(escaped(name))"
+      label += "  on slot \(keys.left) = slot \(keys.right)"
+      label += "  seek column \(column)  base \(base)  reads \(list(ordinals))"
+      if let filter { label += "  inner filter \(filter.rendered)" }
+      return label
+    case let .outer(_, _, on, kind):
+      return "outer \(kind.keyword)  on \(on.rendered)"
+    case let .semijoin(_, _, on, anti):
+      return "semijoin\(anti ? " (anti)" : "")  on \(on.rendered)"
+    case let .apply(_, _, correlation, ordinals, on, kind):
+      var label = "apply \(kind.keyword)  correlation \(rendered(correlation))"
+      label += "  reads \(list(ordinals))  on \(on.rendered)"
+      return label
+    case let .setop(kind, _, _, all, _, _):
+      return kind.keyword + (all ? " all" : "")
+    case .distinct:
+      return "distinct"
+    case let .aggregate(keys, aggregates, _):
+      let keyed = keys.map(\.rendered).joined(separator: ", ")
+      let folds = aggregates.map(\.rendered).joined(separator: ", ")
+      return "aggregate  keys [\(keyed)]  aggregates [\(folds)]"
+    case let .window(windowings, _):
+      let rendered = windowings.map(\.rendered).joined(separator: ", ")
+      return "window [\(rendered)]"
+    case let .limit(count, offset, _):
+      let cap = count.map { "\($0)" } ?? "all"
+      return "limit  count \(cap)" + (offset > 0 ? "  offset \(offset)" : "")
+    }
+  }
+}
+
+// MARK: - Field rendering
+
+/// A comma-separated `[a, b, c]` spelling of an ordinal list, for a scan's
+/// referenced ordinals and a join/apply's taken ones.
+private func list(_ ordinals: Array<Int>) -> String {
+  "[" + ordinals.map { "\($0)" }.joined(separator: ", ") + "]"
+}
+
+/// The `  seek lower..<upper` annotation of a planned row-range seek, or the
+/// empty string when the scan reads the whole relation (`nil`).
+private func rendered(seek: Range<Int>?) -> String {
+  guard let seek else { return "" }
+  return "  seek \(seek.lowerBound)..<\(seek.upperBound)"
+}
+
+/// A correlated node's parameter bindings rendered `[:name ← source, …]`, the
+/// names sorted so the line is stable regardless of the map's iteration order.
+private func rendered(_ correlation: Correlation) -> String {
+  let bindings = correlation.keys.sorted().map { name in
+    "\(param(name)) ← \(rendered(correlation[name]!))"
+  }
+  return "[" + bindings.joined(separator: ", ") + "]"
+}
+
+/// A correlation source's spelling — an outer cell, a merged column, or a
+/// threaded binding.
+private func rendered(_ source: Source) -> String {
+  switch source {
+  case let .slot(slot):
+    return "slot \(slot)"
+  case let .coalesce(slots, _):
+    return "coalesce(" + slots.map { "slot \($0)" }.joined(separator: ", ")
+        + ")"
+  case .bound:
+    return "bound"
+  }
+}
+
+extension Comparison {
+  /// This comparison operator's SQL symbol, for a rendered predicate.
+  fileprivate var symbol: String {
+    switch self {
+    case .equal: "="
+    case .unequal: "<>"
+    case .lt: "<"
+    case .gt: ">"
+    case .leq: "<="
+    case .geq: ">="
+    }
+  }
+}
+
+extension Arithmetic {
+  /// This arithmetic operator's SQL symbol, for a rendered term.
+  fileprivate var symbol: String {
+    switch self {
+    case .add: "+"
+    case .subtract: "-"
+    case .multiply: "*"
+    case .divide: "/"
+    case .concatenate: "||"
+    }
+  }
+}
+
+extension Join.Kind {
+  /// This join kind's ISO keyword, for a rendered `outer`/`apply` node.
+  fileprivate var keyword: String {
+    switch self {
+    case .inner: "INNER"
+    case .left: "LEFT"
+    case .right: "RIGHT"
+    case .full: "FULL"
+    }
+  }
+}
+
+extension SetOperation {
+  /// This set operator's ISO keyword, for a rendered `setop` node.
+  fileprivate var keyword: String {
+    switch self {
+    case .union: "union"
+    case .intersect: "intersect"
+    case .except: "except"
+    }
+  }
+}
+
+extension Quantifier {
+  /// This quantifier's ISO keyword, for a rendered quantified predicate.
+  fileprivate var keyword: String {
+    switch self {
+    case .any: "ANY"
+    case .all: "ALL"
+    }
+  }
+}
+
+extension Truth {
+  /// This truth value's ISO keyword, for a rendered `IS <truth>` predicate.
+  fileprivate var keyword: String {
+    switch self {
+    case .true: "TRUE"
+    case .false: "FALSE"
+    case .unknown: "UNKNOWN"
+    }
+  }
+}
+
+// MARK: - Value rendering
+
+extension Value {
+  /// This constant's plan-tree spelling — a NULL as `NULL`, text single-quoted
+  /// with its control characters and quotes escaped, a blob as a lowercase-hex
+  /// `x'…'` literal, the rest their bare description.
+  fileprivate var literal: String {
+    switch self {
+    case .null: "NULL"
+    case let .integer(integer): "\(integer)"
+    case let .double(double): "\(double)"
+    case let .text(text): "'\(escaped(text, quote: true))'"
+    case let .boolean(boolean): boolean ? "TRUE" : "FALSE"
+    case let .blob(bytes):
+      "x'" + bytes.map(Value.hex).joined() + "'"
+    }
+  }
+
+  /// A byte's two lowercase-hex nibbles, high nibble first — the per-byte
+  /// spelling a rendered blob literal joins.
+  private static func hex(_ byte: UInt8) -> String {
+    let digits = Array("0123456789abcdef")
+    return String([digits[Int(byte >> 4)], digits[Int(byte & 0x0f)]])
+  }
+}
+
+// MARK: - Term rendering
+
+extension Term {
+  /// This lowered scalar term's plan-tree spelling — a slot read, a constant, a
+  /// correlated parameter, or a compound expression over such.
+  fileprivate var rendered: String {
+    switch self {
+    case let .slot(slot):
+      return "slot \(slot)"
+    case let .parameter(name):
+      return param(name)
+    case let .constant(value):
+      return value.literal
+    case let .apply(name, arguments):
+      return "\(escaped(name))(" + arguments.map(\.rendered)
+          .joined(separator: ", ") + ")"
+    case let .binary(op, lhs, rhs):
+      return "(\(lhs.rendered) \(op.symbol) \(rhs.rendered))"
+    case let .case(branches, otherwise, _):
+      let arms = branches.map { "WHEN \($0.0.rendered) THEN \($0.1.rendered)" }
+      let tail = otherwise.map { " ELSE \($0.rendered)" } ?? ""
+      return "CASE " + arms.joined(separator: " ") + tail + " END"
+    case let .cast(term, type):
+      return "CAST(\(term.rendered) AS \(type.domain))"
+    case let .coalesce(elements, _):
+      return "COALESCE(" + elements.map(\.rendered).joined(separator: ", ")
+          + ")"
+    case let .nullif(lhs, rhs):
+      return "NULLIF(\(lhs.rendered), \(rhs.rendered))"
+    case let .subquery(_, correlation, _):
+      return correlation.isEmpty ? "(subquery)" : "(correlated subquery)"
+    case let .grouping(_, bits):
+      return "GROUPING(\(bits))"
+    }
+  }
+}
+
+// MARK: - Filter rendering
+
+extension Filter.Operand {
+  /// This `LIKE`/`BETWEEN` operand's spelling — a lowered term or a run-time
+  /// parameter.
+  fileprivate var rendered: String {
+    switch self {
+    case let .term(term): term.rendered
+    case let .parameter(name): param(name)
+    }
+  }
+}
+
+extension Filter {
+  /// This lowered predicate's plan-tree spelling — a comparison, a connective,
+  /// or one of the ISO predicate forms, rendered in slot space.
+  fileprivate var rendered: String {
+    switch self {
+    case let .compare(lhs, op, rhs):
+      return "\(lhs.rendered) \(op.symbol) \(rhs.rendered)"
+    case let .bound(lhs, op, name):
+      return "\(lhs.rendered) \(op.symbol) \(param(name))"
+    case let .match(left, right):
+      return "slot \(left) = slot \(right)"
+    case let .null(term, negated):
+      return "\(term.rendered) IS \(negated ? "NOT " : "")NULL"
+    case let .membership(operand, values, negated):
+      return "\(operand.rendered)\(negated ? " NOT" : "") IN ("
+          + values.map(\.rendered).joined(separator: ", ") + ")"
+    case let .comparison(lhs, op, rhs):
+      return "\(row(lhs)) \(op.symbol) \(row(rhs))"
+    case let .memberships(lhs, rows, negated):
+      let elements = rows.map(row).joined(separator: ", ")
+      return "\(row(lhs))\(negated ? " NOT" : "") IN (\(elements))"
+    case let .like(operand, pattern, escape, negated):
+      let tail = escape.map { " ESCAPE \($0.rendered)" } ?? ""
+      return "\(operand.rendered)\(negated ? " NOT" : "") LIKE "
+          + pattern.rendered + tail
+    case let .between(test, lower, upper, negated):
+      return "\(test.rendered)\(negated ? " NOT" : "") BETWEEN "
+          + "\(lower.rendered) AND \(upper.rendered)"
+    case let .distinct(lhs, rhs, negated):
+      return "\(lhs.rendered) IS \(negated ? "NOT " : "")DISTINCT FROM "
+          + rhs.rendered
+    case let .exists(_, correlation, negated):
+      return "\(negated ? "NOT " : "")EXISTS \(subquery(correlation))"
+    case let .within(lhs, _, correlation, negated):
+      return "\(row(lhs))\(negated ? " NOT" : "") IN \(subquery(correlation))"
+    case let .quantified(lhs, op, quantifier, _, correlation):
+      return "\(row(lhs)) \(op.symbol) \(quantifier.keyword) "
+          + subquery(correlation)
+    case let .truth(filter, value, negated):
+      return "\(filter.rendered) IS \(negated ? "NOT " : "")\(value.keyword)"
+    case let .and(lhs, rhs):
+      return "(\(lhs.rendered) AND \(rhs.rendered))"
+    case let .or(lhs, rhs):
+      return "(\(lhs.rendered) OR \(rhs.rendered))"
+    case let .not(operand):
+      return "NOT \(operand.rendered)"
+    case let .incomparable(inner):
+      return "incomparable(\(inner.rendered))"
+    }
+  }
+}
+
+/// A row-value operand `(a, b, c)` rendered from its component terms — the
+/// parenthesised form an ISO row comparison/membership prints.
+private func row(_ terms: Array<Term>) -> String {
+  "(" + terms.map(\.rendered).joined(separator: ", ") + ")"
+}
+
+/// A parameter name rendered `:name` with exactly one leading colon, whether or
+/// not the stored name already carries it — a user `:p` is stored bare while a
+/// synthetic correlated name (`:__correlated_0_0`) keeps its colon, so this
+/// normalises both to one spelling.
+private func param(_ name: String) -> String {
+  ":" + escaped(String(name.drop(while: { $0 == ":" })))
+}
+
+/// `text` with its backslash and control characters backslash-escaped — and,
+/// under `quote`, its single quotes too — so a rendered value or user-provided
+/// identifier is a single operator line with unambiguous quoting. A delimited
+/// identifier or a text constant may hold a newline or a quote verbatim; left
+/// raw it would split the line and corrupt the single-line box the shell frames
+/// it in. `quote` escapes the wrapping single quotes a text literal adds; a
+/// bare identifier (a relation, routine, or parameter name) is rendered
+/// unquoted, so it escapes control characters alone.
+private func escaped(_ text: String, quote: Bool = false) -> String {
+  var spelled = ""
+  for scalar in text.unicodeScalars {
+    switch scalar {
+    case "\\": spelled += "\\\\"
+    case "'" where quote: spelled += "\\'"
+    case "\n": spelled += "\\n"
+    case "\r": spelled += "\\r"
+    case "\t": spelled += "\\t"
+    case let control where control.value < 0x20:
+      spelled += "\\u{\(String(control.value, radix: 16))}"
+    default: spelled.unicodeScalars.append(scalar)
+    }
+  }
+  return spelled
+}
+
+/// A subquery operand's spelling — marked correlated when its `correlation`
+/// binds an outer cell (it re-runs per outer row), plain when uncorrelated.
+private func subquery(_ correlation: Correlation) -> String {
+  correlation.isEmpty ? "(subquery)" : "(correlated subquery)"
+}
+
+// MARK: - Aggregate and window rendering
+
+extension Aggregation {
+  /// This lowered aggregate's plan-tree spelling — `FUNCTION(argument)`, with
+  /// `DISTINCT` and a `FILTER (WHERE …)` when present, and `*` for `COUNT(*)`.
+  fileprivate var rendered: String {
+    let inner = "\(distinct ? "DISTINCT " : "")\(argument?.rendered ?? "*")"
+    let gate = filter.map { " FILTER (WHERE \($0.rendered))" } ?? ""
+    return "\(function.keyword)(\(inner))\(gate)"
+  }
+}
+
+extension Windowing {
+  /// This lowered window's plan-tree spelling — `FUNCTION OVER (PARTITION BY …
+  /// ORDER BY … <frame>)`, each clause omitted when empty. An explicit frame is
+  /// rendered so windows folding different row sets — `ROWS BETWEEN 1 PRECEDING
+  /// AND CURRENT ROW` vs `5 PRECEDING` — are distinct plan lines.
+  fileprivate var rendered: String {
+    var over = Array<String>()
+    if !partition.isEmpty {
+      over.append("PARTITION BY "
+          + partition.map(\.rendered).joined(separator: ", "))
+    }
+    if !order.isEmpty {
+      let keys = order.map {
+        "\($0.term.rendered) \($0.ascending ? "ASC" : "DESC")"
+      }
+      over.append("ORDER BY " + keys.joined(separator: ", "))
+    }
+    if let frame { over.append(frame.rendered) }
+    return "\(function.rendered) OVER (\(over.joined(separator: " ")))"
+  }
+}
+
+extension Frame {
+  /// This window frame's plan-tree spelling — `<unit> BETWEEN <start> AND
+  /// <end>`, so an explicit frame's unit and bounds distinguish the row set the
+  /// window folds.
+  fileprivate var rendered: String {
+    "\(unit.keyword) BETWEEN \(start.rendered) AND \(end.rendered)"
+  }
+}
+
+extension Frame.Unit {
+  /// This frame unit's ISO keyword.
+  fileprivate var keyword: String {
+    switch self {
+    case .rows: "ROWS"
+    case .range: "RANGE"
+    case .groups: "GROUPS"
+    }
+  }
+}
+
+extension Frame.Bound {
+  /// This frame bound's plan-tree spelling.
+  fileprivate var rendered: String {
+    switch self {
+    case .unboundedPreceding: "UNBOUNDED PRECEDING"
+    case let .preceding(rows): "\(rows) PRECEDING"
+    case .currentRow: "CURRENT ROW"
+    case let .following(rows): "\(rows) FOLLOWING"
+    case .unboundedFollowing: "UNBOUNDED FOLLOWING"
+    }
+  }
+}
+
+extension Windowing.Function {
+  /// This lowered window function's plan-tree spelling — its ISO name and any
+  /// lowered operands (an aggregate window rendered as its aggregation).
+  fileprivate var rendered: String {
+    switch self {
+    case .rowNumber: return "ROW_NUMBER()"
+    case .rank: return "RANK()"
+    case .denseRank: return "DENSE_RANK()"
+    case let .aggregate(aggregation): return aggregation.rendered
+    case let .lead(value, offset, fallback):
+      let tail = fallback.map { ", \($0.rendered)" } ?? ""
+      return "LEAD(\(value.rendered), \(offset)\(tail))"
+    case let .lag(value, offset, fallback):
+      let tail = fallback.map { ", \($0.rendered)" } ?? ""
+      return "LAG(\(value.rendered), \(offset)\(tail))"
+    case let .firstValue(value): return "FIRST_VALUE(\(value.rendered))"
+    case let .lastValue(value): return "LAST_VALUE(\(value.rendered))"
+    case let .nthValue(value, n): return "NTH_VALUE(\(value.rendered), \(n))"
+    case let .ntile(n): return "NTILE(\(n))"
+    case .percentRank: return "PERCENT_RANK()"
+    case .cumeDist: return "CUME_DIST()"
+    }
+  }
+}
+
+// MARK: - Explain
+
+extension Catalog where Self: ~Escapable {
+  /// Renders `query`'s optimised physical plan as one text row per plan-tree
+  /// line — the rows the `EXPLAIN <query>` statement yields.
+  ///
+  /// It builds the plan through `plan(of:)` — the same compile → pushdown →
+  /// decorrelate → optimise pipeline a run drives — and renders it, without
+  /// executing the query. The result is a single-column relation of `.text`
+  /// cells (`columns(of:)` names the column `plan`), so the CLI frames it as a
+  /// one-column table and an `expect(…)`/`run(_ statement:)` test reads the
+  /// plan lines back as ordinary rows.
+  internal borrowing func explain(_ query: Query, _ context: Context)
+      throws(SQLError) -> Array<Array<Value>> {
+    try plan(of: query, context).render().map { [.text($0)] }
+  }
+}

--- a/Sources/SQLEngine/Parser.swift
+++ b/Sources/SQLEngine/Parser.swift
@@ -177,10 +177,22 @@ internal struct Parser: ~Escapable {
   /// leading `WITH` the common-table-expression form; anything else is a
   /// `query` — a `SELECT` or a `UNION` of several.
   internal mutating func parse() throws(SQLError) -> Statement {
-    let statement = switch current?.kind {
-    case .create: try create()
-    case .with: try with()
-    default: try Statement.select(query())
+    // `EXPLAIN` is a contextual keyword recognised only here, at statement
+    // start — not a reserved token — so an existing relation, column, alias, or
+    // routine named `Explain` still lexes as an ordinary identifier and parses
+    // everywhere else (`SELECT Explain FROM T`, `SELECT * FROM Explain`). A
+    // statement never otherwise begins with a bare identifier, so a leading
+    // `explain` is unambiguous.
+    let statement: Statement
+    if case let .identifier(text)? = current?.kind,
+        text.uppercased() == "EXPLAIN" {
+      statement = try explain()
+    } else {
+      statement = switch current?.kind {
+      case .create: try create()
+      case .with: try with()
+      default: try Statement.select(query())
+      }
     }
     if let token = current {
       throw .trailing(at: token.location)
@@ -206,6 +218,19 @@ internal struct Parser: ~Escapable {
       try ctes.append(cte(recursive: recursive))
     }
     return try .with(ctes: ctes, query: query())
+  }
+
+  /// Parses `EXPLAIN <query>` (the leading `EXPLAIN` is the next token) — the
+  /// diagnostic plan-inspection statement.
+  ///
+  /// `EXPLAIN` prefixes a `query` (a `SELECT` or a set-operation chain — the
+  /// same `<query expression>` a bare statement is), so a consumer renders that
+  /// query's optimised physical plan rather than running it. It is deliberately
+  /// query-scoped: a `WITH` or a `CREATE` after `EXPLAIN` is rejected as a
+  /// trailing token, since neither yields a single physical plan to render.
+  private mutating func explain() throws(SQLError) -> Statement {
+    _ = try advance(expecting: "EXPLAIN")
+    return try .explain(query())
   }
 
   /// Parses one `cte := identifier ['(' identifier (, identifier)* ')'] AS '('

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -133,6 +133,20 @@ extension Catalog where Self: ~Escapable {
     switch statement {
     case let .select(query):
       return try columns(of: query, routines: routines, validate: validate)
+    case let .explain(query):
+      // `EXPLAIN` yields the plan tree as one text column per line — a fixed
+      // single-column shape, whatever the inspected query projects. Under
+      // `validate`, prove it plannable by building its plan — exactly what
+      // running the EXPLAIN does (`plan(of:)`) — rather than deriving the
+      // inspected query's schema. Planning faults on a query that cannot be
+      // planned (an unknown column, a statically incomparable comparison), so a
+      // client cannot describe an unplannable EXPLAIN; but it does not eager
+      // type-check a projected row operand the way the schema derive would, so
+      // `EXPLAIN SELECT Name + 1 FROM People` — which runs fine, no row
+      // expression evaluated — is not wrongly rejected. The plan is discarded,
+      // only its faults matter. Then name the fixed diagnostic column.
+      if validate { _ = try plan(of: query, Context(routines: routines)) }
+      return [OutputColumn(name: "plan", type: .text)]
     case let .with(ctes, query):
       return try columns(of: query, with: ctes, routines: routines,
                          validate: validate)

--- a/Sources/SQLEngineWinMD/Session+Run.swift
+++ b/Sources/SQLEngineWinMD/Session+Run.swift
@@ -38,7 +38,11 @@ extension Session {
       return []
     case let .select(query):
       return try self.run(query, functions, bindings: bindings)
-    case .with:
+    case .explain, .with:
+      // Both are runnable row-producing statements — `EXPLAIN` yields its plan
+      // tree, a `WITH` its trailing query's rows — so both route through the
+      // statement-level `run`, which materialises a `WITH`'s CTEs and renders
+      // an `EXPLAIN`'s plan.
       return try self.run(parsed, functions, bindings: bindings)
     }
   }

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -783,6 +783,7 @@ internal struct Shell: ~Escapable {
   private static func trailing(_ statement: Statement) -> SQLEngine.Query {
     switch statement {
     case let .select(query): query
+    case let .explain(query): query
     case let .with(_, query): query
     case let .create(_, view): view.query
     case .function:

--- a/Tests/SQLTests/Queries/ExplainTests.swift
+++ b/Tests/SQLTests/Queries/ExplainTests.swift
@@ -1,0 +1,609 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// A small join catalog: a `Child` keyed on `Pid`, a `Parent` and `People` each
+/// sorted on `Id` (so an equi-join on them seeks), and an `Unsorted` whose join
+/// key is not sorted (so the executor would hash it — a plan the optimiser
+/// still shapes as the same index-nested-loop `join` node).
+private func fixtures() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Child", ["Pid": .integer, "Kid": .text], sorted: "Pid") {
+      Row(1, "Ann")
+      Row(2, "Bob")
+    }
+    Relation("Parent", ["Id": .integer, "Name": .text], sorted: "Id") {
+      Row(1, "Ada")
+      Row(2, "Bee")
+    }
+    Relation("Unsorted", ["Id": .integer, "Tag": .text]) {
+      Row(1, "x")
+      Row(2, "y")
+    }
+    Relation("People", ["Id": .integer, "Name": .text, "Age": .integer],
+             sorted: "Id") {
+      Row(1, "Alice", 30)
+      Row(2, "Bob", 40)
+    }
+  }
+}
+
+/// The rendered plan-tree lines of `sql` planned against `catalog` — the exact
+/// output `EXPLAIN <sql>` yields, built through the shared compile → pushdown →
+/// decorrelate → optimise pipeline without executing.
+private func lines(_ catalog: borrowing FixtureCatalog, _ sql: String,
+                   _ bindings: Bindings = [:]) throws -> Array<String> {
+  let query = try parse(query: sql)
+  return try catalog.plan(of: query,
+                          Context(routines: .standard, bindings: bindings))
+                    .render()
+}
+
+// MARK: - Leaf and seek
+
+@Suite struct ExplainTests {
+  @Test func `a sort-key equality plans a seeked scan`() throws {
+    let catalog = try fixtures()
+    #expect(try lines(catalog, "SELECT Name FROM People WHERE Id = 2") == [
+      "project [slot 1]",
+      "└─ scan People  reads [0, 1]  seek 1..<2",
+    ])
+  }
+
+  @Test func `a range keeps the residual predicate as a select`() throws {
+    let catalog = try fixtures()
+    // The lower bound seeks; the upper bound stays a residual `select` over the
+    // seeked scan.
+    #expect(try lines(catalog,
+                      "SELECT Name FROM People WHERE Id > 1 AND Id < 9") == [
+      "project [slot 1]",
+      "└─ select  slot 0 < 9",
+      "   └─ scan People  reads [0, 1]  seek 1..<2",
+    ])
+  }
+
+  @Test func `a whole-relation scan plans no seek`() throws {
+    let catalog = try fixtures()
+    let rendered = try lines(catalog, "SELECT Name FROM People")
+    #expect(rendered.contains { $0.contains("scan People") })
+    #expect(rendered.allSatisfy { !$0.contains("seek") })
+  }
+
+  // MARK: - Joins
+
+  @Test func `an equi-join plans an index-nested-loop join`() throws {
+    let catalog = try fixtures()
+    #expect(try lines(catalog,
+                      "SELECT Child.Kid, Parent.Name FROM Child "
+                    + "JOIN Parent ON Child.Pid = Parent.Id") == [
+      "project [slot 1, slot 3]",
+      "└─ join (index nested loop)  inner Parent  on slot 0 = slot 2  "
+          + "seek column 0  base 2  reads [0, 1]",
+      "   └─ scan Child  reads [0, 1]",
+    ])
+  }
+
+  @Test func `a hash-eligible join plans the same node as a seekable one`()
+      throws {
+    let catalog = try fixtures()
+    // Whether the inner join key is sorted (seek) or not (hash) is a runtime
+    // choice the executor makes from live seekability; the optimiser shapes
+    // both as the one index-nested-loop `join` node, so the physical plan is
+    // identical bar the inner relation name — EXPLAIN renders that node
+    // faithfully rather than simulating the runtime strategy.
+    let hashed = try lines(catalog,
+                           "SELECT Child.Kid, Unsorted.Tag FROM Child "
+                         + "JOIN Unsorted ON Child.Pid = Unsorted.Id")
+    // Byte-for-byte the same node the seekable-inner join plans, bar the inner
+    // relation name — the plan does not encode the runtime hash-vs-seek choice.
+    #expect(hashed == [
+      "project [slot 1, slot 3]",
+      "└─ join (index nested loop)  inner Unsorted  on slot 0 = slot 2  "
+          + "seek column 0  base 2  reads [0, 1]",
+      "   └─ scan Child  reads [0, 1]",
+    ])
+  }
+
+  @Test func `a cross join plans a nested-loop product`() throws {
+    let catalog = try fixtures()
+    let rendered = try lines(catalog,
+                             "SELECT Child.Kid, Parent.Name "
+                           + "FROM Child CROSS JOIN Parent")
+    #expect(rendered.contains { $0.contains("product (nested loop)") })
+    #expect(rendered.allSatisfy { !$0.contains("join") })
+  }
+
+  @Test func `a non-equi join stays a product under a select`() throws {
+    let catalog = try fixtures()
+    let rendered = try lines(catalog,
+                             "SELECT Child.Kid, Parent.Name FROM Child "
+                           + "JOIN Parent ON Child.Pid < Parent.Id")
+    #expect(rendered.contains { $0.contains("select  slot 0 < slot 2") })
+    #expect(rendered.contains { $0.contains("product (nested loop)") })
+  }
+
+  @Test func `a LEFT JOIN plans an outer node`() throws {
+    let catalog = try fixtures()
+    #expect(try lines(catalog,
+                      "SELECT Child.Kid, Parent.Name FROM Child "
+                    + "LEFT JOIN Parent ON Child.Pid = Parent.Id") == [
+      "project [slot 1, slot 3]",
+      "└─ outer LEFT  on slot 0 = slot 2",
+      "   ├─ scan Child  reads [0, 1]",
+      "   └─ scan Parent  reads [0, 1]",
+    ])
+  }
+
+  // MARK: - Sort, distinct, limit, aggregate, window
+
+  @Test func `an ORDER BY plans a sort node`() throws {
+    let catalog = try fixtures()
+    let rendered =
+        try lines(catalog, "SELECT Name FROM People ORDER BY Age DESC")
+    #expect(rendered.contains { $0.contains("sort  slot 1 DESC") })
+  }
+
+  @Test func `a DISTINCT over a non-unique scan is kept`() throws {
+    let catalog = try fixtures()
+    let rendered = try lines(catalog, "SELECT DISTINCT Age FROM People")
+    #expect(rendered.contains("distinct"))
+  }
+
+  @Test func `a DISTINCT over a grouped unique source is elided`() throws {
+    let catalog = try fixtures()
+    // The aggregate already yields one row per distinct key, so the optimiser
+    // drops the redundant `distinct` — the plan shows the aggregate and no
+    // `distinct` node.
+    let rendered = try lines(catalog,
+                             "SELECT DISTINCT Age FROM People GROUP BY Age")
+    #expect(!rendered.contains("distinct"))
+    #expect(rendered.contains { $0.contains("aggregate") })
+  }
+
+  @Test func `an OFFSET·FETCH plans a limit node`() throws {
+    let catalog = try fixtures()
+    let rendered = try lines(catalog,
+                             "SELECT Name FROM People "
+                           + "OFFSET 1 ROWS FETCH FIRST 2 ROWS ONLY")
+    #expect(rendered.contains { $0.contains("limit  count 2  offset 1") })
+  }
+
+  @Test func `a GROUP BY plans an aggregate with its keys and folds`() throws {
+    let catalog = try fixtures()
+    let rendered = try lines(catalog,
+                             "SELECT Age, COUNT(*) FROM People GROUP BY Age")
+    #expect(rendered.contains {
+      $0.contains("aggregate  keys [slot 0]  aggregates [COUNT(*)]")
+    })
+  }
+
+  @Test func `a window function plans a window node with its OVER clause`()
+      throws {
+    let catalog = try fixtures()
+    let rendered = try lines(catalog,
+                             "SELECT Name, ROW_NUMBER() OVER "
+                           + "(PARTITION BY Age ORDER BY Id) FROM People")
+    #expect(rendered.contains {
+      $0.contains("window [ROW_NUMBER() OVER "
+                + "(PARTITION BY slot 2 ORDER BY slot 0 ASC)]")
+    })
+  }
+
+  @Test func `an explicit window frame is rendered in the OVER clause`()
+      throws {
+    let catalog = try fixtures()
+    // The frame's unit and bounds are rendered, so a window is distinct from
+    // one folding a different row set.
+    let one = try lines(catalog, "SELECT SUM(Age) OVER (ORDER BY Id "
+                              + "ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) "
+                              + "FROM People")
+    #expect(one.contains {
+      $0.contains("ROWS BETWEEN 1 PRECEDING AND CURRENT ROW")
+    })
+    // A wider frame folds different rows, so it must plan differently.
+    let five = try lines(catalog, "SELECT SUM(Age) OVER (ORDER BY Id "
+                               + "ROWS BETWEEN 5 PRECEDING AND CURRENT ROW) "
+                               + "FROM People")
+    #expect(one != five)
+  }
+
+  @Test func `a LEAD default operand is rendered`() throws {
+    let catalog = try fixtures()
+    // The third operand — the partition-edge default — is part of the value,
+    // so it is rendered; `LEAD(A, 1, 0)` must not read like the implicit-NULL
+    // form.
+    let withDefault =
+        try lines(catalog, "SELECT LEAD(Age, 1, 0) OVER (ORDER BY Id) "
+                         + "FROM People")
+    #expect(withDefault.contains { $0.contains(", 1, 0)") })
+    let without =
+        try lines(catalog, "SELECT LEAD(Age, 1) OVER (ORDER BY Id) FROM People")
+    #expect(withDefault != without)
+  }
+
+  // MARK: - Decorrelation
+
+  @Test func `a correlated EXISTS decorrelates to a semijoin`() throws {
+    let catalog = try fixtures()
+    #expect(try lines(catalog,
+                      "SELECT Name FROM Parent WHERE EXISTS "
+                    + "(SELECT 1 FROM Child WHERE Child.Pid = Parent.Id)") == [
+      "project [slot 1]",
+      "└─ semijoin  on slot 0 = slot 2",
+      "   ├─ scan Parent  reads [0, 1]",
+      "   └─ scan Child  reads [0]",
+    ])
+  }
+
+  @Test func `a correlated NOT EXISTS decorrelates to an anti-semijoin`()
+      throws {
+    let catalog = try fixtures()
+    let sql = "SELECT Name FROM Parent WHERE NOT EXISTS "
+            + "(SELECT 1 FROM Child WHERE Child.Pid = Parent.Id)"
+    let rendered = try lines(catalog, sql)
+    #expect(rendered.contains { $0.contains("semijoin (anti)") })
+  }
+
+  @Test func `a decorrelatable LATERAL folds to a join`() throws {
+    let catalog = try fixtures()
+    // The correlated CROSS APPLY decorrelates into a set-based equi-join —
+    // there is no `apply` node left in the plan.
+    let rendered = try lines(catalog,
+                             "SELECT Parent.Name, d.Kid FROM Parent "
+                           + "CROSS JOIN LATERAL (SELECT Kid FROM Child "
+                           + "WHERE Child.Pid = Parent.Id) AS d")
+    #expect(rendered.contains { $0.contains("join (index nested loop)") })
+    #expect(rendered.allSatisfy { !$0.contains("apply") })
+  }
+
+  @Test func `a non-decorrelatable LATERAL stays an apply with correlation`()
+      throws {
+    let catalog = try fixtures()
+    // A lateral whose body aggregates does not decorrelate, so it stays an
+    // `apply` — its correlation (the outer cell each re-execution binds) shown.
+    let rendered = try lines(catalog,
+                             "SELECT Parent.Name, d.n FROM Parent "
+                           + "CROSS JOIN LATERAL (SELECT COUNT(*) AS n FROM "
+                           + "Child WHERE Child.Pid = Parent.Id) AS d")
+    #expect(rendered.contains {
+      $0.contains("apply INNER  correlation [:__correlated_0_0 ← slot 0]")
+    })
+  }
+
+  // MARK: - Subqueries and set operations
+
+  @Test func `a scalar subquery renders in the projection`() throws {
+    let catalog = try fixtures()
+    let rendered = try lines(catalog,
+                             "SELECT Name, (SELECT COUNT(*) FROM Child) "
+                           + "FROM Parent")
+    #expect(rendered.contains { $0.contains("(subquery)") })
+  }
+
+  @Test func `a UNION plans a setop over its two arms`() throws {
+    let catalog = try fixtures()
+    #expect(try lines(catalog,
+                      "SELECT Id FROM People UNION SELECT Id FROM Parent") == [
+      "union",
+      "├─ project [slot 0]",
+      "│  └─ scan People  reads [0]",
+      "└─ project [slot 0]",
+      "   └─ scan Parent  reads [0]",
+    ])
+  }
+
+  // MARK: - SQL surface
+
+  @Test func `EXPLAIN parses to an explain statement`() throws {
+    let statement = try Statement(parsing: "EXPLAIN SELECT Name FROM People")
+    guard case .explain = statement else {
+      Issue.record("expected an .explain statement")
+      return
+    }
+  }
+
+  @Test func `EXPLAIN at statement start is contextual and case-insensitive`()
+      throws {
+    let catalog = try fixtures()
+    // Recognised in any case at statement start; a set-operation query is a
+    // valid inspected query too.
+    for keyword in ["EXPLAIN", "explain", "Explain"] {
+      let statement =
+          try Statement(parsing: "\(keyword) SELECT Name FROM People")
+      guard case .explain = statement else {
+        Issue.record("expected an .explain statement for \(keyword)")
+        return
+      }
+      #expect(try !catalog.run(statement, .standard).isEmpty)
+    }
+  }
+
+  @Test func `Explain is an ordinary identifier away from statement start`()
+      throws {
+    // `EXPLAIN` is not reserved, so a relation, column, and alias all named
+    // `Explain` — the exact names the reserved token used to break — parse and
+    // run as ordinary identifiers.
+    let catalog = try Catalog {
+      Relation("Explain", ["Explain": .integer]) {
+        Row(1)
+      }
+    }
+    try catalog.expect("SELECT * FROM Explain", yields: [[1]])
+    try catalog.expect("SELECT Explain FROM Explain", yields: [[1]])
+    try catalog.expect("SELECT Explain AS Explain FROM Explain",
+                       yields: [[1]])
+  }
+
+  @Test func `EXPLAIN yields the plan tree as text rows`() throws {
+    let catalog = try fixtures()
+    let sql = "SELECT Name FROM People WHERE Id = 2"
+    let statement = try Statement(parsing: "EXPLAIN " + sql)
+    let rows = try catalog.run(statement, .standard)
+    let expected = try lines(catalog, sql).map { [Value.text($0)] }
+    #expect(rows == expected)
+  }
+
+  @Test func `EXPLAIN describes a single text plan column`() throws {
+    let catalog = try fixtures()
+    let statement = try Statement(parsing: "EXPLAIN SELECT Name FROM People")
+    let columns = try catalog.columns(of: statement, routines: .standard)
+    #expect(columns.map(\.name) == ["plan"])
+    #expect(columns.map(\.type) == [.text])
+  }
+
+  @Test func `describing an unplannable EXPLAIN faults`() throws {
+    let catalog = try fixtures()
+    // The inspected query names no `Missing` column, so describing the
+    // `EXPLAIN` must fault as running it would — a prepare/schema client cannot
+    // be handed a plan-column schema for a statement that cannot be planned.
+    let statement =
+        try Statement(parsing: "EXPLAIN SELECT Missing FROM People")
+    #expect(throws: SQLError.self) {
+      _ = try catalog.columns(of: statement, routines: .standard,
+                              validate: true)
+    }
+  }
+
+  @Test func `describing an EXPLAIN validates by planning not executing`()
+      throws {
+    let catalog = try fixtures()
+    // `Name + 1` is text + integer — an operand error only a row evaluation
+    // raises. Running the EXPLAIN builds a plan and never evaluates it, so
+    // describing the EXPLAIN plans without faulting — even though describing
+    // the bare SELECT eager-type-checks the operand and does fault.
+    let explain =
+        try Statement(parsing: "EXPLAIN SELECT Name + 1 FROM People")
+    #expect(throws: Never.self) {
+      _ = try catalog.columns(of: explain, routines: .standard, validate: true)
+    }
+    // The EXPLAIN itself runs, so describing it must agree.
+    #expect(throws: Never.self) {
+      _ = try catalog.run(explain, .standard)
+    }
+    let select = try Statement(parsing: "SELECT Name + 1 FROM People")
+    #expect(throws: SQLError.self) {
+      _ = try catalog.columns(of: select, routines: .standard, validate: true)
+    }
+  }
+
+  @Test func `a text literal with a newline renders on one line`() throws {
+    let catalog = try fixtures()
+    // The string constant carries a literal newline; the plan literal escapes
+    // it (`\n`) so the operator stays a single line and the shell's box frame
+    // is not corrupted.
+    let rendered = try lines(catalog, "SELECT 'a\nb' AS s FROM People")
+    #expect(rendered.allSatisfy { !$0.contains("\n") })
+    #expect(rendered.contains { $0.contains("'a\\nb'") })
+  }
+
+  @Test func `a text literal with a quote renders it escaped`() throws {
+    let catalog = try fixtures()
+    // A doubled `''` embeds one quote (ISO); the plan literal escapes it (`\'`)
+    // so the quoting is unambiguous rather than reading as a closed string.
+    let rendered = try lines(catalog, "SELECT 'it''s' AS s FROM People")
+    #expect(rendered.contains { $0.contains("'it\\'s'") })
+  }
+
+  @Test func `a delimited relation name with a newline renders on one line`()
+      throws {
+    // A delimited identifier is verbatim and may hold a newline; the scan label
+    // escapes it (`\n`) so the operator stays a single line rather than
+    // splitting the row and corrupting the shell's box frame.
+    let catalog = try Catalog {
+      Relation("a\nb", ["x": .integer]) { Row(1) }
+    }
+    let query = try parse(query: "SELECT x FROM \"a\nb\"")
+    let rendered = try catalog.plan(of: query,
+                                    Context(routines: .standard)).render()
+    #expect(rendered.allSatisfy { !$0.contains("\n") })
+    #expect(rendered.contains { $0.contains("scan a\\nb") })
+  }
+
+  @Test func `the EXPLAIN feature leaves a normal query's rows unchanged`()
+      throws {
+    let catalog = try fixtures()
+    // A plain SELECT still returns its own rows — EXPLAIN is purely diagnostic
+    // and never touches the execution path of a non-EXPLAIN query.
+    try catalog.expect("SELECT Name FROM People WHERE Id = 2",
+                       yields: [["Bob"]])
+  }
+}
+
+// MARK: - Plan-only augmentation
+
+private final class Counter: @unchecked Sendable {
+  private(set) var count = 0
+  func next() -> Int { count += 1; return count }
+}
+
+/// `EXPLAIN` inspects the plan without executing it, so it augments
+/// schema-only: a derived table's body never runs — a stateful routine or a
+/// throwing derived expression stays unfired — and a bare set operation still
+/// resolves each arm's own aliases, as the run path does.
+@Suite struct ExplainPlanOnlyTests {
+  @Test func `planning a derived table does not run its body`() throws {
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    let catalog = try Catalog {
+      Relation("T", ["a": .integer]) { Row(1); Row(2) }
+    }
+    let query =
+        try parse(query: "SELECT x FROM (SELECT tick() AS x FROM T) AS d")
+    let rendered = try catalog.plan(of: query,
+                                    Context(routines: routines)).render()
+    // The plan is produced, and `tick()` never fired — a materialising augment
+    // would have run the derived body once per row.
+    #expect(!rendered.isEmpty)
+    #expect(counter.count == 0)
+  }
+
+  @Test func `planning a throwing derived expression does not raise`() throws {
+    let catalog = try Catalog {
+      Relation("T", ["a": .integer]) { Row(1) }
+    }
+    // `1 / 0` raises at execution; EXPLAIN stops before it, so planning the
+    // derived table succeeds rather than surfacing an execution-time fault.
+    let query =
+        try parse(query: "SELECT x FROM (SELECT 1 / 0 AS x FROM T) AS d")
+    #expect(throws: Never.self) {
+      _ = try catalog.plan(of: query, Context(routines: .standard)).render()
+    }
+  }
+
+  @Test func `a bare set operation plans each arm's own aliases`() throws {
+    let catalog = try Catalog {
+      Relation("T", ["a": .integer]) { Row(1) }
+    }
+    // Each arm scans an arm-local derived alias (`d`, `e`) the top-level scope
+    // does not bind; the plan-only path must optimise each arm under its own
+    // augmented scope rather than faulting `.relation`. A carrier-free set
+    // operation reaches the plan helper only through `EXPLAIN` — the run path
+    // runs its arms directly — so this is the shape a single top-level context
+    // would break.
+    let sql = "SELECT v FROM (VALUES (1)) AS d(v) WHERE v = 1 " +
+              "UNION ALL SELECT v FROM (VALUES (2)) AS e(v)"
+    let query = try parse(query: sql)
+    #expect(throws: Never.self) {
+      _ = try catalog.plan(of: query, Context(routines: .standard)).render()
+    }
+  }
+
+  @Test func `a bare set operation decorrelates an arm under its own scope`()
+      throws {
+    let catalog = try Catalog {
+      Relation("Child", ["Pid": .integer]) {
+        Row(1)
+        Row(2)
+      }
+    }
+    // The first arm's correlated EXISTS names the arm-local `d.v`, which the
+    // shared top-level scope does not bind — so a shared-context decorrelation
+    // bails and leaves it correlated. Running the bare UNION decorrelates each
+    // arm under its own augmented scope to a semijoin; the inspected plan must
+    // match, not report the correlated form the run never uses.
+    let sql = "SELECT v FROM (VALUES (1)) AS d(v) " +
+              "WHERE EXISTS (SELECT 1 FROM Child WHERE Child.Pid = v) " +
+              "UNION ALL SELECT Pid FROM Child"
+    let query = try parse(query: sql)
+    let rendered = try catalog.plan(of: query,
+                                    Context(routines: .standard)).render()
+    #expect(rendered.contains { $0.contains("semijoin") })
+  }
+}
+
+// MARK: - Convergence guards
+
+/// Structural guards that catch a whole class of EXPLAIN regressions at once,
+/// rather than one query at a time: the renderer must distinguish physically
+/// different plans (a dropped field collapses two), and describing an EXPLAIN
+/// must agree with planning it (the diagnostic must not diverge from the run).
+@Suite struct ExplainConvergenceTests {
+  /// Each query below is physically distinct from every other — a different
+  /// source, filter, seek, sort, limit, window frame, offset default, or set
+  /// operation. If the renderer drops a distinguishing field (as it once
+  /// dropped the window frame and the LEAD default), two of these collapse to
+  /// the same text and the count no longer matches. This catches a dropped
+  /// field without a per-field golden.
+  @Test func `physically distinct queries render distinctly`() throws {
+    let catalog = try fixtures()
+    let queries = [
+      "SELECT Age FROM People",
+      "SELECT Name FROM People",
+      "SELECT Age FROM People WHERE Id = 1",
+      "SELECT Age FROM People WHERE Id = 2",
+      "SELECT Age, Name FROM People",
+      "SELECT Age FROM People WHERE Age > 1",
+      "SELECT Age FROM People ORDER BY Age",
+      "SELECT Age FROM People ORDER BY Age DESC",
+      "SELECT DISTINCT Age FROM People",
+      "SELECT Age FROM People OFFSET 1 ROWS FETCH FIRST 2 ROWS ONLY",
+      "SELECT Age FROM People OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY",
+      "SELECT Age FROM People OFFSET 1 ROWS FETCH FIRST 3 ROWS ONLY",
+      "SELECT SUM(Age) OVER (ORDER BY Id "
+        + "ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM People",
+      "SELECT SUM(Age) OVER (ORDER BY Id "
+        + "ROWS BETWEEN 5 PRECEDING AND CURRENT ROW) FROM People",
+      "SELECT SUM(Age) OVER (ORDER BY Id "
+        + "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM People",
+      "SELECT SUM(Age) OVER (ORDER BY Id "
+        + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM People",
+      "SELECT LEAD(Age, 1) OVER (ORDER BY Id) FROM People",
+      "SELECT LEAD(Age, 1, 0) OVER (ORDER BY Id) FROM People",
+      "SELECT LEAD(Age, 1, 9) OVER (ORDER BY Id) FROM People",
+      "SELECT LEAD(Age, 2, 0) OVER (ORDER BY Id) FROM People",
+      "SELECT COUNT(*) FROM People",
+      "SELECT COUNT(DISTINCT Age) FROM People",
+      "SELECT Name FROM Parent WHERE EXISTS "
+        + "(SELECT 1 FROM Child WHERE Child.Pid = Parent.Id)",
+      "SELECT Name FROM Parent WHERE NOT EXISTS "
+        + "(SELECT 1 FROM Child WHERE Child.Pid = Parent.Id)",
+      "SELECT Id FROM People UNION SELECT Id FROM Parent",
+      "SELECT Id FROM People UNION ALL SELECT Id FROM Parent",
+      "SELECT Id FROM People INTERSECT SELECT Id FROM Parent",
+    ]
+    let renders = try queries.map {
+      try lines(catalog, $0).joined(separator: "\n")
+    }
+    // A collision means two physically different plans render identically.
+    #expect(Set(renders).count == queries.count)
+  }
+
+  /// Describing an `EXPLAIN` (`columns(of:validate:)`) must succeed on exactly
+  /// the queries running the `EXPLAIN` (`run`) succeeds on — both prove the
+  /// query plannable, neither evaluates a row. A divergence is the class of bug
+  /// that produced the materialise-derived-rows, per-arm-scope, and
+  /// validate-by-executing rounds; this asserts agreement across a corpus so a
+  /// new divergence fails here rather than in review.
+  @Test func `describing an EXPLAIN agrees with planning it`() throws {
+    let catalog = try fixtures()
+    let queries = [
+      "SELECT Age FROM People",
+      "SELECT Name + 1 FROM People",
+      "SELECT Age FROM People WHERE Id = 2",
+      "SELECT COUNT(*) FROM People",
+      "SELECT DISTINCT Age FROM People",
+      "SELECT Missing FROM People",
+      "SELECT Age FROM People WHERE Name = 1",
+      "SELECT Id FROM People UNION SELECT Id FROM Parent",
+      "SELECT Name FROM Parent WHERE EXISTS "
+        + "(SELECT 1 FROM Child WHERE Child.Pid = Parent.Id)",
+    ]
+    for query in queries {
+      let statement = try Statement(parsing: "EXPLAIN " + query)
+      let planned = (try? catalog.run(statement, .standard)) != nil
+      let described = (try? catalog.columns(of: statement, routines: .standard,
+                                            validate: true)) != nil
+      #expect(planned == described, "EXPLAIN \(query)")
+    }
+  }
+}
+


### PR DESCRIPTION
The optimiser turns a query into a physical `Plan` (seeks, index-nested-loop and hash joins, decorrelation, DISTINCT elision), but nothing could observe the result — optimiser behaviour was testable only through row output. `EXPLAIN` closes that gap by rendering the optimised physical plan.

Three pieces:

  - A pure, stable pretty-printer (`Plan.render`, in `Explain.swift`) that lays the plan out as an indented operator tree with box-drawing connectors, one node per line, each annotated with the optimiser-relevant fields: a scan's referenced ordinals and seek range, a join's seek key and pushed inner filter, an outer/semijoin kind, an apply's correlation, sort keys, aggregate keys and folds, a window's OVER clause, a limit's count/offset, a setop kind. It renders the physical node faithfully and does not simulate the executor's runtime hash-vs-seek choice.

  - A testable entry point (`Catalog.plan(of:)`) that runs the exact compile → pushdown → decorrelate → optimise pipeline the executor uses, without executing. The shared walk is factored into `optimised(_:_:)`, which `run` now also drives, so an EXPLAIN inspects precisely the plan a run executes — the two cannot drift.

  - A SQL surface: `EXPLAIN <query>` parses to a new `Statement.explain` case and dispatches through the statement-level `run` to yield the plan tree as a single-column relation of text lines (`columns(of:)` names the column `plan`). It is a diagnostic non-ISO extension, so the CLI shell and an `expect`/`run(_ statement:)` test consume it as ordinary rows. The feature is purely additive and leaves every non-EXPLAIN query's execution untouched.

A focused suite pins the renderings for a seek, an index-nested-loop join, a hash-eligible join (the same node, since the strategy is a runtime choice), a nested-loop product, a sort, an elided vs kept DISTINCT, a decorrelated EXISTS semijoin, a non-decorrelatable apply with its correlation, a decorrelated lateral, a LIMIT, an aggregate, a window, a set operation, and the SQL surface.