### PR TITLE
SQLEngine: support a window function over grouped output

### DIFF
--- a/Sources/SQLEngine/AST.swift
+++ b/Sources/SQLEngine/AST.swift
@@ -688,6 +688,32 @@ public struct Select: Hashable, Sendable {
     }
     return expressions
   }
+
+  /// The projection and ORDER BY expressions the select evaluates, for routing
+  /// the query on a feature one of them carries — an aggregate or a window. It
+  /// underlies both `aggregates` and `windows` so the two scan one identical
+  /// set: a feature in the ORDER BY routes the query exactly as one in the
+  /// projection does.
+  ///
+  /// Unlike `orderKeys`, this does no output-name resolution — an ORDER BY
+  /// ordinal or bare-output-name key references a projected item already in
+  /// this set, so only a literal `.expression` key contributes — so it does not
+  /// consult `aggregates` (which `orderKeys` does, to pick the output surface)
+  /// and the aggregate routing may read it without a cycle.
+  internal var expressions: Array<Expression> {
+    var evaluated: Array<Expression> = switch projection {
+    case .all, .columns:
+      []
+    case let .expressions(items):
+      items.map(\.expression)
+    }
+    for key in order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        evaluated.append(expression)
+      }
+    }
+    return evaluated
+  }
 }
 
 /// A relation in a `FROM` or `JOIN`: a base relation named by an identifier, or

--- a/Sources/SQLEngine/Aggregation.swift
+++ b/Sources/SQLEngine/Aggregation.swift
@@ -5,12 +5,15 @@
 
 extension Select {
   /// Whether the select aggregates — it has a `GROUP BY`, a `HAVING`, or an
-  /// aggregate function anywhere in its projection.
+  /// aggregate function anywhere in its projection or its ORDER BY.
   ///
   /// A query with any of these compiles through the grouped path; one with none
   /// keeps the ordinary `Project(Limit(Sort(Select(_))))` shape unchanged. A
   /// `HAVING` alone (no `GROUP BY`, no aggregate) still aggregates — it filters
-  /// the single whole-result group.
+  /// the single whole-result group. An aggregate reachable only from the ORDER
+  /// BY (`ORDER BY SUM(sal)`, or a window `RANK() OVER (ORDER BY SUM(sal))`)
+  /// aggregates too — the same `expressions` set `windows` scans, so the two
+  /// routings stay in step rather than one forgetting the ORDER BY.
   internal var aggregates: Bool {
     let grouped = switch grouping {
     case let .keys(keys): !keys.isEmpty
@@ -20,11 +23,40 @@ extension Select {
     case .sets, .arm: true
     }
     if grouped || having != nil { return true }
-    switch projection {
-    case .all, .columns:
-      return false
-    case let .expressions(items):
-      return items.contains { $0.expression.aggregated }
+    return expressions.contains { $0.aggregated }
+  }
+}
+
+extension Aggregand {
+  /// Whether this aggregate operand nests a query aggregate — `*` never does,
+  /// an expression its own (the `SUM(sal)` of `SUM(SUM(sal))`).
+  internal var aggregated: Bool {
+    switch self {
+    case .star: false
+    case let .expression(expression): expression.aggregated
+    }
+  }
+}
+
+extension WindowFunction {
+  /// Whether this window function's own operand or FILTER nests a query
+  /// aggregate. The window function itself (an aggregate window `SUM(x) OVER
+  /// ()`) is cardinality-preserving and not a query aggregate; only an
+  /// aggregate in its argument, value, default, or FILTER —
+  /// `SUM(SUM(sal))`, `LEAD(SUM(sal), 1, COUNT(*))` — makes the enclosing query
+  /// an aggregate one, routing it through the grouped path where the inner
+  /// aggregate lowers.
+  internal var aggregated: Bool {
+    switch self {
+    case .rowNumber, .rank, .denseRank, .ntile, .percentRank, .cumeDist:
+      false
+    case let .aggregate(_, argument, _, filter):
+      argument.aggregated || (filter?.aggregated ?? false)
+    case let .lead(value, _, fallback), let .lag(value, _, fallback):
+      value.aggregated || (fallback?.aggregated ?? false)
+    case let .firstValue(value), let .lastValue(value),
+         let .nthValue(value, _):
+      value.aggregated
     }
   }
 }
@@ -57,12 +89,13 @@ extension Expression {
       // only if an argument is (a GROUP BY expression never is, so this is
       // false in practice) — mirroring the neighbouring `call` arm.
       arguments.contains { $0.aggregated }
-    case let .window(_, spec):
+    case let .window(function, spec):
       // A window function is not itself an aggregate — it preserves cardinality
-      // rather than folding a group — but a query aggregate nested in its
-      // partition or order (`ROW_NUMBER() OVER (ORDER BY SUM(x))`) is one, so
-      // descend the specification's expressions as a `call`'s arguments.
-      spec.expressions.contains { $0.aggregated }
+      // rather than folding a group — but a query aggregate nested in its own
+      // operand or FILTER (`SUM(SUM(sal)) OVER ()`, `LEAD(SUM(sal)) OVER ()`),
+      // or in its partition/order (`ROW_NUMBER() OVER (ORDER BY SUM(x))`), is
+      // one, so the enclosing query routes through the grouped path.
+      function.aggregated || spec.expressions.contains { $0.aggregated }
     }
   }
 
@@ -1240,11 +1273,53 @@ extension Catalog where Self: ~Escapable {
     let supers = try superset.map { key throws(SQLError) -> Term in
       try scope.term(key, context.routines, subquery: plans.rest)
     }
+    // A window function beside the aggregation computes over the grouped rows —
+    // one output row per group, widened by the window slots — via a `window`
+    // node above the aggregate. A `GROUPING SETS` arm is deferred: its window
+    // would see only that arm's grouped rows, not the union of every set's the
+    // ISO semantics prescribe, so it faults the feature diagnostic on both the
+    // run and validate paths (this compile is the parity gate).
+    if select.windows, case .arm = select.grouping {
+      throw .state("0A000",
+                   "a window function with GROUPING SETS is not yet supported")
+    }
+
     // Lower the projection, HAVING, and ORDER BY against the grouped slot
     // space, enforcing the projection rule (every non-aggregated column must be
-    // a GROUP BY key).
+    // a GROUP BY key). In a window query the surface additionally routes each
+    // window function to an appended output slot over the aggregate node.
     var grouped = try Grouped(scope, grouping, keys, aggregations,
-                              superset: supers, subquery: plans.rest)
+                              superset: supers, subquery: plans.rest,
+                              windowed: select.windows)
+
+    // A window query validates each collected window's function and frame ahead
+    // of lowering — an unsupported function or frame faulting the feature
+    // diagnostic in parity with the schema type derive, exactly as the plain
+    // window path checks. The windows are gathered from the projection and the
+    // `ORDER BY`, the only clauses a window is allowed in.
+    if select.windows {
+      // `front` already validated the WINDOW-clause definitions for
+      // well-formedness (a referenced one is validated strictly below via its
+      // inlined form in the projection/ORDER BY), so no revalidation here.
+      var windows = Array<Expression>()
+      for expression in select.projection.projected {
+        expression.collect(windows: &windows)
+      }
+      for expression in select.orderKeys {
+        expression.collect(windows: &windows)
+      }
+      for expression in windows {
+        guard case let .window(function, spec) = expression else {
+          throw .state("XX000", "expected a window function")
+        }
+        guard function.supported else {
+          throw .state("0A000", "\(function.keyword) is not yet supported")
+        }
+        try function.require(order: spec)
+        if let frame = spec.frame { try frame.reject(for: function) }
+      }
+    }
+
     let projection = try grouped.terms(select.projection, context.routines,
                                        subquery: plans.rest)
     let having: Filter? = if let clause = select.having {
@@ -1269,12 +1344,28 @@ extension Catalog where Self: ~Escapable {
       order = try distinct(clause.keys, order, projection)
     }
 
-    // The HAVING filters groups below the sort, the slot the WHERE occupies on
-    // the non-aggregate path, so the shared `shaped` applies it identically —
-    // an ORDER BY key naming a computed aggregate output (`COUNT(*) * 2 AS n`)
-    // then materialises once and sorts on the returned value.
-    return node.shaped(distinct: select.distinct, projection: projection,
-                       filter: having, order: order, limit: select.limit)
+    // A non-window aggregate query shapes the aggregate node directly, the
+    // HAVING filtering groups below the sort (the slot the WHERE occupies on
+    // the non-aggregate path), so `shaped` applies it identically — an ORDER BY
+    // key naming a computed aggregate output (`COUNT(*) * 2 AS n`) then
+    // materialises once and sorts on the returned value.
+    guard select.windows else {
+      return node.shaped(distinct: select.distinct, projection: projection,
+                         filter: having, order: order, limit: select.limit)
+    }
+
+    // A window query places a `window` node above the aggregate, the HAVING
+    // filtering groups below it — so the window functions see the surviving
+    // groups (ISO: HAVING restricts groups before the windows compute) — and
+    // the node appends each windowing's value at its output slot. The
+    // projection and ORDER BY were lowered over that widened space, so `shaped`
+    // sorts, projects, dedups, and pages the window output with no residual
+    // filter.
+    var source = node
+    if let having { source = .select(having, source) }
+    let window = Plan.window(grouped.windowings, source)
+    return window.shaped(distinct: select.distinct, projection: projection,
+                         filter: nil, order: order, limit: select.limit)
   }
 }
 
@@ -1331,12 +1422,29 @@ extension Expression {
       // arguments so any aggregate nested in one is collected (a GROUP BY
       // expression never nests one, so this gathers nothing in practice).
       for argument in arguments { argument.collect(into: &expressions) }
-    case let .window(_, spec):
+    case let .window(function, spec):
       // A window function is not a query aggregate, but — like a `call` —
-      // descend its specification's expressions so an aggregate nested in a
-      // partition or order (`ROW_NUMBER() OVER (ORDER BY SUM(x))`) is collected.
+      // descend its constituents so an aggregate the window folds over grouped
+      // output is collected and computed by the group node. Its specification's
+      // partition and order (`RANK() OVER (ORDER BY SUM(x))`) and its own
+      // operands both bear one: an aggregate window's argument and `FILTER`
+      // (`SUM(SUM(x)) OVER ()`), a positional function's value and default
+      // (`LEAD(SUM(x)) OVER (ORDER BY d)`).
       for expression in spec.expressions {
         expression.collect(into: &expressions)
+      }
+      switch function {
+      case let .aggregate(_, operand, _, filter):
+        if case let .expression(expression) = operand {
+          expression.collect(into: &expressions)
+        }
+        filter?.collect(into: &expressions)
+      case .rowNumber, .rank, .denseRank, .ntile, .percentRank, .cumeDist,
+           .lead, .lag, .firstValue, .lastValue, .nthValue:
+        if let positional = function.positional {
+          positional.value.collect(into: &expressions)
+          positional.default?.collect(into: &expressions)
+        }
       }
     }
   }

--- a/Sources/SQLEngine/Compilation.swift
+++ b/Sources/SQLEngine/Compilation.swift
@@ -1415,10 +1415,14 @@ extension Catalog where Self: ~Escapable {
     // of a filtered-out derived body a nested subquery names.
     let plans = try subquery(of: select, context, enclosing: scope,
                              prefixes: prefixes)
-    // A WINDOW clause with no window function is dropped after compilation, so
-    // validate its definitions here — against the whole join `scope`, so a
-    // definition naming a joined relation's column resolves as the query's own
-    // clauses do.
+    // A WINDOW clause's definitions are validated here for well-formedness
+    // against the whole join `scope` — a definition naming a joined relation's
+    // column resolves as the query's own clauses do. A referenced definition is
+    // additionally validated strictly by its inlined form in the projection/
+    // ORDER BY on the query's compute surface (base or grouped); this check is
+    // what an unused definition gets, so `validate(named:)` imposes no grouping
+    // rule, admitting `WINDOW w AS (ORDER BY sal)` beside one over `SUM(sal)`
+    // whether the query aggregates or not.
     try validate(named: select.window, against: scope, context.routines,
                  subquery: plans.rest)
     var matches = Array<Filter>()
@@ -1732,17 +1736,33 @@ extension Catalog where Self: ~Escapable {
   /// definition carrying a subquery is not spuriously rejected. Every definition
   /// is validated whether or not a window function references it, so a query
   /// with a `WINDOW` clause never silently accepts an unresolvable unused one.
-  internal borrowing func validate(named windows: Array<NamedWindow>,
-                                   against scope: Scope, _ routines: Routines,
-                                   subquery: Resolution) throws(SQLError) {
+  internal borrowing func validate(
+      named windows: Array<NamedWindow>, against scope: Scope,
+      _ routines: Routines, subquery: Resolution) throws(SQLError) {
     for definition in windows {
       let spec = try definition.spec.resolved(against: windows)
       // The function-independent structural frame check — a reversed or inverted
-      // frame — that `reject(for:)` runs for a referenced window; `windowing`
-      // resolves the keys but not the frame's bounds, so run it here too.
+      // frame — that `reject(for:)` runs for a referenced window.
       if let frame = spec.frame { try frame.check() }
-      _ = try Expression.window(function: .rowNumber, spec: spec)
-          .windowing(scope, routines, subquery: subquery)
+      // A window `ORDER BY` output ordinal has no meaning — there is no output
+      // to name — rejected here as it is for a referenced window's spec.
+      for key in spec.order?.keys ?? [] {
+        if case .ordinal = key.sort {
+          throw .state("0A000",
+                       "a window ORDER BY output ordinal is not supported")
+        }
+      }
+      // A definition is validated for well-formedness against the input scope,
+      // not lowered onto a compute surface: a referenced definition is inlined
+      // into the projection/ORDER BY and validated strictly there (base scope
+      // or grouped), so this need only confirm an unused one is well-formed —
+      // its columns resolve and any aggregate is structurally valid — with no
+      // grouping rule. That is the one check admitting both a dead `ORDER BY
+      // sal` (an ordinary column, no GROUP BY key) and `ORDER BY SUM(sal)` (an
+      // aggregate needing no slot): neither compute surface accepts both.
+      for expression in spec.expressions {
+        try scope.admit(expression, routines, subquery: subquery)
+      }
     }
   }
 

--- a/Sources/SQLEngine/Grouped.swift
+++ b/Sources/SQLEngine/Grouped.swift
@@ -83,19 +83,52 @@ internal struct Grouped {
   /// (`SQLError.ambiguous`) rather than silently picking the last projection.
   private var ambiguous: Set<String> = []
 
+  /// The window registry when this surface lowers a window query over the
+  /// aggregate output — `nil` for an ordinary grouped query, whose `.window`
+  /// arm faults the feature diagnostic. A window function's `term` lowering
+  /// resolves its `Windowing` over this same grouped surface (its partition,
+  /// order, and aggregate arguments reading the group keys and aggregate
+  /// results) and appends it here, taking output slot `width + j`. It is a
+  /// reference so the non-mutating `term` accumulates into it as `slot(of:)`
+  /// does on the plain window path.
+  private final class Registry {
+    var windowings = Array<Windowing>()
+  }
+  private let registry: Registry?
+
+  /// The grouped output width — the key slots plus the aggregate slots — the
+  /// appended window results begin at (windowing `j` at slot `width + j`),
+  /// matching the aggregate node the window node sits above. Zero for an
+  /// ordinary grouped query (no window layer).
+  private let width: Int
+
+  /// The windowings the query computes, each appended as one output slot
+  /// (windowing `j` at slot `width + j`), gathered as the projection and `ORDER
+  /// BY` lower — empty until they have, and for an ordinary grouped query.
+  internal var windowings: Array<Windowing> { registry?.windowings ?? [] }
+
   /// Builds a grouping over `scope` for the `GROUP BY` `columns` (with their
   /// already-lowered base-ordinal `terms`, so a merged column's coalesce term
   /// is matched by term) and the query's distinct `aggregates` (in
   /// first-appearance order — aggregate `j` at grouped slot `columns.count +
   /// j`). The `aggregates` are already deduped by RESOLVED `Aggregation` (see
   /// `group`), so a qualification-equivalent pair is one entry, one slot.
+  ///
+  /// When `windowed`, the surface additionally lowers a window query over the
+  /// aggregate output: a window function `term` meets resolves to an appended
+  /// output slot (`width + j`, past the `grouping.count + aggregates.count`
+  /// grouped slots) rather than faulting, and `windowings` gathers them for the
+  /// window node the caller places above the aggregate.
   internal init(_ scope: Scope, _ grouping: Array<Expression>,
                 _ terms: Array<Term>,
                 _ aggregates: Array<Aggregation>,
                 superset: Array<Term> = [],
-                subquery: Resolution = .unsupported) throws(SQLError) {
+                subquery: Resolution = .unsupported,
+                windowed: Bool = false) throws(SQLError) {
     self.scope = scope
     self.superset = superset
+    self.registry = windowed ? Registry() : nil
+    self.width = windowed ? grouping.count + aggregates.count : 0
     var keys = Dictionary<Int, Int>(minimumCapacity: grouping.count)
     for index in grouping.indices {
       // A bare-column grouping key a local relation binds maps its combined
@@ -208,7 +241,13 @@ internal struct Grouped {
       false
     }
     let plain = if case .column = expression { !merged } else { false }
-    if !plain, !expression.aggregated, !expression.grouping {
+    // A window-bearing expression is skipped too and descends into the switch:
+    // `scope.term` faults on a window (it has no grouped whole-expression key
+    // match), so the `.window` arm routes each window to its appended output
+    // slot and the compound arms recurse, lowering an aggregate/key leaf to its
+    // grouped slot and a window leaf to its appended one.
+    if !plain, !expression.aggregated, !expression.grouping,
+        !expression.windowed {
       let lowered = try scope.term(expression, routines, subquery: subquery)
       if let index = terms.firstIndex(of: lowered) { return .slot(index) }
       // A reference to a column another set groups on but this arm's set omits
@@ -315,12 +354,29 @@ internal struct Grouped {
       // switch), so it never reaches here — an internal inconsistency if it
       // does.
       throw .state("XX000", "unlowered GROUPING")
-    case .window:
-      // A window function is not yet supported anywhere; its resolution faults
-      // the feature diagnostic before this grouped lowering, so it never
-      // reaches here in practice, but the reject is uniform across every
-      // resolution surface.
-      throw .state("0A000", "a window function is not supported")
+    case let .window(function, spec):
+      // A window over grouped output reads the aggregate node's grouped
+      // records: its partition, order, and any aggregate argument lower through
+      // this same grouped surface (a `GROUP BY` key or an aggregate result
+      // slot, a non-grouped column faulting `.grouping` as everywhere), and the
+      // window node above the aggregate appends its value at output slot `width
+      // + j`. A deterministic window shares an already-appended slot; a
+      // stateful or non-deterministic one takes a fresh slot per occurrence, as
+      // the plain window path dedups. Without a registry — an ordinary grouped
+      // query, no window layer — a window has no per-row meaning over a
+      // collapsed group, so it faults, the reject uniform across surfaces.
+      guard let registry else {
+        throw .state("0A000", "a window function is not supported")
+      }
+      let windowing = try Expression.window(function: function, spec: spec)
+          .windowing(self, routines, subquery: subquery)
+      if windowing.deterministic(routines),
+          let index = registry.windowings.firstIndex(of: windowing) {
+        return .slot(width + index)
+      }
+      let index = registry.windowings.count
+      registry.windowings.append(windowing)
+      return .slot(width + index)
     }
   }
 
@@ -541,6 +597,57 @@ internal struct Grouped {
       }
     }
     return resolved
+  }
+}
+
+// MARK: - Grouped window surface
+
+extension Grouped: WindowSurface {
+  /// Lowers a window's `ORDER BY` to grouped-space sort keys, major to minor —
+  /// each key a value expression over the grouped record (an aggregate result
+  /// or a `GROUP BY` key, a non-grouped column faulting `.grouping`). An output
+  /// ordinal names a projected column, meaningless as the window order fixing
+  /// the input row order, so it faults as it does over a plain source.
+  internal func window(order: Order, _ routines: Routines = [:],
+                       subquery: Resolution = .unsupported)
+      throws(SQLError) -> Array<SortKey> {
+    var keys = Array<SortKey>()
+    keys.reserveCapacity(order.keys.count)
+    for key in order.keys {
+      switch key.sort {
+      case .ordinal:
+        throw .state("0A000",
+                     "a window ORDER BY output ordinal is not supported")
+      case let .expression(expression):
+        try keys.append(SortKey(term: resolve(expression, routines,
+                                              subquery: subquery),
+                                ascending: key.ascending, column: nil))
+      }
+    }
+    return keys
+  }
+
+  /// Reconciles a `LEAD`/`LAG` `fallback` default against its `value`'s type
+  /// over grouped output — both may be aggregates, so the type derive runs over
+  /// the base `scope` (which types an aggregate by its result) while the value
+  /// lowering routes through the grouped surface. Mirrors `Scope.reconciled`:
+  /// an explicit NULL default is type-neutral and coerces to the value type,
+  /// while an irreconcilable pair faults, so the run and validate paths agree.
+  internal func reconciled(_ fallback: Expression, with value: Expression,
+                           _ routines: Routines = [:],
+                           subquery: Resolution = .unsupported)
+      throws(SQLError) -> Term {
+    let expected = try scope.derive(value, routines, subquery: subquery)
+    if case .literal(.null) = fallback {
+      let null = try resolve(fallback, routines, subquery: subquery)
+      return .cast(null, expected)
+    }
+    let actual = try scope.derive(fallback, routines, subquery: subquery)
+    guard expected.unified(with: actual) != nil else {
+      throw .operand("a LEAD/LAG default and value have irreconcilable types")
+    }
+    let lowered = try resolve(fallback, routines, subquery: subquery)
+    return expected == actual ? lowered : .cast(lowered, expected)
   }
 }
 

--- a/Sources/SQLEngine/Schema+Derivation.swift
+++ b/Sources/SQLEngine/Schema+Derivation.swift
@@ -1709,9 +1709,13 @@ extension Catalog where Self: ~Escapable {
     // output name (an alias, else a group column's own name) — the surface an
     // `ORDER BY` output name resolves against — then lower the `ORDER BY`,
     // which faults a non-group column, an out-of-range ordinal, or an ambiguous
-    // name.
+    // name. A window in the ORDER BY (`ORDER BY RANK() OVER (…)`) makes this a
+    // window query, so build the windowed surface `group` builds — threading
+    // the same `select.windows` — or `Grouped.order` faults lowering the window
+    // through a surface with no window registry.
     var grouped = try Grouped(scope, grouping, keys, aggregations,
-                              superset: supers, subquery: subquery)
+                              superset: supers, subquery: subquery,
+                              windowed: select.windows)
     let projection = try grouped.terms(select.projection, routines,
                                        subquery: subquery)
     _ = try grouped.order(clause, projection, routines, subquery: subquery)

--- a/Sources/SQLEngine/Scope.swift
+++ b/Sources/SQLEngine/Scope.swift
@@ -2666,6 +2666,144 @@ internal struct Scope {
 
   // MARK: - Aggregate discovery
 
+  /// Validates a `WINDOW` definition expression for well-formedness only —
+  /// every column reference resolves against this scope (a subquery and its
+  /// arity through the full `term`) and an aggregate's operand does too —
+  /// imposing no grouping rule and materialising no aggregate slot. An unused
+  /// definition computes nothing (a referenced one is validated strictly by the
+  /// inlined form in the projection/ORDER BY), so it need only be well-formed;
+  /// this lone check admits both a dead definition naming an ordinary column
+  /// (`ORDER BY sal`, no GROUP BY key) and one naming an aggregate (`ORDER BY
+  /// SUM(sal)`, needing no slot) — neither surface a referenced window resolves
+  /// against (a base scope, a grouped surface) accepts both. An aggregate-free
+  /// subexpression resolves through `term` wholesale; an aggregate node
+  /// recurses into its operand, imposing no grouping there.
+  internal func admit(_ expression: Expression,
+                      _ routines: Routines = [:],
+                      subquery: Resolution = .unsupported)
+      throws(SQLError) {
+    guard expression.aggregated else {
+      _ = try term(expression, routines, subquery: subquery)
+      return
+    }
+    switch expression {
+    case let .aggregate(_, operand, _, filter):
+      // An aggregate's argument is a per-row scalar — resolve it through the
+      // full `term`, not `admit`. `term` faults on any aggregate, so a nested
+      // aggregate (`SUM(SUM(x))`) is rejected exactly as the referenced form
+      // rejects it; admit here would recursively accept the inner one. The
+      // leniency an unused definition earns is confined to the key level (it
+      // may be an aggregate, and a column need not be a GROUP BY key), not
+      // carried into the argument, which stays a strict scalar.
+      if case let .expression(argument) = operand {
+        _ = try term(argument, routines, subquery: subquery)
+      }
+      // The FILTER is a per-row predicate that (ISO) holds no aggregate, so
+      // lower it over the input scope: its columns resolve and an aggregate in
+      // it faults. An unresolved or malformed FILTER in an unused definition
+      // thus still faults rather than being silently dropped.
+      if let filter {
+        _ = try lower(filter, routines, subquery: subquery)
+      }
+    case let .binary(_, lhs, rhs), let .nullif(lhs, rhs):
+      try admit(lhs, routines, subquery: subquery)
+      try admit(rhs, routines, subquery: subquery)
+    case let .case(whens, otherwise):
+      // The `WHEN` guard is a per-row predicate; admit walks it and admits each
+      // expression operand, so a non-aggregate leaf (an unresolved column)
+      // faults while an aggregate operand recurses leniently — a guard valid
+      // only in a grouped context is not rejected, yet its plain columns are
+      // still validated. Each result expression admits as any.
+      for branch in whens {
+        try admit(branch.when, routines, subquery: subquery)
+        try admit(branch.then, routines, subquery: subquery)
+      }
+      if let otherwise {
+        try admit(otherwise, routines, subquery: subquery)
+      }
+    case let .cast(operand, _):
+      try admit(operand, routines, subquery: subquery)
+    case let .coalesce(arguments), let .call(_, arguments),
+         let .grouping(arguments):
+      for argument in arguments {
+        try admit(argument, routines, subquery: subquery)
+      }
+    case .column, .literal, .subquery, .window:
+      _ = try term(expression, routines, subquery: subquery)
+    }
+  }
+
+  /// Admits a predicate from a WINDOW definition's spec — a CASE guard — by
+  /// walking it and admitting each expression operand (see `admit(_:)` over an
+  /// expression): a non-aggregate leaf resolves and faults when unknown, while
+  /// an aggregate operand recurses leniently, so a guard valid only in a
+  /// grouped context is not rejected yet its plain columns are still validated.
+  /// A nested predicate recurses; an EXISTS/quantified subquery is its own
+  /// scope, compiled separately, so only its left operands are admitted here.
+  private func admit(_ predicate: Predicate, _ routines: Routines = [:],
+                     subquery: Resolution = .unsupported) throws(SQLError) {
+    switch predicate {
+    case let .comparison(left, _, right), let .distinct(left, right, _):
+      try admit(left, routines, subquery: subquery)
+      try admit(right, routines, subquery: subquery)
+    case let .bound(left, _, _):
+      try admit(left, routines, subquery: subquery)
+    case let .null(expression, _):
+      try admit(expression, routines, subquery: subquery)
+    case let .membership(operand, values, _):
+      try admit(operand, routines, subquery: subquery)
+      for value in values {
+        try admit(value, routines, subquery: subquery)
+      }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs + rhs {
+        try admit(expression, routines, subquery: subquery)
+      }
+    case let .among(lhs, rows, _):
+      for expression in lhs {
+        try admit(expression, routines, subquery: subquery)
+      }
+      for row in rows {
+        for expression in row {
+          try admit(expression, routines, subquery: subquery)
+        }
+      }
+    case let .within(lhs, _, _), let .quantified(lhs, _, _, _):
+      for expression in lhs {
+        try admit(expression, routines, subquery: subquery)
+      }
+    case let .like(operand, pattern, escape, _):
+      try admit(operand, routines, subquery: subquery)
+      try admit(pattern, routines, subquery: subquery)
+      if let escape {
+        try admit(escape, routines, subquery: subquery)
+      }
+    case let .between(test, lower, upper, _):
+      try admit(test, routines, subquery: subquery)
+      try admit(lower, routines, subquery: subquery)
+      try admit(upper, routines, subquery: subquery)
+    case let .truth(inner, _, _):
+      try admit(inner, routines, subquery: subquery)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      try admit(lhs, routines, subquery: subquery)
+      try admit(rhs, routines, subquery: subquery)
+    case let .not(operand):
+      try admit(operand, routines, subquery: subquery)
+    case .exists:
+      break
+    }
+  }
+
+  /// Admits a LIKE/BETWEEN operand — an expression operand is admitted; a
+  /// run-time `:parameter` carries no column to resolve.
+  private func admit(_ operand: Predicate.Operand,
+                     _ routines: Routines = [:],
+                     subquery: Resolution = .unsupported) throws(SQLError) {
+    if case let .expression(expression) = operand {
+      try admit(expression, routines, subquery: subquery)
+    }
+  }
+
   /// Validates the aggregate sub-expressions of `expression` — an aggregate's
   /// fold runs over every row (in the aggregate node) before a `LIMIT`, so it
   /// is reachable even under a zero-row limit — without validating the

--- a/Sources/SQLEngine/Windowed.swift
+++ b/Sources/SQLEngine/Windowed.swift
@@ -228,13 +228,7 @@ extension Select {
   /// source rows before the projection reads it. A window is allowed only in
   /// the SELECT list and `ORDER BY` (ISO 9075); one elsewhere is rejected.
   internal var windows: Bool {
-    let projected = switch projection {
-    case .all, .columns:
-      false
-    case let .expressions(items):
-      items.contains { $0.expression.windowed }
-    }
-    return projected || orderKeys.contains { $0.windowed }
+    expressions.contains { $0.windowed }
   }
 }
 
@@ -418,6 +412,50 @@ extension Windowing {
   }
 }
 
+// MARK: - Window surface
+
+/// The scalar lowering surface a window's operands resolve against — the base
+/// `Scope` for a window over a plain or joined source, the `Grouped` surface
+/// for a window over grouped output (its partition, order, and aggregate
+/// arguments reading the group keys and aggregate results). Abstracting the
+/// surface keeps `windowing`/`lowered` one shared lowering, so a window over a
+/// scan and a window over grouped output cannot drift — the parity `compile`
+/// gates apply to both by construction.
+internal protocol WindowSurface {
+  /// Lowers a scalar `expression` to a `Term` over this surface's slot space.
+  func resolve(_ expression: Expression, _ routines: Routines,
+               subquery: Resolution) throws(SQLError) -> Term
+
+  /// Lowers a predicate — an aggregate window's `FILTER (WHERE …)` — to a
+  /// `Filter` over this surface's slot space.
+  func lower(_ predicate: Predicate, _ routines: Routines,
+             subquery: Resolution) throws(SQLError) -> Filter
+
+  /// Lowers a window's `ORDER BY` to sort keys over this surface, major to
+  /// minor — each an ISO `<sort key>` value expression, an output ordinal
+  /// meaningless (there is no projected output to name) and rejected.
+  func window(order: Order, _ routines: Routines,
+              subquery: Resolution) throws(SQLError) -> Array<SortKey>
+
+  /// Reconciles a `LEAD`/`LAG` `fallback` default against its `value`'s type,
+  /// lowering the default over this surface and casting it to the value type.
+  func reconciled(_ fallback: Expression, with value: Expression,
+                  _ routines: Routines, subquery: Resolution)
+      throws(SQLError) -> Term
+}
+
+extension Scope: WindowSurface {
+  /// The module-visible entry the window lowering resolves a scalar operand
+  /// through — `term` under the `WindowSurface` name, so the base scope drives
+  /// the shared `windowing`/`lowered` for a window over a plain or joined
+  /// source exactly as the grouped surface does over grouped output.
+  internal func resolve(_ expression: Expression, _ routines: Routines = [:],
+                        subquery: Resolution = .unsupported)
+      throws(SQLError) -> Term {
+    try term(expression, routines, subquery: subquery)
+  }
+}
+
 // MARK: - Window discovery
 
 extension Expression {
@@ -489,12 +527,12 @@ extension Expression {
   }
 
   /// Lowers this AST `.window` expression to a `Windowing`, its `PARTITION BY`
-  /// keys and window `ORDER BY` resolved to combined base-ordinal terms through
-  /// `scope`. `self` is always an `.window` — the window collectors gather only
-  /// those.
-  internal func windowing(_ scope: Scope, _ routines: Routines = [:],
-                          subquery: Resolution = .unsupported)
-      throws(SQLError) -> Windowing {
+  /// keys and window `ORDER BY` resolved to `surface` terms — combined base
+  /// ordinals over the base `Scope`, grouped slots over the `Grouped` surface.
+  /// `self` is always an `.window` — the window collectors gather only those.
+  internal func windowing<Surface: WindowSurface>(
+      _ surface: Surface, _ routines: Routines = [:],
+      subquery: Resolution = .unsupported) throws(SQLError) -> Windowing {
     guard case let .window(function, spec) = self else {
       throw .state("XX000", "expected a window function")
     }
@@ -504,32 +542,85 @@ extension Expression {
     guard spec.base == nil else {
       throw .state("XX000", "an un-inlined window reference")
     }
+    // A window function's operands, its PARTITION/ORDER, and an aggregate
+    // FILTER are scalar (or predicate) positions, so a window nested in any of
+    // them — `LEAD(RANK() OVER (…), 1) OVER (…)`, `… OVER (ORDER BY RANK()
+    // OVER (…))` — is not allowed: the executor computes every windowing from
+    // the source records before any window slot exists, so an operand reading
+    // another window's not-yet-appended slot reads past the record. Reject it
+    // on this shared lowering, before resolving through the surface, so the
+    // grouped surface (whose `term` resolves a window to a registry slot,
+    // unlike the base scope that faults one) rejects a nested window exactly as
+    // the plain path does, run and validate alike.
+    guard !function.windowed,
+          !spec.expressions.contains(where: { $0.windowed }) else {
+      throw .state("0A000",
+                   "a window function is not allowed in a window function")
+    }
     let partition = try spec.partition.map { key throws(SQLError) -> Term in
-      try scope.term(key, routines, subquery: subquery)
+      try surface.resolve(key, routines, subquery: subquery)
     }
     let order: Array<SortKey> = if let clause = spec.order {
-      try scope.window(order: clause, routines, subquery: subquery)
+      try surface.window(order: clause, routines, subquery: subquery)
     } else {
       []
     }
-    let lowered = try function.lowered(scope, routines, subquery: subquery)
+    let lowered = try function.lowered(surface, routines, subquery: subquery)
     return Windowing(function: lowered, partition: partition, order: order,
                      frame: spec.frame)
   }
 }
 
+extension Aggregand {
+  /// Whether this aggregate operand nests a window — `*` never does, an
+  /// expression its own. Mirrors `aggregated`, for the nested-window reject.
+  internal var windowed: Bool {
+    switch self {
+    case .star: false
+    case let .expression(expression): expression.windowed
+    }
+  }
+}
+
 extension WindowFunction {
-  /// Lowers this AST window function to a `Windowing.Function` over `scope` — a
-  /// ranking function maps to its ranking case (nothing to resolve), and an
-  /// aggregate window lowers its operand and `FILTER` to the source slot space,
-  /// reusing the collapsing aggregate's own `aggregation` lowering so the two
-  /// resolve identically (run ≡ validate).
+  /// Whether this window function nests another window in its own operands or
+  /// FILTER — `LEAD(RANK() OVER (…), …)`, `SUM(ROW_NUMBER() OVER ()) OVER ()`.
+  /// A window is not a scalar, so it may not appear in a window's operand (nor,
+  /// checked at the spec, its PARTITION/ORDER); mirrors `aggregated`, which
+  /// carves the same operands for a nested aggregate. `windowing` rejects on it
+  /// before resolving the operand through a surface.
+  internal var windowed: Bool {
+    switch self {
+    case .rowNumber, .rank, .denseRank, .ntile, .percentRank, .cumeDist:
+      false
+    case let .aggregate(_, argument, _, filter):
+      argument.windowed || (filter?.windowed ?? false)
+    case let .lead(value, _, fallback), let .lag(value, _, fallback):
+      value.windowed || (fallback?.windowed ?? false)
+    case let .firstValue(value), let .lastValue(value),
+         let .nthValue(value, _):
+      value.windowed
+    }
+  }
+}
+
+extension WindowFunction {
+  /// Lowers this AST window function to a `Windowing.Function` over `surface` —
+  /// a ranking function maps to its ranking case (nothing to resolve), and an
+  /// aggregate window lowers its operand and `FILTER` to the surface's slot
+  /// space, building the same `Aggregation` the collapsing aggregate does so
+  /// the two resolve identically (run ≡ validate).
   /// Faults a constant argument the parser's grammar rejects but a directly
   /// built AST could still carry — a nonpositive `NTILE` bucket count or
-  /// `NTH_VALUE` position, or a negative `LEAD`/`LAG` offset. `lowered` calls
-  /// this, the point compile lowers every window through, so the executor never
-  /// divides by a zero bucket count, subscripts a row before the partition
-  /// start, or negates `Int.min`, and the run and validate paths fault alike.
+  /// `NTH_VALUE` position, or a negative `LEAD`/`LAG` offset — and an aggregate
+  /// window whose `FILTER` search condition itself contains an aggregate,
+  /// which ISO forbids (a filter is a per-row gate). `lowered` calls this, the
+  /// point compile lowers every window through, so the executor never divides
+  /// by a zero bucket count, subscripts a row before the partition start, or
+  /// negates `Int.min`, and the run and validate paths fault alike — the
+  /// FILTER rule in particular is enforced here, surface-independently, so a
+  /// grouped surface cannot resolve an aggregate FILTER to a grouped slot and
+  /// admit on the run path a shape the type-derive rejects.
   private func check() throws(SQLError) {
     switch self {
     case let .ntile(buckets):
@@ -544,13 +635,16 @@ extension WindowFunction {
       guard offset >= 0 else {
         throw .state("22023", "\(keyword) requires a nonnegative offset")
       }
+    case let .aggregate(_, _, _, filter?) where filter.aggregated:
+      throw .state("42803", "an aggregate is not allowed in a FILTER")
     default:
       break
     }
   }
 
-  internal func lowered(_ scope: Scope, _ routines: Routines = [:],
-                        subquery: Resolution = .unsupported)
+  internal func lowered<Surface: WindowSurface>(
+      _ surface: Surface, _ routines: Routines = [:],
+      subquery: Resolution = .unsupported)
       throws(SQLError) -> Windowing.Function {
     try check()
     switch self {
@@ -561,30 +655,44 @@ extension WindowFunction {
     case .denseRank:
       return .denseRank
     case let .aggregate(function, operand, distinct, filter):
-      let aggregation = try Expression
-          .aggregate(function, of: operand, distinct: distinct, filter: filter)
-          .aggregation(scope, routines, subquery: subquery)
-      return .aggregate(aggregation)
+      // Build the `Aggregation` from the surface exactly as the collapsing
+      // aggregate's `aggregation` does — the argument through `resolve`, the
+      // `FILTER` through `lower` — so a window aggregate over grouped output
+      // (`SUM(SUM(x)) OVER ()`) reads the inner aggregate's grouped slot while
+      // a scan's window aggregate reads its base ordinal, from one lowering.
+      let argument: Term? = switch operand {
+      case .star:
+        nil
+      case let .expression(expression):
+        try surface.resolve(expression, routines, subquery: subquery)
+      }
+      let gate = try filter.map { predicate throws(SQLError) -> Filter in
+        try surface.lower(predicate, routines, subquery: subquery)
+      }
+      return .aggregate(Aggregation(function: function, argument: argument,
+                                    distinct: distinct, filter: gate))
     case let .lead(value, offset, fallback):
-      return try .lead(scope.term(value, routines, subquery: subquery),
+      return try .lead(surface.resolve(value, routines, subquery: subquery),
                        offset: offset,
                        default: fallback.map { expression throws(SQLError) in
-                         try scope.reconciled(expression, with: value, routines,
-                                              subquery: subquery)
+                         try surface.reconciled(expression, with: value,
+                                                routines, subquery: subquery)
                        })
     case let .lag(value, offset, fallback):
-      return try .lag(scope.term(value, routines, subquery: subquery),
+      return try .lag(surface.resolve(value, routines, subquery: subquery),
                       offset: offset,
                       default: fallback.map { expression throws(SQLError) in
-                        try scope.reconciled(expression, with: value, routines,
-                                             subquery: subquery)
+                        try surface.reconciled(expression, with: value,
+                                               routines, subquery: subquery)
                       })
     case let .firstValue(value):
-      return try .firstValue(scope.term(value, routines, subquery: subquery))
+      return try .firstValue(surface.resolve(value, routines,
+                                             subquery: subquery))
     case let .lastValue(value):
-      return try .lastValue(scope.term(value, routines, subquery: subquery))
+      return try .lastValue(surface.resolve(value, routines,
+                                            subquery: subquery))
     case let .nthValue(value, position):
-      return try .nthValue(scope.term(value, routines, subquery: subquery),
+      return try .nthValue(surface.resolve(value, routines, subquery: subquery),
                            position)
     case let .ntile(buckets):
       return .ntile(buckets)

--- a/Tests/SQLTests/Queries/AggregateTests.swift
+++ b/Tests/SQLTests/Queries/AggregateTests.swift
@@ -80,6 +80,17 @@ struct AggregateTests {
         """, yields: [[1, 0, nil, nil, nil, nil]])
   }
 
+  @Test func `a bare aggregate reachable only from ORDER BY aggregates`()
+      throws {
+    // No GROUP BY and no projected aggregate — the aggregate that makes this a
+    // whole-result aggregation appears only in the ORDER BY, so the routing
+    // must scan the ORDER BY as the window routing does, or the sort lowers
+    // `SUM(Amount)` through the ungrouped scope and faults. One group, one row:
+    // the literal projection ordered by the whole-table SUM.
+    try sales().expect("SELECT 1 FROM Sales ORDER BY SUM(Amount)",
+                       yields: [[1]])
+  }
+
   @Test func `GROUP BY one column aggregates each group`() throws {
     try sales().expect("""
         SELECT Dept, COUNT(*), SUM(Amount) FROM Sales

--- a/Tests/SQLTests/Queries/ExplainTests.swift
+++ b/Tests/SQLTests/Queries/ExplainTests.swift
@@ -613,6 +613,8 @@ private final class Counter: @unchecked Sendable {
       "SELECT LEAD(Age, 2, 0) OVER (ORDER BY Id) FROM People",
       "SELECT COUNT(*) FROM People",
       "SELECT COUNT(DISTINCT Age) FROM People",
+      "SELECT Age, RANK() OVER (ORDER BY COUNT(*)) "
+        + "FROM People GROUP BY Age",
       "SELECT Name FROM Parent WHERE EXISTS "
         + "(SELECT 1 FROM Child WHERE Child.Pid = Parent.Id)",
       "SELECT Name FROM Parent WHERE NOT EXISTS "
@@ -642,6 +644,7 @@ private final class Counter: @unchecked Sendable {
       "SELECT Age FROM People WHERE Id = 2",
       "SELECT COUNT(*) FROM People",
       "SELECT DISTINCT Age FROM People",
+      "SELECT Age, RANK() OVER (ORDER BY COUNT(*)) FROM People GROUP BY Age",
       "SELECT Missing FROM People",
       "SELECT Age FROM People WHERE Name = 1",
       "SELECT Id FROM People UNION SELECT Id FROM Parent",

--- a/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -1053,6 +1053,31 @@ struct WindowFunctionRejectionTests {
                "a window function is allowed only in SELECT and ORDER BY"))
   }
 
+  @Test func `a window nested in a window operand is rejected`() throws {
+    // A window is not a scalar, so it may not be another window's operand. The
+    // grouped surface made this resolvable (its `term` has a window registry),
+    // so `windowing` rejects it uniformly, before resolving, on every surface.
+    try rejects(
+        "SELECT LEAD(RANK() OVER (ORDER BY x), 1) OVER (ORDER BY x) FROM T",
+        .state("0A000",
+               "a window function is not allowed in a window function"))
+  }
+
+  @Test func `a window nested in a window ORDER BY is rejected`() throws {
+    try rejects(
+        "SELECT RANK() OVER (ORDER BY RANK() OVER (ORDER BY x)) FROM T",
+        .state("0A000",
+               "a window function is not allowed in a window function"))
+  }
+
+  @Test func `a window nested in an aggregate window argument is rejected`()
+      throws {
+    try rejects(
+        "SELECT SUM(ROW_NUMBER() OVER ()) OVER () FROM T",
+        .state("0A000",
+               "a window function is not allowed in a window function"))
+  }
+
   @Test func `a window ORDER BY output ordinal is rejected`() throws {
     try rejects(
         "SELECT ROW_NUMBER() OVER (ORDER BY 1) FROM T",
@@ -1206,11 +1231,137 @@ struct WindowFunctionRejectionTests {
 
   @Test func `an unused definition is validated in an aggregate query`()
       throws {
-    // An aggregate query routes through the grouped path ahead of the window and
-    // ordinary paths' checks, so its `WINDOW` clause is validated there too — an
-    // undefined base still faults rather than the query grouping regardless.
+    // An aggregate query with no window used validates its `WINDOW` clause on
+    // the base scope (in `front`), like any query — an undefined base still
+    // faults rather than the query grouping regardless.
     try rejects("SELECT SUM(x) FROM T WINDOW bad AS (missing)",
                 .state("42704", "window \"missing\" is not defined"))
+  }
+
+  @Test func `an unused valid definition runs in an aggregate query`() throws {
+    // The one aggregate makes this a whole-result aggregation with no window
+    // used, so the unused `WINDOW w` validates on the input scope — `x` is an
+    // ordinary column there, NOT a non-GROUP BY column faulting `.grouping`, as
+    // it would were the definition (wrongly) validated on the grouped surface
+    // where no window ever computes. The query runs, counting the two rows.
+    try fixture().expect("SELECT COUNT(*) FROM T WINDOW w AS (ORDER BY x)",
+                         yields: [[2]])
+    #expect(try fixture().columns(
+        of: parse(query: "SELECT COUNT(*) FROM T WINDOW w AS (ORDER BY x)"),
+        validate: true).count == 1)
+  }
+
+  @Test func `an unused bad-column definition faults in an aggregate query`()
+      throws {
+    // The base-scope validation still catches an unresolvable column in an
+    // unused definition of an aggregate query — it is not silently accepted
+    // because no window references it.
+    try rejects("SELECT COUNT(*) FROM T WINDOW w AS (ORDER BY nonesuch)",
+                .column("nonesuch"))
+  }
+
+  @Test func `an unused definition may name an aggregate`() throws {
+    // A dead definition is validated for well-formedness only, so an aggregate
+    // in its spec is admitted (its argument resolves) with no grouped slot to
+    // materialise — the one check that fits both an ordinary column and an
+    // aggregate, since a used definition validates strictly by its inlined
+    // form. It holds whether the query aggregates (a whole-result COUNT) …
+    try fixture().expect("SELECT COUNT(*) FROM T WINDOW w AS (ORDER BY SUM(x))",
+                         yields: [[2]])
+    // … or not (a plain projection): the aggregate in the unused spec neither
+    // makes the query aggregate nor faults.
+    try fixture().expect("SELECT x FROM T WINDOW w AS (ORDER BY SUM(x))",
+                         yields: [[1], [2]])
+    for sql in ["SELECT COUNT(*) FROM T WINDOW w AS (ORDER BY SUM(x))",
+                "SELECT x FROM T WINDOW w AS (ORDER BY SUM(x))"] {
+      #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                  .count == 1)
+    }
+  }
+
+  @Test func `an unused aggregate definition over a bad column faults`()
+      throws {
+    // Well-formedness still resolves the aggregate's argument, so an
+    // unresolvable column inside a dead definition's aggregate faults.
+    try rejects("SELECT x FROM T WINDOW w AS (ORDER BY SUM(nonesuch))",
+                .column("nonesuch"))
+  }
+
+  @Test func `an unused definition validates an aggregate FILTER`() throws {
+    // The FILTER of an aggregate in a dead definition is a per-row predicate,
+    // so an unresolved column in it faults rather than being silently dropped …
+    try rejects(
+        "SELECT x FROM T WINDOW w AS " +
+        "(ORDER BY SUM(x) FILTER (WHERE nonesuch > 0))",
+        .column("nonesuch"))
+    // … while a resolvable FILTER runs.
+    try fixture().expect(
+        "SELECT x FROM T WINDOW w AS (ORDER BY SUM(x) FILTER (WHERE x > 0))",
+        yields: [[1], [2]])
+  }
+
+  @Test func `an unused definition validates a CASE guard`() throws {
+    // A CASE guard in a dead definition's spec is a per-row predicate too — an
+    // aggregate-free guard's unresolved column faults …
+    try rejects(
+        "SELECT x FROM T WINDOW w AS " +
+        "(ORDER BY CASE WHEN nonesuch > 0 THEN SUM(x) END)",
+        .column("nonesuch"))
+    // … while a guard that itself aggregates (valid only in a grouped context)
+    // is not spuriously rejected — the aggregate operand recurses leniently.
+    try fixture().expect(
+        "SELECT x FROM T WINDOW w AS " +
+        "(ORDER BY CASE WHEN SUM(x) > 0 THEN x END)",
+        yields: [[1], [2]])
+    // … yet a non-aggregate leaf beside the aggregate in such a guard is still
+    // validated: the walk admits each operand, so `nonesuch` faults rather than
+    // the whole aggregate-bearing guard being skipped.
+    try rejects(
+        "SELECT x FROM T WINDOW w AS " +
+        "(ORDER BY CASE WHEN SUM(x) > nonesuch THEN x END)",
+        .column("nonesuch"))
+  }
+
+  @Test func `an unused definition rejects a nested aggregate`() throws {
+    // An aggregate's argument is a scalar, so it may not contain an aggregate.
+    // An unused definition's argument is resolved through the same strict
+    // `term` a referenced one is, so the nesting faults rather than the inner
+    // aggregate being recursively admitted.
+    try rejects("SELECT x FROM T WINDOW w AS (ORDER BY SUM(SUM(x)))",
+                .state("42803", "an aggregate is not allowed here"))
+  }
+
+  @Test func `an unused definition faults a context-free error as a used one`()
+      throws {
+    // The contract: an unused definition is validated for every context-free
+    // error a referenced one is — a nested aggregate, an unresolved column in
+    // an aggregate argument, FILTER, or CASE guard, a window in an argument —
+    // differing only in the grouping rule a dead definition is spared. A parity
+    // guard over the class: each malformed spec faults identically whether the
+    // window is referenced (`OVER w`) or left unused. It catches a future
+    // divergence mechanically rather than one reviewed case at a time.
+    func outcome(_ sql: String) throws -> SQLError? {
+      do {
+        _ = try fixture().columns(of: parse(query: sql), validate: true)
+        return nil
+      } catch let error as SQLError {
+        return error
+      }
+    }
+    let specs = [
+      "ORDER BY SUM(SUM(x))",
+      "ORDER BY SUM(x + COUNT(x))",
+      "ORDER BY SUM(nonesuch)",
+      "ORDER BY SUM(x) FILTER (WHERE nonesuch > 0)",
+      "ORDER BY CASE WHEN SUM(x) > nonesuch THEN x END",
+      "ORDER BY SUM(ROW_NUMBER() OVER ())",
+    ]
+    for spec in specs {
+      let referenced =
+          try outcome("SELECT ROW_NUMBER() OVER w FROM T WINDOW w AS (\(spec))")
+      let unused = try outcome("SELECT x FROM T WINDOW w AS (\(spec))")
+      #expect(referenced == unused, "\(spec)")
+    }
   }
 
   @Test func `an unused definition resolves against the whole join scope`()
@@ -1806,13 +1957,324 @@ struct WindowOverJoinTests {
             "a window function is allowed only in SELECT and ORDER BY"))
   }
 
-  @Test func `a window in an aggregate query over a join is still rejected`()
-      throws {
-    // A window beside an aggregate routes to the grouped path (which does not
-    // yet support windows) whether or not the query joins — the join does not
-    // change the routing.
+  @Test func `a window beside an aggregate over a join is supported`() throws {
+    // A window beside an aggregate over a join computes over the grouped rows:
+    // the whole-table `SUM(U.v)` is 800 (id 4 dropped by the inner join) and
+    // the single grouped row's `ROW_NUMBER() OVER ()` is 1.
     try fixture().expect(
         "SELECT SUM(U.v), ROW_NUMBER() OVER () FROM T JOIN U ON T.id = U.id",
-        fails: .state("0A000", "a window function is not supported"))
+        yields: [[800, 1]])
+  }
+}
+
+@Suite("Window functions over grouped output")
+struct WindowOverGroupedTests {
+  // Groups: dept 1 sums 300 (count 2), dept 2 sums 600 (count 2), dept 3 sums
+  // 500 (count 1). The aggregate node yields one row per group in key first-
+  // appearance order (dept 1, 2, 3), the order the window then reads.
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("Emp", ["dept": .integer, "sal": .integer]) {
+        Row(1, 100)
+        Row(1, 200)
+        Row(2, 300)
+        Row(2, 300)
+        Row(3, 500)
+      }
+    }
+  }
+
+  @Test func `RANK orders the groups by an aggregate`() throws {
+    // The window ranks the grouped rows by `SUM(sal)` ascending (300, 500, 600
+    // → ranks 1, 2, 3), each group's row carrying its rank; the output stays in
+    // group order (dept 1, 2, 3).
+    try fixture().expect(
+        "SELECT dept, SUM(sal), RANK() OVER (ORDER BY SUM(sal)) " +
+        "FROM Emp GROUP BY dept",
+        yields: [[1, 300, 1], [2, 600, 3], [3, 500, 2]])
+  }
+
+  @Test func `a grand-total aggregate window sums the group totals`() throws {
+    // `SUM(SUM(sal)) OVER ()` folds the outer aggregate over every grouped
+    // row — the group totals summed, 300 + 600 + 500 = 1400 — over each row.
+    try fixture().expect(
+        "SELECT dept, SUM(sal), SUM(SUM(sal)) OVER () FROM Emp GROUP BY dept",
+        yields: [[1, 300, 1400], [2, 600, 1400], [3, 500, 1400]])
+  }
+
+  @Test func `ROW_NUMBER orders the groups by a COUNT`() throws {
+    // Ordering the grouped rows by `COUNT(*)` ascending, dept 3 (count 1) is
+    // first; dept 1 and 2 tie on count 2 and break by group order, so the
+    // ROW_NUMBER is 1 for dept 3, 2 for dept 1, 3 for dept 2.
+    try fixture().expect(
+        "SELECT dept, COUNT(*), ROW_NUMBER() OVER (ORDER BY COUNT(*)) " +
+        "FROM Emp GROUP BY dept",
+        yields: [[1, 2, 2], [2, 2, 3], [3, 1, 1]])
+  }
+
+  @Test func `a window orders by a group key`() throws {
+    // A bare window over a `GROUP BY` key ranks the groups by that key — no
+    // aggregate involved, the key read from its grouped slot.
+    try fixture().expect(
+        "SELECT dept, RANK() OVER (ORDER BY dept) FROM Emp GROUP BY dept",
+        yields: [[1, 1], [2, 2], [3, 3]])
+  }
+
+  @Test func `a window partitions by a group key`() throws {
+    // Partitioning by the `GROUP BY` key makes each group its own partition, so
+    // the whole-partition `COUNT(*)` is 1 for every group.
+    try fixture().expect(
+        "SELECT dept, COUNT(*) OVER (PARTITION BY dept) " +
+        "FROM Emp GROUP BY dept",
+        yields: [[1, 1], [2, 1], [3, 1]])
+  }
+
+  @Test func `HAVING filters the groups below the window`() throws {
+    // HAVING drops dept 1 (300) before the window computes, so the surviving
+    // dept 3 (500) and dept 2 (600) rank 1 and 2 — not 2 and 3, which they
+    // would were the window computed over all three groups.
+    try fixture().expect(
+        "SELECT dept, SUM(sal), RANK() OVER (ORDER BY SUM(sal)) " +
+        "FROM Emp GROUP BY dept HAVING SUM(sal) >= 500",
+        yields: [[2, 600, 2], [3, 500, 1]])
+  }
+
+  @Test func `the query ORDER BY sorts on the window`() throws {
+    // The query orders by the window rank descending (aliased `r`), so the
+    // output comes out dept 2 (rank 3), dept 3 (rank 2), dept 1 (rank 1).
+    try fixture().expect(
+        "SELECT dept, SUM(sal), RANK() OVER (ORDER BY SUM(sal)) AS r " +
+        "FROM Emp GROUP BY dept ORDER BY r DESC",
+        yields: [[2, 600, 3], [3, 500, 2], [1, 300, 1]])
+  }
+
+  @Test func `DISTINCT dedups the windowed rows`() throws {
+    // `COUNT(*) OVER ()` counts the three grouped rows, so every row carries 3;
+    // DISTINCT then collapses them to a single row.
+    try fixture().expect(
+        "SELECT DISTINCT COUNT(*) OVER () FROM Emp GROUP BY dept",
+        yields: [[3]])
+  }
+
+  @Test func `two windows over grouped output compute independently`() throws {
+    // A ranking and a grand-total aggregate window share the grouped source,
+    // each appending its own slot: rank by `SUM(sal)`, and the total 1400.
+    try fixture().expect(
+        "SELECT dept, RANK() OVER (ORDER BY SUM(sal)), SUM(SUM(sal)) OVER () " +
+        "FROM Emp GROUP BY dept",
+        yields: [[1, 1, 1400], [2, 3, 1400], [3, 2, 1400]])
+  }
+
+  @Test func `a window nests in an arithmetic compound`() throws {
+    // `RANK() OVER (…) + 1` lowers the window leaf to its appended slot and the
+    // literal to a constant, so each group's rank is offset by one.
+    try fixture().expect(
+        "SELECT dept, RANK() OVER (ORDER BY SUM(sal)) + 1 " +
+        "FROM Emp GROUP BY dept",
+        yields: [[1, 2], [2, 4], [3, 3]])
+  }
+
+  @Test func `a running frame accumulates over the groups`() throws {
+    // A `ROWS UNBOUNDED PRECEDING → CURRENT ROW` frame over the group totals,
+    // ordered by dept, runs the cumulative total 300, 900, 1400.
+    try fixture().expect(
+        """
+        SELECT dept, SUM(SUM(sal)) OVER (ORDER BY dept
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        FROM Emp GROUP BY dept
+        """,
+        yields: [[1, 300], [2, 900], [3, 1400]])
+  }
+
+  @Test func `LEAD reads the next group's aggregate with a default`() throws {
+    // `LEAD(SUM(sal), 1, 0)` over the groups ordered by dept reads the next
+    // group's total (300 → 600, 600 → 500) and the default 0 past the last
+    // group — the value and default both aggregates the group node folds, the
+    // default reconciled to the value's integer type.
+    try fixture().expect(
+        "SELECT dept, SUM(sal), LEAD(SUM(sal), 1, 0) OVER (ORDER BY dept) " +
+        "FROM Emp GROUP BY dept",
+        yields: [[1, 300, 600], [2, 600, 500], [3, 500, 0]])
+  }
+
+  @Test func `a window over a whole-table aggregate is one row`() throws {
+    // With no `GROUP BY` the aggregate is the single whole-table group, so the
+    // window computes over one row: the grand `SUM(sal)` 1400, ranked 1.
+    try fixture().expect(
+        "SELECT SUM(sal), RANK() OVER (ORDER BY SUM(sal)) FROM Emp",
+        yields: [[1400, 1]])
+  }
+
+  @Test func `run and validate agree on a window over grouped output`()
+      throws {
+    // The schema path types the same three-column shape the run produces — the
+    // parity `compile` gates, no grouped-specific rejection surviving.
+    let sql = "SELECT dept, SUM(sal), RANK() OVER (ORDER BY SUM(sal)) " +
+              "FROM Emp GROUP BY dept"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 3)
+    try fixture().expect(sql,
+                         yields: [[1, 300, 1], [2, 600, 3], [3, 500, 2]])
+  }
+
+  @Test func `a non-grouped column in a window operand is rejected`() throws {
+    // A window `ORDER BY` naming a column that is neither a `GROUP BY` key nor
+    // aggregated has no grouped value — the standard grouping rule rejects it,
+    // on both the run and validate paths.
+    let sql = "SELECT dept, RANK() OVER (ORDER BY sal) FROM Emp GROUP BY dept"
+    try fixture().expect(sql, fails: .grouping("sal"))
+    #expect(throws: SQLError.grouping("sal")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a window with GROUPING SETS is deferred`() throws {
+    // A window over a `GROUPING SETS` arm would see only that arm's grouped
+    // rows, not the union ISO prescribes, so it is deferred — faulting the
+    // feature diagnostic on both the run and validate paths.
+    let sql = "SELECT dept, SUM(sal), RANK() OVER (ORDER BY SUM(sal)) " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    let fault = SQLError.state(
+        "0A000", "a window function with GROUPING SETS is not yet supported")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `an aggregate in a grouped window FILTER is rejected`() throws {
+    // A FILTER is a per-row gate, so it may not itself contain an aggregate —
+    // the rule a collapsing aggregate's FILTER obeys. The grouped surface could
+    // otherwise resolve the inner `SUM(sal)` to a grouped slot and lower it, so
+    // the shared window `check` enforces the rule surface-independently and the
+    // run and validate paths reject alike, rather than run admitting a shape
+    // the type-derive faults.
+    let sql = "SELECT SUM(SUM(sal)) FILTER (WHERE SUM(sal) > 0) OVER () " +
+              "FROM Emp GROUP BY dept"
+    let fault = SQLError.state("42803",
+                               "an aggregate is not allowed in a FILTER")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a window in a HAVING is rejected`() throws {
+    // A window is allowed only in the SELECT list and `ORDER BY`; one in a
+    // HAVING has no per-row meaning there, rejected ahead of the grouped
+    // routing.
+    let sql = "SELECT dept FROM Emp GROUP BY dept " +
+              "HAVING RANK() OVER (ORDER BY dept) > 1"
+    let fault = SQLError.state(
+        "0A000", "a window function is allowed only in SELECT and ORDER BY")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a whole-table aggregate window routes through group`() throws {
+    // No GROUP BY and no other projected aggregate, so the aggregate that makes
+    // this a grouped query hides in the window's own operand — `SUM(sal)` is
+    // 1400 over the whole-table group, and the outer `SUM(…) OVER ()` sums that
+    // lone row. The routing must reach the grouped path, not the plain window
+    // path (which would fault 42803 lowering the inner aggregate).
+    let sql = "SELECT SUM(SUM(sal)) OVER () FROM Emp"
+    try fixture().expect(sql, yields: [[1400]])
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
+  }
+
+  @Test func `a positional window over a whole-table aggregate routes`()
+      throws {
+    // Same routing gate for a positional window whose operand is the aggregate:
+    // `FIRST_VALUE(SUM(sal)) OVER ()` reads the lone whole-table group's 1400.
+    try fixture().expect(
+        "SELECT FIRST_VALUE(SUM(sal)) OVER () FROM Emp",
+        yields: [[1400]])
+  }
+
+  @Test func `a named grouped window resolves an aggregate spec`() throws {
+    // `WINDOW w AS (ORDER BY SUM(sal))` names an aggregate, which `front`
+    // cannot resolve on the base scope; the grouped surface revalidates it, the
+    // named form matches the inline `RANK() OVER (ORDER BY SUM(sal))`. Ranks by
+    // SUM(sal) ascending (300, 500, 600 → dept 1, 3, 2), output in group order.
+    try fixture().expect(
+        "SELECT dept, RANK() OVER w FROM Emp GROUP BY dept " +
+        "WINDOW w AS (ORDER BY SUM(sal))",
+        yields: [[1, 1], [2, 3], [3, 2]])
+  }
+
+  @Test func `an unused definition runs in a grouped query`() throws {
+    // The definition's ORDER BY names a non-grouped column, but no window is
+    // computed (nothing references `w`), so it validates on the input scope —
+    // `sal` an ordinary column there — not the grouped surface. The grouped
+    // query runs, counting each department (contrast the used window below).
+    let sql = "SELECT dept, COUNT(*) FROM Emp GROUP BY dept " +
+              "WINDOW w AS (ORDER BY sal)"
+    try fixture().expect(sql, yields: [[1, 2], [2, 2], [3, 1]])
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+  }
+
+  @Test func `an unused aggregate definition beside a used window runs`()
+      throws {
+    // A window is used (`ROW_NUMBER`), so the query validates every definition;
+    // the unused `w` names an aggregate whose grouped slot nothing computes.
+    // Its well-formedness (`SUM(sal)`'s argument resolves) is confirmed without
+    // requiring a collected grouped slot, so the query runs — the row number
+    // over the three grouped departments — rather than faulting the internal
+    // uncollected-aggregate error.
+    let sql = "SELECT dept, ROW_NUMBER() OVER () FROM Emp GROUP BY dept " +
+              "WINDOW w AS (ORDER BY SUM(sal))"
+    try fixture().expect(sql, yields: [[1, 1], [2, 2], [3, 3]])
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+  }
+
+  @Test func `a used grouped window on a non-grouped column is rejected`()
+      throws {
+    // The window is used, so its definition validates on the grouped surface,
+    // where `sal` — neither a GROUP BY key nor aggregated — faults `.grouping`
+    // on both paths. The unused form above validates on the input scope; a used
+    // window imposes the grouped context its rows are computed over.
+    let sql = "SELECT dept, RANK() OVER w FROM Emp GROUP BY dept " +
+              "WINDOW w AS (ORDER BY sal)"
+    try fixture().expect(sql, fails: .grouping("sal"))
+    #expect(throws: SQLError.grouping("sal")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a window nested in a grouped window operand is rejected`()
+      throws {
+    // With the grouped surface's window registry, `LEAD`'s value operand could
+    // With the grouped surface's window registry, `LEAD`'s value operand could
+    // resolve the inner `RANK` to an appended slot the executor has not filled
+    // — it computes every windowing from the grouped records first, so the
+    // outer would read past the record. The nested window is rejected before
+    // lowering, on the run and validate paths alike.
+    let sql = "SELECT LEAD(RANK() OVER (ORDER BY SUM(sal)), 1) " +
+              "OVER (ORDER BY dept) FROM Emp GROUP BY dept"
+    let fault = SQLError.state(
+        "0A000", "a window function is not allowed in a window function")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `an aggregate window reachable only from ORDER BY routes`()
+      throws {
+    // The one aggregate hides in a window that appears solely in the query
+    // ORDER BY, never the projection — so the aggregate routing must scan the
+    // ORDER BY too (the `expressions` set `windows` already scanned), or the
+    // query takes the plain window path and lowers the inner `SUM(sal)` through
+    // the base scope, faulting 42803. Over the lone whole-table group the
+    // window ranks one row, ordering the literal projection trivially.
+    let sql = "SELECT 1 FROM Emp ORDER BY RANK() OVER (ORDER BY SUM(sal))"
+    try fixture().expect(sql, yields: [[1]])
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
   }
 }


### PR DESCRIPTION
A query with both a GROUP BY (or an aggregate) and a window function routed to the grouped path, which rejected any window at Grouped.term with 0A000 "a window function is not supported". So `SELECT dept, SUM(sal), RANK() OVER (ORDER BY SUM(sal)) … GROUP BY dept`, `SUM(SUM(sal)) OVER ()`, and `ROW_NUMBER() OVER (PARTITION BY dept ORDER BY COUNT(*))` were all unplannable, though the window node is source- agnostic — the interpreter runs a `window` node over whatever records its source yields, so the restriction was a compile-side gap, as the window- over-join gap was.

Mirror the window-over-join fix. Abstract the window-operand lowering behind a `WindowSurface` protocol (resolve a scalar, lower a predicate, lower a window ORDER BY, reconcile a LEAD/LAG default) and make `Expression.windowing`/`WindowFunction.lowered` generic over it. The base `Scope` conforms (a window over a scan or a join lowers exactly as before, one shared path), and `Grouped` conforms — its partition, window ORDER BY, and aggregate arguments lower to grouped slots (a group key or an aggregate result), a non-grouped column faulting `.grouping` as everywhere. A windowed `Grouped` carries a window registry and appends each windowing at an output slot past the grouped width, its `.window` term arm resolving a window to that slot and its existing compound recursion carrying a window nested in arithmetic or a CASE.

`group` then places a `Plan.window(windowings, aggregate)` node above the aggregate — the HAVING filtering groups below it, so the window sees the surviving groups (ISO orders HAVING before the windows) — and shapes the projection and ORDER BY, lowered over the widened space, above it. The aggregate collector now descends a window function's own operands (an aggregate window's argument and FILTER, a positional function's value and default), so the inner aggregate of `SUM(SUM(sal)) OVER ()` is collected and folded by the group node even when it is projected nowhere else; the collector is shared by the run and the schema type-derive, so both agree.

`compile` is the parity gate `columns(of:)` runs first, so admitting the shape here admits it on the run and validate paths at once. Supported: ranking, aggregate (default and explicit frames), distribution, and positional windows over the grouped rows; a window over a group key or an aggregate; a window nested in a compound; DISTINCT, HAVING, and an outer ORDER BY on a window. Deferred, faulting 0A000 on both paths: a window over a GROUPING SETS arm (its window would see only that arm's rows, not the union). A window in a WHERE/HAVING/ON stays rejected (allowed only in SELECT and ORDER BY), and a non-grouped column in a window operand faults `.grouping`.

Adds a suite covering each supported shape, the two deferred/rejected ones with run/validate parity, and extends the EXPLAIN convergence guards (distinctness and describe-agrees-with-plan) with a window-over-grouped query.