### PR TITLE
SQLQuery: a LINQ-like composable query builder over the engine AST

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let _ =
             products: [
               .executable(name: "winmd-inspect", targets: ["winmd-inspect"]),
               .library(name: "SQLEngine", targets: ["SQLEngine"]),
+              .library(name: "SQLQuery", targets: ["SQLQuery"]),
               .library(name: "SQLStandard", targets: ["SQLStandard"]),
               .library(name: "WinMDSynthesis", targets: ["WinMDSynthesis"]),
               .library(name: "SQLEngineWinMD", targets: ["SQLEngineWinMD"]),
@@ -42,6 +43,16 @@ let _ =
                       swiftSettings: [
                         .enableExperimentalFeature("Lifetimes"),
                       ]),
+              .target(name: "SQLQuery", dependencies: ["SQLEngine"],
+                      swiftSettings: [
+                        .enableExperimentalFeature("Lifetimes"),
+                      ]),
+              .testTarget(name: "SQLQueryTests",
+                          dependencies: ["SQLEngine", "SQLQuery",
+                                         "SQLStandard", "SQLTestSupport"],
+                          swiftSettings: [
+                            .enableExperimentalFeature("Lifetimes"),
+                          ]),
               .target(name: "SQLTestSupport",
                       dependencies: ["SQLEngine", "SQLStandard"],
                       swiftSettings: [

--- a/Sources/SQLEngine/Aggregation.swift
+++ b/Sources/SQLEngine/Aggregation.swift
@@ -14,7 +14,7 @@ extension Select {
   /// BY (`ORDER BY SUM(sal)`, or a window `RANK() OVER (ORDER BY SUM(sal))`)
   /// aggregates too — the same `expressions` set `windows` scans, so the two
   /// routings stay in step rather than one forgetting the ORDER BY.
-  internal var aggregates: Bool {
+  public var aggregates: Bool {
     let grouped = switch grouping {
     case let .keys(keys): !keys.isEmpty
     // A `GROUPING SETS (…)` (or one expanded arm) always aggregates — even

--- a/Sources/SQLQuery/Aggregate.swift
+++ b/Sources/SQLQuery/Aggregate.swift
@@ -1,0 +1,51 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SQLEngine
+
+// Aggregate and scalar-function term builders — the projection-side vocabulary.
+// `count()`, `sum(_:)`, `min(_:)`, `max(_:)`, `avg(_:)` build the engine's
+// `Expression.aggregate` node (the engine already supports GROUP BY and these
+// aggregates); `call(_:_:)` builds a scalar-function `Expression.call` so a
+// projection or predicate can name a registered routine.
+
+extension Term {
+  /// `f(arguments)` — a call to the registered scalar function `name` over its
+  /// argument terms, each lifted through `TermConvertible`. The function must
+  /// resolve in the `Routines` passed to the run — an ISO built-in (`UPPER`,
+  /// `SUBSTRING`, …) under `Routines.standard`, or a caller-registered one.
+  public static func call(_ name: String,
+                          _ arguments: any TermConvertible...) -> Term {
+    Term(.call(name: name, arguments: arguments.map(\.term.expression)))
+  }
+}
+
+/// `COUNT(*)` — the number of rows in the group.
+public func count() -> Term {
+  Term(.aggregate(.count, of: .star))
+}
+
+/// `COUNT(operand)` — the number of non-NULL values of `operand` in the group.
+public func count(_ operand: some TermConvertible) -> Term {
+  Term(.aggregate(.count, of: .expression(operand.term.expression)))
+}
+
+/// `SUM(operand)` — the total of the non-NULL numeric values in the group.
+public func sum(_ operand: some TermConvertible) -> Term {
+  Term(.aggregate(.sum, of: .expression(operand.term.expression)))
+}
+
+/// `MIN(operand)` — the least non-NULL value in the group.
+public func min(_ operand: some TermConvertible) -> Term {
+  Term(.aggregate(.min, of: .expression(operand.term.expression)))
+}
+
+/// `MAX(operand)` — the greatest non-NULL value in the group.
+public func max(_ operand: some TermConvertible) -> Term {
+  Term(.aggregate(.max, of: .expression(operand.term.expression)))
+}
+
+/// `AVG(operand)` — the average of the non-NULL numeric values in the group.
+public func avg(_ operand: some TermConvertible) -> Term {
+  Term(.aggregate(.avg, of: .expression(operand.term.expression)))
+}

--- a/Sources/SQLQuery/Filter.swift
+++ b/Sources/SQLQuery/Filter.swift
@@ -1,0 +1,121 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+public import SQLEngine
+
+// The predicate layer: a `Filter` — a proxy over a `Predicate` — and the
+// operator overloads that build one. `column("x") == 3` yields a `Filter`, and
+// `&&`/`||`/`!` combine filters into the engine's `and`/`or`/`not` nodes; the
+// `WHERE`, `ON`, and `HAVING` clauses each take a `Filter` and lower its
+// `predicate`.
+
+/// A predicate proxy — a wrapper over the engine's `Predicate` the comparison
+/// and logical operators build, so a fluent `.where(column("x") == 3 && …)`
+/// reads as the condition it lowers to.
+public struct Filter: Hashable, Sendable {
+  /// The engine predicate this filter lowers to.
+  public let predicate: Predicate
+
+  public init(_ predicate: Predicate) {
+    self.predicate = predicate
+  }
+}
+
+// MARK: - Comparisons
+
+extension Term {
+  /// `self <op> other` as a comparison `Filter`, lifting a bare literal operand
+  /// through `TermConvertible` so `column("x") == 3` needs no `.literal` rite.
+  private func compare(_ op: Comparison,
+                       _ other: some TermConvertible) -> Filter {
+    Filter(.comparison(left: expression, op: op,
+                       right: other.term.expression))
+  }
+
+  public static func == (lhs: Term, rhs: some TermConvertible) -> Filter {
+    lhs.compare(.equal, rhs)
+  }
+
+  public static func != (lhs: Term, rhs: some TermConvertible) -> Filter {
+    lhs.compare(.unequal, rhs)
+  }
+
+  public static func < (lhs: Term, rhs: some TermConvertible) -> Filter {
+    lhs.compare(.lt, rhs)
+  }
+
+  public static func > (lhs: Term, rhs: some TermConvertible) -> Filter {
+    lhs.compare(.gt, rhs)
+  }
+
+  public static func <= (lhs: Term, rhs: some TermConvertible) -> Filter {
+    lhs.compare(.leq, rhs)
+  }
+
+  public static func >= (lhs: Term, rhs: some TermConvertible) -> Filter {
+    lhs.compare(.geq, rhs)
+  }
+}
+
+// MARK: - Null / membership / like / between
+
+extension Term {
+  /// `self IS NULL` — a definite test of whether the term evaluates to NULL.
+  public var null: Filter {
+    Filter(.null(expression, negated: false))
+  }
+
+  /// `self IS NOT NULL` — the term evaluates to a value, not NULL (`present`
+  /// reads the positive sense; it lowers to the direct `IS NOT NULL` node, not
+  /// a `NOT (… IS NULL)` wrapper).
+  public var present: Filter {
+    Filter(.null(expression, negated: true))
+  }
+
+  /// `self IN (values)` — whether the term equals any of the listed values,
+  /// each lifted through `TermConvertible`. The engine requires a non-empty
+  /// list. Pass `negated: true` for `NOT IN`, mirroring the engine node's flag.
+  public func `in`(_ values: any TermConvertible...,
+                   negated: Bool = false) -> Filter {
+    Filter(.membership(expression, values.map(\.term.expression),
+                       negated: negated))
+  }
+
+  /// `self LIKE pattern [ESCAPE escape]` — whether the term's text matches the
+  /// pattern (`%` any run, `_` one character). Pass `negated: true` for
+  /// `NOT LIKE`, mirroring the engine node's flag.
+  public func like(_ pattern: String, escape: String? = nil,
+                   negated: Bool = false) -> Filter {
+    Filter(.like(expression,
+                 pattern: .expression(.literal(.string(pattern))),
+                 escape: escape.map { .expression(.literal(.string($0))) },
+                 negated: negated))
+  }
+
+  /// `self BETWEEN lower AND upper` — whether the term is within the inclusive
+  /// range, each bound lifted through `TermConvertible`. Pass `negated: true`
+  /// for `NOT BETWEEN`, mirroring the engine node's flag.
+  public func between(_ lower: some TermConvertible,
+                      and upper: some TermConvertible,
+                      negated: Bool = false) -> Filter {
+    Filter(.between(expression, .expression(lower.term.expression),
+                    .expression(upper.term.expression), negated: negated))
+  }
+}
+
+// MARK: - Logical combinators
+
+/// `lhs AND rhs`.
+public func && (lhs: Filter, rhs: Filter) -> Filter {
+  Filter(.and(lhs.predicate, rhs.predicate))
+}
+
+/// `lhs OR rhs`.
+public func || (lhs: Filter, rhs: Filter) -> Filter {
+  Filter(.or(lhs.predicate, rhs.predicate))
+}
+
+/// `NOT operand`.
+public prefix func ! (operand: Filter) -> Filter {
+  Filter(.not(operand.predicate))
+}

--- a/Sources/SQLQuery/Gaps.swift
+++ b/Sources/SQLQuery/Gaps.swift
@@ -1,0 +1,11 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Engine-blocked LINQ surface — the operators with no node in today's engine
+// AST to lower against. They are deliberately not offered: faking a lowering
+// would build a query the engine cannot execute, so each waits on a real engine
+// feature rather than a change to this module.
+//
+// Write combinators — `Insert`/`Update`/`Delete`: the engine is read-only (only
+//   `CREATE VIEW`/`CREATE FUNCTION` define; `run` rejects a write), so these
+//   wait on the read-write storage roadmap's DML statements.

--- a/Sources/SQLQuery/Projection.swift
+++ b/Sources/SQLQuery/Projection.swift
@@ -1,0 +1,71 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SQLEngine
+
+// The projection vocabulary: a `Projection` item — a term with an optional
+// output alias — and the `as(_:)` sugar that names one. `QueryBuilder.select`
+// gathers these into the engine's `Projection`, choosing the simpler
+// `.columns` case when every item is an unaliased bare column and the richer
+// `.expressions` case otherwise (mirroring the parser's own choice).
+
+/// One projected term with an optional output alias — the builder analogue of
+/// the engine's `Projected`. A bare `Term` projects unaliased; `term.as("x")`
+/// names its output column.
+public struct Projection: Hashable, Sendable {
+  /// The term this item projects.
+  public let term: Term
+
+  /// The output alias, if any.
+  public let alias: String?
+
+  public init(_ term: Term, as alias: String? = nil) {
+    self.term = term
+    self.alias = alias
+  }
+}
+
+extension Term {
+  /// This term projected under the output alias `alias` — `column("x").as("y")`
+  /// projects `x AS y`.
+  public func `as`(_ alias: String) -> Projection {
+    Projection(self, as: alias)
+  }
+}
+
+/// A value `QueryBuilder.select` can project — a bare `Term` (projected without
+/// an alias) or a `Projection` (a term with an optional `as(_:)` alias). It
+/// lets `select` take `count()`, `column("t.x")`, or `sum(a).over(…)` directly,
+/// not only a wrapped or aliased item, mirroring how `TermConvertible` lets the
+/// scalar operators take bare literals. A bare string is not convertible here —
+/// it stays a column name for the `select(_:String...)` overload, rather than
+/// lowering to a text literal.
+public protocol ProjectionConvertible {
+  /// The projection item this value projects as.
+  var projection: Projection { get }
+}
+
+extension Projection: ProjectionConvertible {
+  public var projection: Projection { self }
+}
+
+extension Term: ProjectionConvertible {
+  public var projection: Projection { Projection(self) }
+}
+
+extension Projection {
+  /// The engine `Projected` this item lowers to.
+  internal var projected: Projected {
+    Projected(expression: term.expression, alias: alias)
+  }
+
+  /// The bare column this item projects unaliased, or `nil` when it aliases or
+  /// projects a non-column expression — the test `QueryBuilder.select` uses to
+  /// choose the simpler `Projection.columns` lowering.
+  internal var column: Column? {
+    guard alias == nil, case let .column(column) = term.expression else {
+      return nil
+    }
+    return column
+  }
+}

--- a/Sources/SQLQuery/QueryBuilder.swift
+++ b/Sources/SQLQuery/QueryBuilder.swift
@@ -1,0 +1,481 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+public import SQLEngine
+
+// The fluent query builder — a value type that accumulates a `Select` and,
+// through the terminals, lowers to the engine's `Query`/`Statement` AST. Each
+// combinator (`where`/`select`/`join`/`order(by:)`/`group(by:)`/`having`/
+// `limit`/`offset`/`distinct`) sets one `Select` field and returns a refined
+// builder; the set operators (`union`/`intersect`/`except`) wrap two builders
+// into a `Query.setop`. The lowering is AST-direct — no SQL text is emitted —
+// so a build carries no lexer/parser round-trip, and the built AST equals the
+// one `Statement(parsing:)` would produce for the equivalent SQL (the test
+// oracle, since the AST is `Hashable`).
+
+/// A fluent, chainable builder over one `SELECT`. `from(_:)` roots it at a
+/// relation, the combinators refine it, and `query`/`statement` lower it to the
+/// engine AST — or `run(against:)` hands it straight to a catalog.
+public struct QueryBuilder: Hashable, Sendable {
+  // The `Select` fields, accumulated one combinator at a time. The engine's
+  // `Select` stores each as a `let`, so the builder holds the fields itself and
+  // constructs the immutable `Select` only at the `query` terminal; every
+  // combinator returns a copy with one field replaced.
+  private var unique: Bool
+  private var projection: SQLEngine.Projection
+  private var from: Relation
+  private var joins: Array<Join>
+  private var predicate: Predicate?
+  private var grouping: Array<Column>
+  private var having: Predicate?
+  private var order: Order?
+  private var limit: Limit?
+
+  private init(from: Relation) {
+    self.unique = false
+    self.projection = .all
+    self.from = from
+    self.joins = []
+    self.predicate = nil
+    self.grouping = []
+    self.having = nil
+    self.order = nil
+    self.limit = nil
+  }
+
+  /// A copy of this builder with one field replaced — the shared spine every
+  /// combinator returns through, keeping the builder a pure value.
+  private func with(_ transform: (inout QueryBuilder) -> Void)
+      -> QueryBuilder {
+    var copy = self
+    transform(&copy)
+    return copy
+  }
+
+  /// The `Select` the accumulated fields lower to. The builder holds the
+  /// `GROUP BY` columns as a plain list; it lowers here to the engine's
+  /// ordinary `Grouping.keys` over the column expressions.
+  private var select: Select {
+    let keys = Grouping.keys(grouping.map { .column($0) })
+    return Select(distinct: unique, projection: projection, from: from,
+                  joins: joins, predicate: predicate, grouping: keys,
+                  having: having, order: order, limit: limit)
+  }
+}
+
+// MARK: - Roots
+
+/// A query over the relation `name` (optionally aliased) — the root of a
+/// chain. The relation is named dynamically, matching how winmd vends its
+/// metadata tables; the catalog resolves it at run time.
+public func from(_ name: String, as alias: String? = nil) -> QueryBuilder {
+  QueryBuilder.rooted(at: Relation(name: name, alias: alias))
+}
+
+extension QueryBuilder {
+  fileprivate static func rooted(at relation: Relation) -> QueryBuilder {
+    QueryBuilder(from: relation)
+  }
+}
+
+// MARK: - Projection
+
+extension QueryBuilder {
+  /// Projects the named columns, in order — `SELECT c1, c2, …`. An empty list
+  /// leaves the projection `SELECT *`.
+  public func select(_ columns: String...) -> QueryBuilder {
+    columns.isEmpty
+        ? with { $0.projection = .all }
+        : with { $0.projection = .columns(columns.map { Column($0) }) }
+  }
+
+  /// Projects the given terms and aliased items — `SELECT f(a), b AS x, …`. An
+  /// item is a bare `Term` (`count()`, `column("t.x")`, `sum(a).over(…)`) or a
+  /// `term.as("x")` alias, both `ProjectionConvertible`, so a term need not be
+  /// wrapped or aliased to be projected. It lowers to the simpler
+  /// `Projection.columns` when every item is an unaliased bare column (the
+  /// parser's own choice), else to the richer `Projection.expressions`.
+  public func select(_ items: any ProjectionConvertible...) -> QueryBuilder {
+    let projections = items.map(\.projection)
+    let columns = projections.compactMap(\.column)
+    if columns.count == projections.count {
+      return with { $0.projection = .columns(columns) }
+    }
+    return with { $0.projection = .expressions(projections.map(\.projected)) }
+  }
+
+  /// Marks the projection `SELECT DISTINCT` — the result rows deduplicated.
+  public func distinct() -> QueryBuilder {
+    with { $0.unique = true }
+  }
+}
+
+// MARK: - Filter / join
+
+extension QueryBuilder {
+  /// Filters the scanned rows by `filter` — `WHERE`. A second `where(_:)`
+  /// replaces the predicate rather than conjoining; combine with `&&` to add a
+  /// conjunct.
+  public func `where`(_ filter: Filter) -> QueryBuilder {
+    with { $0.predicate = filter.predicate }
+  }
+
+  /// This builder with `filter` conjoined into its `WHERE` — the existing
+  /// predicate `AND` `filter`, or `filter` alone when there is none. Unlike
+  /// `where(_:)`, which replaces, this narrows the row filter, so a terminal
+  /// (`all`) can add a condition without discarding one the chain already set.
+  internal func filtering(by filter: Filter) -> QueryBuilder {
+    with {
+      if let existing = $0.predicate {
+        $0.predicate = .and(existing, filter.predicate)
+      } else {
+        $0.predicate = filter.predicate
+      }
+    }
+  }
+
+  /// Whether the predicate a terminal (`all`) adds must be tested against this
+  /// query's output rows rather than conjoined into its `WHERE`. It is so when
+  /// the output scope diverges from the pre-projection source scope: a rich
+  /// (`.expressions`) projection introduces an output column absent from the
+  /// source — an aggregate, a window value, a computed expression, or an
+  /// aliased column — which the predicate may name; the query aggregates (a
+  /// `GROUP BY`/`HAVING`, reusing the engine's own `Select.aggregates` so this
+  /// cannot drift from its grouped-compile routing); or a `LIMIT`/`OFFSET`
+  /// pages the rows. `all` wraps such a query as a derived table so its
+  /// predicate resolves against — and applies after — the shaped output. A bare
+  /// `SELECT *` or a plain-column projection is a passthrough whose output
+  /// resolves in the source scope, so `all` filters it in place, keeping the
+  /// query's own relation aliases and joined columns resolvable. A DISTINCT, or
+  /// a window in the ORDER BY alone, preserves the membership a universal test
+  /// depends on, and a plain ORDER BY only reorders, so neither shapes here.
+  internal var shaped: Bool {
+    if case .expressions = projection { return true }
+    return select.aggregates || limit != nil
+  }
+
+  /// Joins `relation` (optionally aliased) on `filter` — an `INNER JOIN` by
+  /// default; pass `kind` for a `LEFT`/`RIGHT`/`FULL` outer join. The `on`
+  /// filter is an arbitrary predicate (equi, non-equi, or composite).
+  public func join(_ relation: String, as alias: String? = nil,
+                   kind: Join.Kind = .inner,
+                   on filter: Filter) -> QueryBuilder {
+    with {
+      $0.joins.append(Join(relation: Relation(name: relation, alias: alias),
+                           kind: kind, on: filter.predicate))
+    }
+  }
+}
+
+// MARK: - Flatten
+
+extension QueryBuilder {
+  /// The qualifier the root `FROM` relation binds — its alias when present,
+  /// else its name — the name a correlated inner query qualifies an outer
+  /// column by, and the key an `OuterRow` proxy stamps onto its references.
+  fileprivate var qualifier: String {
+    from.alias ?? from.name
+  }
+
+  /// A predicate that always holds — the `1 = 1` an `APPLY` carries as its
+  /// vacuous `ON`, since a `LATERAL` body correlates through its own `WHERE`
+  /// rather than a join key. It equals the tree the parser builds for `1 = 1`,
+  /// so the lowering oracle matches.
+  fileprivate static var always: Predicate {
+    .comparison(left: .literal(.integer(1)), op: .equal,
+                right: .literal(.integer(1)))
+  }
+
+  /// Flattens a correlated inner sequence into the outer row set — the LINQ
+  /// `SelectMany`, lowered to a `LATERAL` derived table (an `APPLY`). `body`
+  /// receives an `OuterRow` proxy over the root `FROM` relation, so its inner
+  /// query correlates to a preceding-FROM column exactly as `outer(_:_:)` names
+  /// one — `flatten { t in from("S").where(column("S.k") == t["Id"]) }` lowers
+  /// to `FROM T JOIN LATERAL (SELECT * FROM S WHERE S.k = T.Id) AS d ON 1 = 1`.
+  ///
+  /// `kind` is the apply variety: `.inner` (a CROSS APPLY, the default) drops
+  /// an outer row whose body yields nothing, while `.left` (an OUTER APPLY)
+  /// preserves it NULL-extended. The body binds under `alias`, the name a later
+  /// clause qualifies its columns by.
+  public func flatten(as alias: String = "d", kind: Join.Kind = .inner,
+                      _ body: (OuterRow) -> QueryBuilder) -> QueryBuilder {
+    let inner = body(OuterRow(qualifier: qualifier))
+    let derived = Relation(derived: inner.query, as: alias, lateral: true)
+    return with {
+      $0.joins.append(Join(relation: derived, kind: kind,
+                           on: QueryBuilder.always))
+    }
+  }
+}
+
+/// A proxy over the OUTER row a `flatten` body correlates to — a reference to a
+/// column of the enclosing query's root `FROM` relation. `outer["Id"]` builds
+/// the qualified `outer(_:_:)` reference the engine resolves outward and
+/// re-binds per outer row, so a `flatten` body reads its correlated key without
+/// naming the outer relation's qualifier by hand.
+public struct OuterRow: Sendable {
+  /// The outer relation's qualifier — its alias or name — the reference is
+  /// stamped with.
+  fileprivate let qualifier: String
+
+  /// The outer column `name`, qualified by the enclosing relation — the term a
+  /// `flatten` body compares its inner key against.
+  public subscript(_ name: String) -> Term {
+    column(qualifier, name)
+  }
+}
+
+// MARK: - Order / group / having
+
+extension QueryBuilder {
+  /// Orders the result by the given keys, major to minor — `ORDER BY`. Each key
+  /// is a column name and a direction; `asc(_:)`/`desc(_:)` build one, and a
+  /// bare string defaults to ascending.
+  public func order(by keys: Order.Key...) -> QueryBuilder {
+    with { $0.order = Order(keys: keys) }
+  }
+
+  /// Appends `key` as the next minor sort key — the LINQ `ThenBy`, so
+  /// `order(by: "a").then(by: desc("b"))` orders by `a` then `b DESC`, the same
+  /// `ORDER BY a, b DESC` a single `order(by:)` of both keys builds. It extends
+  /// the ORDER BY the chain has so far; on a chain with no ordering yet it
+  /// starts one, so a lone `then(by:)` reads as `order(by:)` of that key.
+  public func then(by key: Order.Key) -> QueryBuilder {
+    with { $0.order = Order(keys: ($0.order?.keys ?? []) + [key]) }
+  }
+
+  /// Groups the rows by the named columns — `GROUP BY` — so the aggregates
+  /// (`count()`, `sum(_:)`, …) fold over each group.
+  public func group(by columns: String...) -> QueryBuilder {
+    with { $0.grouping = columns.map { Column($0) } }
+  }
+
+  /// Filters the grouped rows by `filter` — `HAVING`, applied after
+  /// aggregation, so it may reference the aggregates and the grouping columns.
+  public func having(_ filter: Filter) -> QueryBuilder {
+    with { $0.having = filter.predicate }
+  }
+}
+
+/// An ascending sort key on `column` — the default direction.
+public func asc(_ column: String) -> Order.Key {
+  Order.Key(column: Column(column), ascending: true)
+}
+
+/// A descending sort key on `column`.
+public func desc(_ column: String) -> Order.Key {
+  Order.Key(column: Column(column), ascending: false)
+}
+
+/// An ascending sort key on the expression `term` — a computed or aggregate
+/// value, as a window `ORDER BY SUM(x)` needs, where a bare column name will
+/// not do.
+public func asc(_ term: Term) -> Order.Key {
+  Order.Key(sort: .expression(term.expression), ascending: true)
+}
+
+/// A descending sort key on the expression `term`.
+public func desc(_ term: Term) -> Order.Key {
+  Order.Key(sort: .expression(term.expression), ascending: false)
+}
+
+extension Order.Key: ExpressibleByStringLiteral {
+  /// A bare column name is an ascending key — `order(by: "Name", desc("Id"))`.
+  public init(stringLiteral value: String) {
+    self.init(column: Column(value), ascending: true)
+  }
+}
+
+// MARK: - Limit / offset
+
+extension QueryBuilder {
+  /// Caps the result at `count` rows — the ISO `FETCH FIRST count ROWS ONLY`,
+  /// preserving any `offset` already set.
+  public func limit(_ count: Int) -> QueryBuilder {
+    with { $0.limit = Limit(count: count, offset: $0.limit?.offset ?? 0) }
+  }
+
+  /// Skips the first `count` rows — the ISO `OFFSET count ROWS`, preserving any
+  /// `limit` cap already set.
+  public func offset(_ count: Int) -> QueryBuilder {
+    with { $0.limit = Limit(count: $0.limit?.count, offset: count) }
+  }
+
+  /// This builder with its fetch cap reduced to at most `probe` rows — the
+  /// smaller of `probe` and any cap already set, keeping the offset. A row
+  /// terminal (`first`/`single`/`any`) probes with a small cap, but must never
+  /// widen a stricter existing one: `limit(0).first` must still yield nothing,
+  /// so the probe bounds against the existing limit rather than replacing it.
+  internal func capped(at probe: Int) -> QueryBuilder {
+    with {
+      let count = $0.limit?.count.map { Swift.min(probe, $0) } ?? probe
+      $0.limit = Limit(count: count, offset: $0.limit?.offset ?? 0)
+    }
+  }
+
+  /// This query as a derived-table source — `(SELECT …) AS \(alias)` — so a
+  /// terminal can test a condition over the shaped result (its ORDER BY /
+  /// LIMIT / OFFSET already applied) rather than by narrowing the query's own
+  /// `WHERE`, which runs before paging and so would change which rows the
+  /// page admits.
+  internal func nested(as alias: String) -> QueryBuilder {
+    QueryBuilder(from: Relation(derived: query, as: alias))
+  }
+}
+
+// MARK: - Terminals
+
+extension QueryBuilder {
+  /// The `Query` this builder lowers to — a single `SELECT` arm.
+  public var query: Query {
+    .select(select)
+  }
+
+  /// The `Statement` this builder lowers to — a `SELECT` statement wrapping
+  /// `query`, the value `Catalog.run(_:_:bindings:)` accepts.
+  public var statement: Statement {
+    .select(query)
+  }
+}
+
+// MARK: - Set operations
+
+extension QueryBuilder {
+  /// `self UNION [ALL] other` — the rows of either arm, duplicates removed
+  /// unless `all`. Set operations lower to a `SetQuery`, not a `QueryBuilder`,
+  /// since a set operation is no longer a single refinable `SELECT`.
+  public func union(_ other: QueryBuilder, all: Bool = false) -> SetQuery {
+    SetQuery(.setop(.union, query, other.query, all: all))
+  }
+
+  /// `self INTERSECT [ALL] other` — the rows present in both arms.
+  public func intersect(_ other: QueryBuilder,
+                        all: Bool = false) -> SetQuery {
+    SetQuery(.setop(.intersect, query, other.query, all: all))
+  }
+
+  /// `self EXCEPT [ALL] other` — the rows of the left arm not in the right.
+  public func except(_ other: QueryBuilder, all: Bool = false) -> SetQuery {
+    SetQuery(.setop(.except, query, other.query, all: all))
+  }
+
+  /// `self` followed by `other`, keeping every row of both — the LINQ `Concat`.
+  /// It is `UNION ALL`: unlike `union`, it preserves duplicates and does not
+  /// deduplicate across the arms, so it is the multiset append rather than a
+  /// set union.
+  public func concat(_ other: QueryBuilder) -> SetQuery {
+    SetQuery(.setop(.union, query, other.query, all: true))
+  }
+
+  /// This query's rows, or a single row of `values` when it yields none — the
+  /// LINQ `DefaultIfEmpty`. It lowers to `WITH source(c1, …) AS (self) SELECT
+  /// c1 AS <name>, … FROM source UNION ALL (SELECT <values> FROM (VALUES (0))
+  /// AS defaults WHERE NOT EXISTS (SELECT * FROM source))`: the source is
+  /// materialized once as the `source` CTE and read by both the emitted arm and
+  /// the emptiness guard, so a non-deterministic source — a routine that varies
+  /// per call — cannot make the two disagree, emitting a row while the guard
+  /// still adds the default, or the reverse. The CTE's columns are unique
+  /// positional names (`c1`, `c2`, …) that the emitted arm re-projects to the
+  /// source's own output names, so a source with duplicate output names
+  /// (`SELECT K, K`) still forms a valid CTE column list — which the engine's
+  /// case-insensitive uniqueness check would reject on the real names — while
+  /// the result keeps those names. (The ISO `VALUES (0)` one-row `<table value
+  /// constructor>` gives the guard arm a `FROM` to hang its `WHERE` on, since a
+  /// FROM-less `SELECT` is neither ISO nor admitted.) `values` must match this
+  /// query's projection in width and order — a `UNION ALL` pairs the arms'
+  /// columns positionally. The source's columns must be nameable, so a `SELECT
+  /// *` source faults `SQLError.named` (there are no names to re-project).
+  public func `default`(_ values: any TermConvertible...)
+      throws(SQLError) -> Defaulted {
+    let names = try query.names
+    let defaults = values.map {
+      Projected(expression: $0.term.expression, alias: nil)
+    }
+    // Materialize the source once as `source` under unique positional names, so
+    // the emitted arm and the emptiness guard below read the same rows (the
+    // once-materialized CTE) and a duplicate output name cannot fault the CTE
+    // column list. The emitted arm re-projects those positions to the source's
+    // real output names, so the result's schema is unchanged.
+    let internals = names.indices.map { "c\($0 + 1)" }
+    let cte = CTE(name: "source", columns: internals, query: query,
+                  recursive: false)
+    let projected = zip(internals, names).map { column, name in
+      Projected(expression: .column(Column(name: column)), alias: name)
+    }
+    let scan = Select(distinct: false, projection: .expressions(projected),
+                      from: Relation(name: "source", alias: nil), joins: [],
+                      predicate: nil, grouping: .keys([]), having: nil,
+                      order: nil, limit: nil)
+    let probe = Query(body: .select(
+        Select(distinct: false, projection: .all,
+               from: Relation(name: "source", alias: nil), joins: [],
+               predicate: nil, grouping: .keys([]), having: nil, order: nil,
+               limit: nil)))
+    // `VALUES (0)` — the ISO `<table value constructor>` as a first-class query
+    // body, a one-row derived table giving the guard arm a `FROM` to hang its
+    // `WHERE` on (a FROM-less `SELECT` is neither ISO nor admitted).
+    let constructor = Query(body: .values([[.literal(.integer(0))]]))
+    let arm = Select(distinct: false, projection: .expressions(defaults),
+                     from: Relation(derived: constructor, as: "defaults"),
+                     joins: [], predicate: .exists(probe, negated: true),
+                     grouping: .keys([]), having: nil, order: nil, limit: nil)
+    let union = Query(body: .setop(.union, .select(scan), .select(arm),
+                                   all: true))
+    return Defaulted(.with(ctes: [cte], query: union))
+  }
+}
+
+/// A set operation over two query terms — the terminal a `union`/`intersect`/
+/// `except` yields. It exposes the same `query`/`statement` terminals a
+/// `QueryBuilder` does but no further `SELECT`-level refinement, since a set
+/// operation is not a single `SELECT`; chain another set operator to extend it.
+public struct SetQuery: Hashable, Sendable {
+  /// The `Query` this set operation lowers to.
+  public let query: Query
+
+  fileprivate init(_ query: Query) {
+    self.query = query
+  }
+
+  /// The `Statement` this set operation lowers to.
+  public var statement: Statement {
+    .select(query)
+  }
+
+  /// `self UNION [ALL] other` — extends the chain, associating left.
+  public func union(_ other: QueryBuilder, all: Bool = false) -> SetQuery {
+    SetQuery(.setop(.union, query, other.query, all: all))
+  }
+
+  /// `self INTERSECT [ALL] other`.
+  public func intersect(_ other: QueryBuilder,
+                        all: Bool = false) -> SetQuery {
+    SetQuery(.setop(.intersect, query, other.query, all: all))
+  }
+
+  /// `self EXCEPT [ALL] other`.
+  public func except(_ other: QueryBuilder, all: Bool = false) -> SetQuery {
+    SetQuery(.setop(.except, query, other.query, all: all))
+  }
+
+  /// `self` followed by `other`, keeping every row of both — the LINQ `Concat`
+  /// (`UNION ALL`), extending the chain and associating left.
+  public func concat(_ other: QueryBuilder) -> SetQuery {
+    SetQuery(.setop(.union, query, other.query, all: true))
+  }
+}
+
+/// The LINQ `DefaultIfEmpty` terminal a `default(_:)` yields — this query's
+/// rows, or a single default row when it yields none. It lowers to a `WITH`
+/// that materializes the source once (see `QueryBuilder.default(_:)`), so it
+/// carries a whole `Statement` rather than a `Query`: it offers the
+/// `statement`/`run`/`columns` terminals but no further refinement or nesting,
+/// since a `WITH` is not a subquery-able query term.
+public struct Defaulted: Hashable, Sendable {
+  /// The `WITH source AS (…) SELECT … UNION ALL …` statement this lowers to.
+  public let statement: Statement
+
+  fileprivate init(_ statement: Statement) {
+    self.statement = statement
+  }
+}

--- a/Sources/SQLQuery/Run.swift
+++ b/Sources/SQLQuery/Run.swift
@@ -1,0 +1,140 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+public import SQLEngine
+
+// The execution convenience — handing a built query straight to a catalog. The
+// module is prelude-agnostic (it depends only on `SQLEngine`, not
+// `SQLStandard`), so these take the `Routines` explicitly, exactly as the pure
+// engine `Catalog.run(_:_:bindings:)` does; a caller under `import SQL` passes
+// `Routines.standard` (or uses the engine overloads directly). The catalog is a
+// borrowing `~Escapable` parameter, so a query builder cannot capture it — the
+// builder is handed to the catalog rather than the reverse.
+
+extension QueryBuilder {
+  /// Runs this query against `catalog` through `routines` and `bindings`,
+  /// returning its result rows. It lowers to `Query` and hands it to the pure
+  /// engine `Catalog.run(_:_:bindings:)`.
+  public borrowing func run<C>(against catalog: borrowing C,
+                               routines: Routines, bindings: Bindings = [:])
+      throws(SQLError) -> Array<Array<Value>> where C: Catalog & ~Escapable {
+    try catalog.run(query, routines, bindings: bindings)
+  }
+
+  /// The result columns this query would yield against `catalog`, typed through
+  /// `routines` — the schema-only counterpart of `run(against:…)`, resolving
+  /// the query without opening a cursor.
+  public borrowing func columns<C>(against catalog: borrowing C,
+                                   routines: Routines, validate: Bool = true)
+      throws(SQLError) -> Array<OutputColumn> where C: Catalog & ~Escapable {
+    try catalog.columns(of: query, routines: routines, validate: validate)
+  }
+
+  /// The first result row, or `nil` if the query yields none — LINQ
+  /// `First`/`FirstOrDefault` (Swift spells both as an Optional). Fetches one
+  /// row (`FETCH FIRST 1 ROW ONLY`) rather than the whole result — but never
+  /// more than a stricter cap already set, so `limit(0).first` still yields nil
+  /// (`capped(at:)` takes the minimum, not `limit(1)` which would expand it).
+  public borrowing func first<C>(against catalog: borrowing C,
+                                 routines: Routines, bindings: Bindings = [:])
+      throws(SQLError) -> Array<Value>? where C: Catalog & ~Escapable {
+    try capped(at: 1).run(against: catalog, routines: routines,
+                          bindings: bindings).first
+  }
+
+  /// The sole result row: `nil` if the query yields none, the row if exactly
+  /// one, `SQLError.cardinality` if more — LINQ `Single`/`SingleOrDefault`.
+  /// Fetches up to two rows to detect a surplus, capped at any stricter
+  /// existing `limit` (after `limit(1)` it fetches one and never over-reports
+  /// cardinality).
+  public borrowing func single<C>(against catalog: borrowing C,
+                                  routines: Routines, bindings: Bindings = [:])
+      throws(SQLError) -> Array<Value>? where C: Catalog & ~Escapable {
+    let rows = try capped(at: 2).run(against: catalog, routines: routines,
+                                     bindings: bindings)
+    guard rows.count <= 1 else { throw .cardinality }
+    return rows.first
+  }
+
+  /// Whether the query yields any row — LINQ `Any` (no predicate; the predicate
+  /// form is `.where(p).any(against:)`). Fetches one row rather than counting,
+  /// capped at any stricter existing `limit` so `limit(0).any` is `false`.
+  /// Distinct from the free `any(_ subquery:)` quantifier used in a comparison
+  /// — this is a terminal on the builder.
+  public borrowing func any<C>(against catalog: borrowing C,
+                               routines: Routines, bindings: Bindings = [:])
+      throws(SQLError) -> Bool where C: Catalog & ~Escapable {
+    try !capped(at: 1).run(against: catalog, routines: routines,
+                           bindings: bindings).isEmpty
+  }
+
+  /// The number of rows the query yields — LINQ `Count`. It runs the query and
+  /// counts the result rows, so it reflects the whole shape the chain builds
+  /// (a `distinct`, a `group(by:)`, a `limit`/`offset`), exactly as `first`/
+  /// `any` execute and reduce rather than build a fresh statement.
+  public borrowing func count<C>(against catalog: borrowing C,
+                                 routines: Routines, bindings: Bindings = [:])
+      throws(SQLError) -> Int where C: Catalog & ~Escapable {
+    try run(against: catalog, routines: routines, bindings: bindings).count
+  }
+
+  /// Whether every row of the sequence satisfies `predicate` — LINQ `All`, the
+  /// SQL `NOT EXISTS (… WHERE NOT predicate)`: TRUE when no row falsifies it,
+  /// so an empty sequence is vacuously TRUE and a row whose predicate is
+  /// UNKNOWN (a NULL) is not a violation. It tests for a falsifying row, and
+  /// where that test applies turns on whether the query is `shaped`. A shaped
+  /// query — a GROUP BY/HAVING folds its rows or a LIMIT/OFFSET pages them — is
+  /// wrapped as a derived table so the negation applies to the shaped output
+  /// (`.limit(1).all(p)` judges the one row the page yields, not one a
+  /// pre-filter exposes), and `predicate` names the projected columns. An
+  /// unshaped select/join keeps its own scope: the negation is conjoined into
+  /// its `WHERE`, so the query's own relations and aliases resolve
+  /// (`all(column("e.Salary") > 0)` over `from("Employees", as: "e")`).
+  public borrowing func all<C>(_ predicate: Filter,
+                               against catalog: borrowing C,
+                               routines: Routines, bindings: Bindings = [:])
+      throws(SQLError) -> Bool where C: Catalog & ~Escapable {
+    if shaped {
+      return try !nested(as: "source").filtering(by: !predicate)
+          .any(against: catalog, routines: routines, bindings: bindings)
+    }
+    return try !filtering(by: !predicate)
+        .any(against: catalog, routines: routines, bindings: bindings)
+  }
+}
+
+extension SetQuery {
+  /// Runs this set operation against `catalog` through `routines` and
+  /// `bindings`, returning its result rows.
+  public borrowing func run<C>(against catalog: borrowing C,
+                               routines: Routines, bindings: Bindings = [:])
+      throws(SQLError) -> Array<Array<Value>> where C: Catalog & ~Escapable {
+    try catalog.run(query, routines, bindings: bindings)
+  }
+
+  /// The result columns this set operation would yield against `catalog`.
+  public borrowing func columns<C>(against catalog: borrowing C,
+                                   routines: Routines, validate: Bool = true)
+      throws(SQLError) -> Array<OutputColumn> where C: Catalog & ~Escapable {
+    try catalog.columns(of: query, routines: routines, validate: validate)
+  }
+}
+
+extension Defaulted {
+  /// Runs this `DefaultIfEmpty` against `catalog` through `routines` and
+  /// `bindings`, returning its result rows — the source's rows, or the one
+  /// default row when the source is empty. It hands the `WITH` statement to the
+  /// engine `Catalog.run(_:_:bindings:)` so the source materializes once.
+  public borrowing func run<C>(against catalog: borrowing C,
+                               routines: Routines, bindings: Bindings = [:])
+      throws(SQLError) -> Array<Array<Value>> where C: Catalog & ~Escapable {
+    try catalog.run(statement, routines, bindings: bindings)
+  }
+
+  /// The result columns this `DefaultIfEmpty` would yield against `catalog`.
+  public borrowing func columns<C>(against catalog: borrowing C,
+                                   routines: Routines, validate: Bool = true)
+      throws(SQLError) -> Array<OutputColumn> where C: Catalog & ~Escapable {
+    try catalog.columns(of: statement, routines: routines, validate: validate)
+  }
+}

--- a/Sources/SQLQuery/Subquery.swift
+++ b/Sources/SQLQuery/Subquery.swift
@@ -1,0 +1,210 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+public import SQLEngine
+
+// The subquery layer: the operators that nest a built `Query` inside another —
+// `IN (SELECT …)`, `EXISTS (…)`, a quantified `op {ANY|ALL} (…)`, and a scalar
+// subquery in expression position. The engine grew these nodes (a subquery
+// `Expression`/`Predicate`), so a builder lowers each to its real AST node
+// exactly as `Statement(parsing:)` would for the equivalent SQL text.
+//
+// A nested query is uncorrelated when it names no column of the enclosing query
+// — the engine runs it once and memoises it — or correlated when its inner
+// `WHERE`/`ON` names an enclosing column, which the engine (PR243) re-executes
+// per outer row: it resolves an inner column reference outward when the
+// subquery's own `FROM` does not bind it, binds the outer cell as a synthetic
+// `:__correlated_…` parameter, and re-runs the inner plan against each outer
+// row. Both shapes lower through the same operators below — correlation turns
+// only on the inner query referencing an outer column. `outer(_:_:)` names that
+// reference unambiguously (see its note on the qualifier-shadow rule), and
+// `grouping`/`correlating` build the correlated inner query a LINQ group-join
+// reduces per outer row.
+
+// MARK: - Queryable
+
+/// A built query that nests inside another as a subquery — the `Query` a
+/// membership, `EXISTS`, quantified, or scalar-subquery operator wraps. Both a
+/// `QueryBuilder` (one `SELECT`) and a `SetQuery` (a set operation) vend the
+/// nested `Query`, so a subquery operator takes `some Queryable` and either
+/// composes uniformly.
+public protocol Queryable {
+  /// The engine `Query` this lowers to, the node a subquery operator nests.
+  var query: Query { get }
+}
+
+extension QueryBuilder: Queryable {}
+extension SetQuery: Queryable {}
+
+extension Queryable {
+  /// `value IN (self)` — whether this query yields `value` — the LINQ
+  /// `Contains`, the sequence-side spelling of `Term.in`. `inner.contains(x)`
+  /// reads as "does `inner` contain `x`" and lowers to the same `within`
+  /// predicate `x.in(inner)` builds. The query must project exactly one column.
+  /// Pass `negated: true` for `value NOT IN (self)`, mirroring the node's flag.
+  public func contains(_ value: some TermConvertible,
+                       negated: Bool = false) -> Filter {
+    value.term.in(self, negated: negated)
+  }
+}
+
+// MARK: - Membership
+
+extension Term {
+  /// `self IN (subquery)` — whether the term equals any value the `subquery`
+  /// yields; the `subquery` must project exactly one column. It lowers to the
+  /// engine's `within` predicate, the subquery form of the value-list `in`.
+  /// Pass `negated: true` for `NOT IN`, mirroring the engine node's flag.
+  public func `in`(_ subquery: some Queryable,
+                   negated: Bool = false) -> Filter {
+    Filter(.within([expression], subquery.query, negated: negated))
+  }
+}
+
+// MARK: - EXISTS
+
+/// `EXISTS (subquery)` — whether the `subquery` yields at least one row, a
+/// two-valued test of cardinality alone. It lowers to the engine's `exists`
+/// predicate. Pass `negated: true` for `NOT EXISTS`, mirroring the engine
+/// node's flag.
+public func exists(_ subquery: some Queryable,
+                   negated: Bool = false) -> Filter {
+  Filter(.exists(subquery.query, negated: negated))
+}
+
+// MARK: - Quantified comparison
+
+/// A quantified subquery operand — the `{ANY | SOME | ALL} (subquery)` right
+/// side of a quantified comparison. It pairs a quantifier with the nested
+/// query; a comparison operator against a `Term` lowers the pair to the
+/// engine's `quantified` predicate. `any(_:)` and `all(_:)` build one.
+public struct Quantification: Sendable {
+  fileprivate let quantifier: Quantifier
+  fileprivate let query: Query
+
+  fileprivate init(_ quantifier: Quantifier, _ query: Query) {
+    self.quantifier = quantifier
+    self.query = query
+  }
+}
+
+/// `ANY (subquery)` — the quantifier a comparison holds against when it is TRUE
+/// for at least one value the `subquery` yields (`SOME` is a synonym). The
+/// `subquery` must project exactly one column.
+public func any(_ subquery: some Queryable) -> Quantification {
+  Quantification(.any, subquery.query)
+}
+
+/// `ALL (subquery)` — the quantifier a comparison holds against when it is TRUE
+/// for every value the `subquery` yields. The `subquery` must project exactly
+/// one column.
+public func all(_ subquery: some Queryable) -> Quantification {
+  Quantification(.all, subquery.query)
+}
+
+extension Term {
+  /// `self <op> quantified` as a quantified-comparison `Filter`, lowering to
+  /// the engine's `quantified` predicate — the shared spine the comparison
+  /// operators against a `Quantification` return through.
+  private func compare(_ op: Comparison,
+                       _ quantified: Quantification) -> Filter {
+    Filter(.quantified([expression], op, quantified.quantifier,
+                       quantified.query))
+  }
+
+  public static func == (lhs: Term, rhs: Quantification) -> Filter {
+    lhs.compare(.equal, rhs)
+  }
+
+  public static func != (lhs: Term, rhs: Quantification) -> Filter {
+    lhs.compare(.unequal, rhs)
+  }
+
+  public static func < (lhs: Term, rhs: Quantification) -> Filter {
+    lhs.compare(.lt, rhs)
+  }
+
+  public static func > (lhs: Term, rhs: Quantification) -> Filter {
+    lhs.compare(.gt, rhs)
+  }
+
+  public static func <= (lhs: Term, rhs: Quantification) -> Filter {
+    lhs.compare(.leq, rhs)
+  }
+
+  public static func >= (lhs: Term, rhs: Quantification) -> Filter {
+    lhs.compare(.geq, rhs)
+  }
+}
+
+// MARK: - Scalar subquery
+
+/// `(subquery)` as a scalar `Term` — a nested query in expression position,
+/// yielding its lone cell (NULL when it returns no row, a cardinality fault
+/// when it returns more than one). The `subquery` must project exactly one
+/// column. It lowers to the engine's `subquery` expression, so it composes in a
+/// projection (`select(scalar(q).as("m"))`) or a comparison (`column("V") ==
+/// scalar(q)`).
+public func scalar(_ subquery: some Queryable) -> Term {
+  Term(.subquery(subquery.query))
+}
+
+// MARK: - Correlation
+
+/// A reference from inside a subquery to a column of an enclosing query — the
+/// term a correlated subquery names so the engine (PR243) re-executes it per
+/// outer row, resolving the reference outward and binding the outer cell.
+///
+/// It is a `column(_:_:)` qualified by the OUTER relation's `relation` name (or
+/// alias), which is the unambiguous form the engine's qualifier-shadow rule
+/// requires: a subquery resolves a name against its own `FROM` first; a bare
+/// unqualified name the inner `FROM` also carries binds locally (no
+/// correlation), and a qualifier naming a local relation that lacks the column
+/// is a hard `.column` fault (the inner alias shadows a same-name outer one).
+/// A qualifier naming a relation the inner `FROM` does not answer is never
+/// local, so it always correlates outward to the enclosing query — the shape
+/// this builds. Correlation is admitted only in the inner `WHERE`/`ON`, so
+/// place an `outer(_:_:)` reference there, not in the inner projection.
+public func outer(_ relation: String, _ name: String) -> Term {
+  column(relation, name)
+}
+
+// MARK: - Group join
+
+extension QueryBuilder {
+  /// The correlated inner query a LINQ group-join reduces per outer row — this
+  /// inner query filtered to the rows whose `inner` key equals the enclosing
+  /// row's `outer` key. For each outer row the engine re-executes it against
+  /// that row's `outer` cell (see `outer(_:_:)`), yielding the outer row's
+  /// GROUP of matching inner rows. It returns a `QueryBuilder` (a `Queryable`),
+  /// so a caller reduces the group with the subquery operator its result
+  /// selector wants — `exists(outer.grouping(…))` for "has any match",
+  /// `scalar(outer.grouping(…).select(count()))` for the group count, or
+  /// `column("k").in(outer.grouping(…).select("k"))` for membership.
+  ///
+  /// The correlation is conjoined into the inner query's filter, not
+  /// substituted for it: a prior `where(_:)` on the inner builder stays part of
+  /// the group, so `from("S").where(active).grouping(on:…, equals:…)` keeps
+  /// only the active rows whose key matches, rather than dropping the `active`
+  /// restriction.
+  public func grouping(on inner: Term, equals outer: Term) -> QueryBuilder {
+    filtering(by: inner == outer)
+  }
+
+  /// The correlated inner query a nested LINQ `SelectMany` reduces per outer
+  /// row — this inner query filtered by a `predicate` naming an enclosing
+  /// column (through `outer(_:_:)`). It is the flattening group-join's inner
+  /// sequence: the engine re-executes it per outer row, and a caller reduces it
+  /// with a subquery operator (`exists`/`scalar`/`in`). A group-join keyed on a
+  /// single equality is `grouping(on:equals:)`; this takes an arbitrary
+  /// correlated `predicate` for a non-equi correlation. (A LINQ `SelectMany`
+  /// that flattens the correlated inner rows into the outer set is `flatten`,
+  /// which lowers to a `LATERAL` apply — see `QueryBuilder.swift`.)
+  ///
+  /// As `grouping(on:equals:)`, the correlation is conjoined into the inner
+  /// filter, so a prior `where(_:)` on the inner builder remains in force
+  /// rather than being replaced.
+  public func correlating(where predicate: Filter) -> QueryBuilder {
+    filtering(by: predicate)
+  }
+}

--- a/Sources/SQLQuery/Term.swift
+++ b/Sources/SQLQuery/Term.swift
@@ -1,0 +1,119 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+public import SQLEngine
+
+// The scalar layer of the query builder: a `Term` — a proxy for a value the
+// engine computes per row — and the operator overloads that combine terms into
+// the `Expression` and `Predicate` nodes the engine executes.
+//
+// Swift cannot reflect a closure body into an expression tree the way C#'s
+// `Expression<Func<…>>` does, so a predicate is not captured from a plain
+// `{ $0.x > 3 }`; it is built from operator-overloaded proxies.
+// `column("x") == 3` evaluates the `==` overload on a `Term` (the column) and a
+// lifted literal, yielding a `Predicate.comparison` — the operators construct
+// the tree the way the parser would for the equivalent SQL text, because the
+// operands are these proxy types, not raw values.
+
+// MARK: - ValueConvertible
+
+/// A Swift value that lifts into a SQL scalar `Term`, so a predicate or a
+/// projection is written with bare literals — `column("Flags") == 32` rather
+/// than `column("Flags") == .literal(.integer(32))`.
+///
+/// The conformances mirror `Value`'s cases: `Int` lifts to an integer literal,
+/// `String` to text, `Bool` to a boolean, `Double` to an approximate numeric,
+/// and `Array<UInt8>` to a blob. A `Term` is itself convertible (the identity),
+/// so an overload taking `some Term` accepts both a raw literal and a column
+/// reference uniformly.
+public protocol TermConvertible {
+  /// The scalar term this lifts to.
+  var term: Term { get }
+}
+
+extension Int: TermConvertible {
+  public var term: Term { Term(.literal(.integer(self))) }
+}
+
+extension String: TermConvertible {
+  public var term: Term { Term(.literal(.string(self))) }
+}
+
+extension Bool: TermConvertible {
+  public var term: Term { Term(.literal(.boolean(self))) }
+}
+
+extension Double: TermConvertible {
+  public var term: Term { Term(.literal(.double(self))) }
+}
+
+extension Array: TermConvertible where Element == UInt8 {
+  public var term: Term { Term(.literal(.blob(self))) }
+}
+
+// MARK: - Term
+
+/// A scalar term — a proxy over an `Expression` the engine evaluates per row.
+///
+/// A term wraps a column reference, a literal, a scalar-function call, an
+/// arithmetic combination, or an aggregate. The operator overloads (`==`, `<`,
+/// `+`, `||`, …) and the predicate helpers (`null`, `like`, `between`, `in`)
+/// combine terms into the engine's `Expression`/`Predicate` nodes; `expression`
+/// exposes the built `Expression` for a projection.
+public struct Term: TermConvertible, Hashable, Sendable {
+  /// The engine expression this term lowers to.
+  public let expression: Expression
+
+  public init(_ expression: Expression) {
+    self.expression = expression
+  }
+
+  public var term: Term { self }
+}
+
+/// A column reference by name, the untyped root of the scalar layer — the
+/// dynamic form the memo recommends for winmd relations, which have no
+/// hand-authored Swift entity type. The `spelling` follows `Column`'s
+/// last-dot rule (`"t.Name"` qualifies, `"Flags"` does not).
+public func column(_ spelling: String) -> Term {
+  Term(.column(Column(spelling)))
+}
+
+/// A column reference by an explicit qualifier and name — the form a caller
+/// reaches for when a column name itself contains a dot the last-dot split
+/// would misread.
+public func column(_ qualifier: String, _ name: String) -> Term {
+  Term(.column(Column(qualifier: qualifier, name: name)))
+}
+
+// MARK: - Arithmetic
+
+extension Term {
+  /// `self <op> other` as a `binary` arithmetic term, lifting a bare literal
+  /// operand through `TermConvertible`.
+  private func binary(_ op: Arithmetic,
+                      _ other: some TermConvertible) -> Term {
+    Term(.binary(op, expression, other.term.expression))
+  }
+
+  public static func + (lhs: Term, rhs: some TermConvertible) -> Term {
+    lhs.binary(.add, rhs)
+  }
+
+  public static func - (lhs: Term, rhs: some TermConvertible) -> Term {
+    lhs.binary(.subtract, rhs)
+  }
+
+  public static func * (lhs: Term, rhs: some TermConvertible) -> Term {
+    lhs.binary(.multiply, rhs)
+  }
+
+  public static func / (lhs: Term, rhs: some TermConvertible) -> Term {
+    lhs.binary(.divide, rhs)
+  }
+
+  /// `self || other` — ISO text concatenation.
+  public func concatenating(_ other: some TermConvertible) -> Term {
+    binary(.concatenate, other)
+  }
+}

--- a/Sources/SQLQuery/Window.swift
+++ b/Sources/SQLQuery/Window.swift
@@ -1,0 +1,122 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+public import SQLEngine
+
+// Window-function builders — `<f> OVER (PARTITION BY … ORDER BY …)`, the
+// read-only surface unblocked now the engine has a window node (`Gaps.swift`).
+// A ranking, distribution, offset, or value function is a `Window` seed
+// completed by `.over(…)`; an aggregate term windows through `Term.over(…)`.
+// The frame is the engine default — a running `RANGE UNBOUNDED PRECEDING` for
+// an ordered aggregate, the whole partition otherwise — as an explicit frame,
+// a named window, and a DISTINCT/FILTER window remain later gaps.
+//
+// Each builder is a single word mirroring the engine's `WindowFunction` case
+// (`number()` for `ROW_NUMBER`, `dense()` for `DENSE_RANK`), per the naming
+// convention (CodingStyle §7), not the compound SQL keyword.
+
+/// A window function awaiting its `OVER (…)` specification — a ranking
+/// (`number()`, `rank()`, `dense()`), a distribution (`ntile(_:)`,
+/// `percent()`, `cumulative()`), an offset (`lead(_:)`/`lag(_:)`), or a value
+/// (`first(_:)`, `last(_:)`, `nth(_:_:)`). `.over(…)` completes it to a `Term`
+/// a projection or an `order(by:)` can carry.
+public struct Window {
+  fileprivate let function: WindowFunction
+
+  fileprivate init(_ function: WindowFunction) {
+    self.function = function
+  }
+
+  /// `<function> OVER (PARTITION BY partition ORDER BY order)`. An empty
+  /// `partition` or `order` omits that clause. The engine requires a ranking
+  /// or offset function to carry an `order`, and faults it at compile
+  /// otherwise, exactly as the equivalent SQL does.
+  public func over(partitioning partition: [any TermConvertible] = [],
+                   ordering order: [Order.Key] = []) -> Term {
+    Term(window: function, partition: partition, order: order)
+  }
+}
+
+extension Term {
+  /// Builds a `.window` term from a function and an `OVER` specification — the
+  /// single point `Window.over` and `Term.over` construct the node.
+  fileprivate init(window function: WindowFunction,
+                   partition: [any TermConvertible], order: [Order.Key]) {
+    self.init(.window(function: function,
+                      spec: WindowSpec(
+                          partition: partition.map(\.term.expression),
+                          order: order.isEmpty ? nil : Order(keys: order))))
+  }
+
+  /// `<aggregate> OVER (…)` — this aggregate term (`sum(_:)`, `count()`, …)
+  /// evaluated as a window aggregate over the specification, rather than folded
+  /// by a `GROUP BY`. Only an aggregate term windows this way; `over(…)` on any
+  /// other term is a builder misuse (there is no window of a bare scalar).
+  public func over(partitioning partition: [any TermConvertible] = [],
+                   ordering order: [Order.Key] = []) -> Term {
+    guard case let .aggregate(function, operand, distinct, filter) = expression
+    else {
+      preconditionFailure("over(…) requires an aggregate term")
+    }
+    return Term(window: .aggregate(function, of: operand, distinct: distinct,
+                                   filter: filter),
+                partition: partition, order: order)
+  }
+}
+
+// MARK: - Ranking and distribution
+
+/// `ROW_NUMBER()` — the row's 1-based position in the window order.
+public func number() -> Window { Window(.number) }
+
+/// `RANK()` — the position in the window order, with gaps after a tie.
+public func rank() -> Window { Window(.rank) }
+
+/// `DENSE_RANK()` — the position in the window order, with no gaps after a tie.
+public func dense() -> Window { Window(.dense) }
+
+/// `NTILE(buckets)` — the 1-based bucket the row falls in when the partition is
+/// split into `buckets` near-equal contiguous groups.
+public func ntile(_ buckets: Int) -> Window { Window(.ntile(buckets)) }
+
+/// `PERCENT_RANK()` — `(rank - 1) / (rows - 1)` over the partition.
+public func percent() -> Window { Window(.percent) }
+
+/// `CUME_DIST()` — the cumulative distribution: the fraction of partition rows
+/// at or before the current row's peer group.
+public func cumulative() -> Window { Window(.cumulative) }
+
+// MARK: - Offset
+
+/// `LEAD(value, offset, default)` — `value` from the row `offset` ahead in the
+/// window order, or `default` (NULL when omitted) past the partition end.
+public func lead(_ value: some TermConvertible, offset: Int = 1,
+                 default fallback: (any TermConvertible)? = nil) -> Window {
+  Window(.lead(value.term.expression, offset: offset,
+               default: fallback?.term.expression))
+}
+
+/// `LAG(value, offset, default)` — `value` from the row `offset` behind in the
+/// window order, or `default` (NULL when omitted) before the partition start.
+public func lag(_ value: some TermConvertible, offset: Int = 1,
+                default fallback: (any TermConvertible)? = nil) -> Window {
+  Window(.lag(value.term.expression, offset: offset,
+              default: fallback?.term.expression))
+}
+
+// MARK: - Value
+
+/// `FIRST_VALUE(value)` — `value` from the first row of the window frame.
+public func first(_ value: some TermConvertible) -> Window {
+  Window(.first(value.term.expression))
+}
+
+/// `LAST_VALUE(value)` — `value` from the last row of the window frame.
+public func last(_ value: some TermConvertible) -> Window {
+  Window(.last(value.term.expression))
+}
+
+/// `NTH_VALUE(value, n)` — `value` from the `n`-th (1-based) row of the frame.
+public func nth(_ value: some TermConvertible, _ n: Int) -> Window {
+  Window(.nth(value.term.expression, n))
+}

--- a/Tests/SQLQueryTests/DefaultTests.swift
+++ b/Tests/SQLQueryTests/DefaultTests.swift
@@ -1,0 +1,129 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLQuery
+import SQLStandard
+import SQLTestSupport
+
+// `default` — the LINQ `DefaultIfEmpty` — lowers to `WITH source AS (self)
+// SELECT * FROM source UNION ALL (SELECT <defaults> FROM (VALUES (0)) AS
+// defaults WHERE NOT EXISTS (SELECT * FROM source))`: the source is
+// materialized once as the `source` CTE and read by both the emitted arm and
+// the emptiness guard, so a non-deterministic source cannot make them disagree.
+// The lowering asserts the built statement equals the parser's tree; the
+// execution asserts the source rows survive when present and the default row
+// stands in when they do not.
+
+/// Parses `sql` to the `Statement` the builder should equal.
+private func parsed(_ sql: String) throws -> Statement {
+  try Statement(parsing: sql)
+}
+
+/// A one-column `T` with two rows — the fixture for the non-empty case and,
+/// filtered to nothing, the empty case.
+private func fixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["K": .integer]) {
+      Row(1)
+      Row(2)
+    }
+  }
+}
+
+struct DefaultLoweringTests {
+  @Test func `default materializes the source once as a CTE`() throws {
+    let built = try from("T").select("K").default(0).statement
+    #expect(built == (try parsed("""
+        WITH source (c1) AS (SELECT K FROM T) \
+        SELECT c1 AS K FROM source \
+        UNION ALL \
+        SELECT 0 FROM (VALUES (0)) AS defaults \
+        WHERE NOT EXISTS (SELECT * FROM source)
+        """)))
+  }
+
+  @Test func `default materializes duplicate output names positionally`()
+      throws {
+    // A source may project a name twice (`SELECT K, K`); naming the CTE columns
+    // K, K would fault the engine's case-insensitive uniqueness check, so they
+    // are the unique positional c1, c2, re-projected to the duplicate output
+    // names — the result keeps both K columns.
+    let built = try from("T").select("K", "K").default(0, 0).statement
+    #expect(built == (try parsed("""
+        WITH source (c1, c2) AS (SELECT K, K FROM T) \
+        SELECT c1 AS K, c2 AS K FROM source \
+        UNION ALL \
+        SELECT 0, 0 FROM (VALUES (0)) AS defaults \
+        WHERE NOT EXISTS (SELECT * FROM source)
+        """)))
+  }
+}
+
+struct DefaultExecutionTests {
+  @Test func `default yields the source rows when it is non-empty`() throws {
+    let catalog = try fixture()
+    let rows = try from("T").select("K").default(0)
+        .run(against: catalog, routines: .standard)
+    // The source has rows, so the guard arm contributes none — the result is
+    // the source's two rows and never the default (asserted independent of
+    // order, since a UNION ALL arm carries no ORDER BY).
+    #expect(rows.count == 2)
+    #expect(rows.contains([.integer(1)]) && rows.contains([.integer(2)]))
+    #expect(!rows.contains([.integer(0)]))
+  }
+
+  @Test func `default yields the default row when the source is empty`()
+      throws {
+    let catalog = try fixture()
+    let rows = try from("T").select("K").where(column("K") > 100).default(0)
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(0)]])
+  }
+
+  @Test func `default returns a source with duplicate output names`() throws {
+    let catalog = try fixture()
+    // `SELECT K, K` projects the same name twice; the source is non-empty, so
+    // its rows survive with no default. A CTE column list of K, K would fault
+    // the uniqueness check — the positional c1, c2 names let it materialize.
+    let rows = try from("T").select("K", "K").default(0, 0)
+        .run(against: catalog, routines: .standard)
+    #expect(rows.count == 2)
+    #expect(rows.contains([.integer(1), .integer(1)]))
+    #expect(rows.contains([.integer(2), .integer(2)]))
+  }
+
+  @Test func `default evaluates a non-deterministic source once`() throws {
+    let catalog = try single()
+    // `flip()` returns true, then false, then true, … — a non-deterministic
+    // routine. The source `SELECT K FROM T WHERE flip()` over T's one row keeps
+    // that row on a single evaluation (the first call is true). Were the source
+    // evaluated twice — once for the emitted arm and once for the emptiness
+    // guard — the second call (false) would empty the guard's view and wrongly
+    // append the default for two rows. Materializing the source once as a CTE
+    // makes both arms read the one kept row, so it is invoked exactly once.
+    final class Flip: @unchecked Sendable { var calls = 0 }
+    let state = Flip()
+    let flip = Routine(returns: .boolean, parameters: [],
+                       deterministic: false) { _ throws(SQLError) in
+      defer { state.calls += 1 }
+      return .boolean(state.calls % 2 == 0)
+    }
+    let routines = Routines.standard.merging(["flip": flip])
+    let rows = try from("T").select("K").where(Term.call("flip") == true)
+        .default(0).run(against: catalog, routines: routines)
+    #expect(rows == [[.integer(1)]])
+    #expect(state.calls == 1)
+  }
+}
+
+/// A one-row `T` — the source's routine runs against a single row, so a second
+/// evaluation would alternate and disagree with the first.
+private func single() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["K": .integer]) {
+      Row(1)
+    }
+  }
+}

--- a/Tests/SQLQueryTests/ExecutionTests.swift
+++ b/Tests/SQLQueryTests/ExecutionTests.swift
@@ -1,0 +1,306 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLQuery
+import SQLStandard
+import SQLTestSupport
+
+// Execution over a small in-memory fixture catalog — the built query, handed to
+// `run(against:routines:)`, yields the rows the equivalent SQL would. It proves
+// the AST-direct lowering runs end to end, not just that it equals the parser's
+// tree.
+
+/// An `Employees` relation and a `Departments` relation, a two-table fixture
+/// for the where/select, join, order, and group/aggregate chains.
+private func company() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Employees",
+             ["Name": .text, "Dept": .integer, "Salary": .integer]) {
+      Row("Alice", 1, 100)
+      Row("Bob", 1, 90)
+      Row("Carol", 2, 120)
+      Row("Dave", 2, 80)
+    }
+    Relation("Departments", ["Id": .integer, "Name": .text]) {
+      Row(1, "Engineering")
+      Row(2, "Sales")
+    }
+  }
+}
+
+struct ExecutionTests {
+  @Test func `where and select project the filtered rows`() throws {
+    let catalog = try company()
+    let rows = try from("Employees")
+        .select("Name")
+        .where(column("Salary") >= 100)
+        .order(by: "Name")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.text("Alice")], [.text("Carol")]])
+  }
+
+  @Test func `an equi-join pairs the two relations`() throws {
+    let catalog = try company()
+    let rows = try from("Employees", as: "e")
+        .select(column("e.Name").as("Emp"), column("d.Name").as("Dept"))
+        .join("Departments", as: "d", on: column("e.Dept") == column("d.Id"))
+        .where(column("e.Name") == "Alice")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.text("Alice"), .text("Engineering")]])
+  }
+
+  @Test func `order(by:) descending sorts the result`() throws {
+    let catalog = try company()
+    let rows = try from("Employees")
+        .select("Name")
+        .order(by: desc("Salary"))
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.text("Carol")], [.text("Alice")], [.text("Bob")],
+                     [.text("Dave")]])
+  }
+
+  @Test func `group(by:) with an aggregate folds each group`() throws {
+    let catalog = try company()
+    let rows = try from("Employees")
+        .select(column("Dept").as("Dept"), sum(column("Salary")).as("Total"))
+        .group(by: "Dept")
+        .order(by: "Dept")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(1), .integer(190)],
+                     [.integer(2), .integer(200)]])
+  }
+
+  @Test func `having filters the grouped rows`() throws {
+    let catalog = try company()
+    let rows = try from("Employees")
+        .select(column("Dept").as("Dept"), count().as("N"))
+        .group(by: "Dept")
+        .having(sum(column("Salary")) > 195)
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(2), .integer(2)]])
+  }
+
+  @Test func `distinct deduplicates the projected rows`() throws {
+    let catalog = try company()
+    let rows = try from("Employees")
+        .select("Dept")
+        .distinct()
+        .order(by: "Dept")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(1)], [.integer(2)]])
+  }
+
+  @Test func `limit and offset page the ordered result`() throws {
+    let catalog = try company()
+    let rows = try from("Employees")
+        .select("Name")
+        .order(by: "Name")
+        .offset(1)
+        .limit(2)
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.text("Bob")], [.text("Carol")]])
+  }
+
+  @Test func `union combines two queries`() throws {
+    let catalog = try company()
+    let rows = try from("Employees").select("Dept")
+        .union(from("Departments").select("Id"))
+        .run(against: catalog, routines: .standard)
+    #expect(Set(rows) == [[.integer(1)], [.integer(2)]])
+  }
+
+  @Test func `columns(against:) reports the projected schema`() throws {
+    let catalog = try company()
+    let columns = try from("Employees")
+        .select("Name", "Salary")
+        .columns(against: catalog, routines: .standard)
+    #expect(columns.map(\.name) == ["Name", "Salary"])
+    #expect(columns.map(\.type) == [.text, .integer])
+  }
+
+  @Test func `first returns the first result row`() throws {
+    let catalog = try company()
+    let row = try from("Employees")
+        .select("Name")
+        .order(by: "Name")
+        .first(against: catalog, routines: .standard)
+    #expect(row == [.text("Alice")])
+  }
+
+  @Test func `first returns nil over an empty result`() throws {
+    let catalog = try company()
+    let row = try from("Employees")
+        .select("Name")
+        .where(column("Salary") > 1000)
+        .first(against: catalog, routines: .standard)
+    #expect(row == nil)
+  }
+
+  @Test func `single returns the sole row of a one-row query`() throws {
+    let catalog = try company()
+    let row = try from("Employees")
+        .select("Name")
+        .where(column("Name") == "Carol")
+        .single(against: catalog, routines: .standard)
+    #expect(row == [.text("Carol")])
+  }
+
+  @Test func `single returns nil over an empty result`() throws {
+    let catalog = try company()
+    let row = try from("Employees")
+        .select("Name")
+        .where(column("Salary") > 1000)
+        .single(against: catalog, routines: .standard)
+    #expect(row == nil)
+  }
+
+  @Test func `single throws cardinality for a multi-row query`() throws {
+    let catalog = try company()
+    #expect(throws: SQLError.cardinality) {
+      try from("Employees")
+          .select("Name")
+          .where(column("Dept") == 1)
+          .single(against: catalog, routines: .standard)
+    }
+  }
+
+  @Test func `any is true for a non-empty query`() throws {
+    let catalog = try company()
+    let present = try from("Employees")
+        .select("Name")
+        .where(column("Name") == "Alice")
+        .any(against: catalog, routines: .standard)
+    #expect(present == true)
+  }
+
+  @Test func `any is false for an empty query`() throws {
+    let catalog = try company()
+    let present = try from("Employees")
+        .select("Name")
+        .where(column("Salary") > 1000)
+        .any(against: catalog, routines: .standard)
+    #expect(present == false)
+  }
+
+  @Test func `where then any tests a predicate`() throws {
+    let catalog = try company()
+    let earner = try from("Employees")
+        .where(column("Salary") >= 120)
+        .any(against: catalog, routines: .standard)
+    let millionaire = try from("Employees")
+        .where(column("Salary") >= 1000000)
+        .any(against: catalog, routines: .standard)
+    #expect(earner == true)
+    #expect(millionaire == false)
+  }
+
+  @Test func `first honors a stricter existing limit`() throws {
+    let catalog = try company()
+    // limit(0) caps the result to no rows, so first yields nil — the probe caps
+    // at the existing 0 rather than expanding it back to one row.
+    let row = try from("Employees").limit(0)
+        .first(against: catalog, routines: .standard)
+    #expect(row == nil)
+  }
+
+  @Test func `any honors a stricter existing limit`() throws {
+    let catalog = try company()
+    let present = try from("Employees").limit(0)
+        .any(against: catalog, routines: .standard)
+    #expect(present == false)
+  }
+
+  @Test func `single does not over-report cardinality under limit(1)`()
+      throws {
+    let catalog = try company()
+    // Dept 1 has two rows, but limit(1) caps the sequence to one, so single
+    // returns it rather than fetching two and throwing cardinality.
+    let row = try from("Employees").select("Name")
+        .where(column("Dept") == 1).order(by: "Name").limit(1)
+        .single(against: catalog, routines: .standard)
+    #expect(row == [.text("Alice")])
+  }
+
+  @Test func `all tests the paged sequence not the pre-filtered rows`() throws {
+    let catalog = try company()
+    // Salaries descending are 120, 100, 90, 80; limit(1) yields the one row
+    // [120], which satisfies Salary > 90, so all is true. Injecting the
+    // negation into the WHERE would drop 120/100 before the fetch and expose
+    // 90, wrongly returning false.
+    let satisfied = try from("Employees")
+        .order(by: desc("Salary")).limit(1)
+        .all(column("Salary") > 90, against: catalog, routines: .standard)
+    #expect(satisfied == true)
+    // Ascending, the one-row page is [80], which violates — so all is false,
+    // confirming the paged row, not a pre-filtered one, is the row tested.
+    let violated = try from("Employees")
+        .order(by: asc("Salary")).limit(1)
+        .all(column("Salary") > 90, against: catalog, routines: .standard)
+    #expect(violated == false)
+  }
+
+  @Test func `all resolves a qualifier against the query's own alias`() throws {
+    let catalog = try company()
+    // The predicate names the source alias `e`. An unshaped all keeps the
+    // query's own scope, so e.Salary resolves rather than faulting against a
+    // hidden derived relation. Every salary is positive, so all is true; a
+    // higher floor some row undercuts falsifies it.
+    let positive = try from("Employees", as: "e")
+        .all(column("e.Salary") > 0, against: catalog, routines: .standard)
+    #expect(positive == true)
+    let rich = try from("Employees", as: "e")
+        .all(column("e.Salary") > 100, against: catalog, routines: .standard)
+    #expect(rich == false)
+  }
+
+  @Test func `all over an aggregate-only select tests the grouped row`()
+      throws {
+    let catalog = try company()
+    // count() collapses the four employees to one row n=4 with no GROUP BY, so
+    // the query aggregates and all must test that grouped row through a derived
+    // table — not inject NOT n > 0 into the pre-aggregation WHERE, where the
+    // alias n does not exist (and count() > 0 there is an aggregate in WHERE).
+    let positive = try from("Employees").select(count().as("n"))
+        .all(column("n") > 0, against: catalog, routines: .standard)
+    #expect(positive == true)
+    // Over an empty filter count() is one row n=0, which the grouped row test
+    // falsifies — proving all judges the aggregate output, not the input rows.
+    let empty = try from("Employees").where(column("Salary") > 1000)
+        .select(count().as("n"))
+        .all(column("n") > 0, against: catalog, routines: .standard)
+    #expect(empty == false)
+  }
+
+  @Test func `all over a window projection tests the projected value`()
+      throws {
+    let catalog = try company()
+    // ROW_NUMBER projects rn = 1…4; the rn alias exists only after the window
+    // projection, so all must test it through a derived table — not inject
+    // NOT rn > 0 into the pre-projection WHERE, where rn does not yet exist.
+    let numbered = try from("Employees")
+        .select(number().over(ordering: [asc("Salary")]).as("rn"))
+        .all(column("rn") > 0, against: catalog, routines: .standard)
+    #expect(numbered == true)
+    // rn > 1 is falsified by the first-ordered row (rn = 1), proving the
+    // projected window value is what is tested.
+    let beyond = try from("Employees")
+        .select(number().over(ordering: [asc("Salary")]).as("rn"))
+        .all(column("rn") > 1, against: catalog, routines: .standard)
+    #expect(beyond == false)
+  }
+
+  @Test func `all over a join resolves each side's qualifier`() throws {
+    let catalog = try company()
+    // A joined all keeps both relations in scope — even though Employees and
+    // Departments share a Name column — so a predicate naming a column of each
+    // by its qualifier resolves unambiguously. Every joined row pairs a
+    // positive salary with a positive department id.
+    let paired = try from("Employees", as: "e")
+        .join("Departments", as: "d", on: column("e.Dept") == column("d.Id"))
+        .all(column("e.Salary") > 0 && column("d.Id") > 0,
+             against: catalog, routines: .standard)
+    #expect(paired == true)
+  }
+}

--- a/Tests/SQLQueryTests/FlattenTests.swift
+++ b/Tests/SQLQueryTests/FlattenTests.swift
@@ -1,0 +1,118 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLQuery
+import SQLStandard
+import SQLTestSupport
+
+// `flatten` — the LINQ `SelectMany` — lowers to a `LATERAL` derived table (an
+// APPLY) and, run over a parent/child fixture, yields one row per (parent,
+// child) pair. The lowering asserts the built statement equals the parser's
+// tree for the equivalent `JOIN LATERAL (…) ON 1 = 1`; the execution asserts
+// the flattened row set the engine's per-outer-row re-evaluation produces.
+
+/// Parses `sql` to the `Statement` the builder should equal.
+private func parsed(_ sql: String) throws -> Statement {
+  try Statement(parsing: sql)
+}
+
+struct FlattenLoweringTests {
+  @Test func `flatten lowers to an INNER JOIN LATERAL with a vacuous ON`()
+      throws {
+    let built = from("T")
+        .flatten { t in from("S").where(column("S.k") == t["Id"]) }
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T \
+        JOIN LATERAL (SELECT * FROM S WHERE S.k = T.Id) AS d ON 1 = 1
+        """)))
+  }
+
+  @Test func `an aliased flatten binds the body under that name`() throws {
+    let built = from("T")
+        .flatten(as: "c") { t in from("S").where(column("S.k") == t["Id"]) }
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T \
+        JOIN LATERAL (SELECT * FROM S WHERE S.k = T.Id) AS c ON 1 = 1
+        """)))
+  }
+
+  @Test func `a left flatten lowers to a LEFT JOIN LATERAL (OUTER APPLY)`()
+      throws {
+    let built = from("T")
+        .flatten(kind: .left) { t in
+          from("S").where(column("S.k") == t["Id"])
+        }
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T \
+        LEFT JOIN LATERAL (SELECT * FROM S WHERE S.k = T.Id) AS d ON 1 = 1
+        """)))
+  }
+}
+
+// MARK: - Execution
+
+/// A parent `T(Id)` and its child `S(k, x)` keyed on `T.Id`, so a `flatten`
+/// body's `S.k = T.Id` correlates each parent to its own children. Parent 3 is
+/// childless — the row an INNER flatten drops, an OUTER flatten NULL-extends.
+private func nested() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["Id": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+    }
+    Relation("S", ["k": .integer, "x": .integer]) {
+      Row(1, 100)
+      Row(1, 101)
+      Row(2, 200)
+    }
+  }
+}
+
+struct FlattenExecutionTests {
+  @Test func `flatten yields one row per parent-child pair`() throws {
+    let catalog = try nested()
+    // Parent 1 has two children, parent 2 has one, parent 3 has none — so an
+    // INNER flatten yields three rows, the childless parent contributing none.
+    let rows = try from("T")
+        .flatten { t in from("S").where(column("S.k") == t["Id"]) }
+        .select(column("T.Id").as("Id"), column("d.x").as("x"))
+        .order(by: "Id", "x")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(1), .integer(100)],
+                     [.integer(1), .integer(101)],
+                     [.integer(2), .integer(200)]])
+  }
+
+  @Test func `an INNER flatten drops a childless parent`() throws {
+    let catalog = try nested()
+    let rows = try from("T")
+        .flatten { t in from("S").where(column("S.k") == t["Id"]) }
+        .select(column("T.Id").as("Id"))
+        .run(against: catalog, routines: .standard)
+    // Parent 3 (childless) never appears — only the parents WITH children do.
+    #expect(!rows.contains([.integer(3)]))
+    #expect(rows.count == 3)
+  }
+
+  @Test func `a left flatten NULL-extends a childless parent`() throws {
+    let catalog = try nested()
+    let rows = try from("T")
+        .flatten(kind: .left) { t in
+          from("S").where(column("S.k") == t["Id"])
+        }
+        .select(column("T.Id").as("Id"), column("d.x").as("x"))
+        .order(by: "Id", "x")
+        .run(against: catalog, routines: .standard)
+    // Parent 3 survives with a NULL child column, the OUTER APPLY row.
+    #expect(rows == [[.integer(1), .integer(100)],
+                     [.integer(1), .integer(101)],
+                     [.integer(2), .integer(200)],
+                     [.integer(3), .null]])
+  }
+}

--- a/Tests/SQLQueryTests/JoinOrderTests.swift
+++ b/Tests/SQLQueryTests/JoinOrderTests.swift
@@ -1,0 +1,132 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLQuery
+
+// Joins, ordering, distinct, limit/offset, and the set operators — each built
+// fluently and checked against the parser's AST for the equivalent SQL.
+
+private func parsed(_ sql: String) throws -> Statement {
+  try Statement(parsing: sql)
+}
+
+struct JoinOrderTests {
+  @Test func `an inner equi-join lowers to a JOIN with an ON equality`()
+      throws {
+    let built = from("TypeDef", as: "t")
+        .join("Field", as: "f", on: column("t.Id") == column("f.Owner"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM TypeDef AS t JOIN Field AS f ON t.Id = f.Owner
+        """)))
+  }
+
+  @Test func `a left outer join lowers to LEFT JOIN`() throws {
+    let built = from("a")
+        .join("b", kind: .left, on: column("a.x") == column("b.y"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM a LEFT JOIN b ON a.x = b.y
+        """)))
+  }
+
+  @Test func `order(by:) with mixed directions lowers to ORDER BY`() throws {
+    let built = from("T").order(by: "a", desc("b"), asc("c")).statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T ORDER BY a, b DESC, c ASC
+        """)))
+  }
+
+  @Test func `distinct lowers to SELECT DISTINCT`() throws {
+    let built = from("T").select("a").distinct().statement
+    #expect(built == (try parsed("SELECT DISTINCT a FROM T")))
+  }
+
+  @Test func `limit and offset lower to FETCH and OFFSET`() throws {
+    let built = from("T").offset(5).limit(10).statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T OFFSET 5 ROWS FETCH FIRST 10 ROWS ONLY
+        """)))
+  }
+
+  @Test func `union lowers to a set operation`() throws {
+    let built = from("a").select("x")
+        .union(from("b").select("x"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT x FROM a UNION SELECT x FROM b
+        """)))
+  }
+
+  @Test func `union all keeps duplicates`() throws {
+    let built = from("a").select("x")
+        .union(from("b").select("x"), all: true)
+        .statement
+    #expect(built == (try parsed("""
+        SELECT x FROM a UNION ALL SELECT x FROM b
+        """)))
+  }
+
+  @Test func `intersect and except lower to their operators`() throws {
+    let intersect = from("a").select("x")
+        .intersect(from("b").select("x")).statement
+    #expect(intersect == (try parsed("""
+        SELECT x FROM a INTERSECT SELECT x FROM b
+        """)))
+
+    let except = from("a").select("x")
+        .except(from("b").select("x")).statement
+    #expect(except == (try parsed("""
+        SELECT x FROM a EXCEPT SELECT x FROM b
+        """)))
+  }
+
+  @Test func `a chained set operation associates left`() throws {
+    let built = from("a").select("x")
+        .union(from("b").select("x"))
+        .union(from("c").select("x"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT x FROM a UNION SELECT x FROM b UNION SELECT x FROM c
+        """)))
+  }
+}
+
+struct GroupTests {
+  @Test func `group(by:) with an aggregate lowers to GROUP BY`() throws {
+    let built = from("Sales")
+        .select(column("Dept").as("Dept"), sum(column("Amount")).as("Total"))
+        .group(by: "Dept")
+        .statement
+    #expect(built == (try parsed("""
+        SELECT Dept AS Dept, SUM(Amount) AS Total FROM Sales GROUP BY Dept
+        """)))
+  }
+
+  @Test func `having filters the grouped rows`() throws {
+    let built = from("Sales")
+        .select(column("Dept").as("Dept"), count().as("N"))
+        .group(by: "Dept")
+        .having(count() > 1)
+        .statement
+    #expect(built == (try parsed("""
+        SELECT Dept AS Dept, COUNT(*) AS N FROM Sales
+          GROUP BY Dept HAVING COUNT(*) > 1
+        """)))
+  }
+
+  @Test func `the aggregate builders lower to their aggregate nodes`() throws {
+    let built = from("S")
+        .select(count().as("c"), count(column("a")).as("ca"),
+                sum(column("a")).as("s"), min(column("a")).as("mn"),
+                max(column("a")).as("mx"), avg(column("a")).as("av"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT COUNT(*) AS c, COUNT(a) AS ca, SUM(a) AS s,
+               MIN(a) AS mn, MAX(a) AS mx, AVG(a) AS av
+          FROM S
+        """)))
+  }
+}

--- a/Tests/SQLQueryTests/LoweringTests.swift
+++ b/Tests/SQLQueryTests/LoweringTests.swift
@@ -1,0 +1,103 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLQuery
+
+// The lowering oracle: a fluent query builds the same `Statement` AST the
+// parser builds for the equivalent SQL text. The AST is `Hashable`/`Equatable`,
+// so each test asserts the built statement equals `Statement(parsing:)` of the
+// hand-written SQL — an exact, cheap oracle that the AST-direct lowering is
+// correct without running anything.
+
+/// Parses `sql` to the `Statement` the builder should equal.
+private func parsed(_ sql: String) throws -> Statement {
+  try Statement(parsing: sql)
+}
+
+struct LoweringTests {
+  @Test func `a bare FROM lowers to SELECT *`() throws {
+    #expect(from("TypeDef").statement == (try parsed("SELECT * FROM TypeDef")))
+  }
+
+  @Test func `select of bare columns lowers to a columns projection`() throws {
+    let built = from("TypeDef").select("TypeNamespace", "TypeName").statement
+    #expect(built == (try parsed("""
+        SELECT TypeNamespace, TypeName FROM TypeDef
+        """)))
+  }
+
+  @Test func `select of a bare term projects it without wrapping`() throws {
+    // count() is a Term, not a Projection; the ProjectionConvertible overload
+    // projects it directly, as the documented scalar(…select(count())) needs —
+    // no manual Projection(…) wrap or throwaway alias.
+    let built = from("Method").select(count()).statement
+    #expect(built == (try parsed("SELECT COUNT(*) FROM Method")))
+  }
+
+  @Test func `select mixes a bare term with an aliased item`() throws {
+    let built = from("Method").select(column("Name"), count().as("n"))
+        .statement
+    #expect(built == (try parsed("SELECT Name, COUNT(*) AS n FROM Method")))
+  }
+
+  @Test func `where with a comparison lowers to a predicate`() throws {
+    let built = from("TypeDef").where(column("Flags") == 32).statement
+    #expect(built == (try parsed("SELECT * FROM TypeDef WHERE Flags = 32")))
+  }
+
+  @Test func `conjoined comparisons lower to AND`() throws {
+    let built = from("TypeDef")
+        .where(column("Flags") == 32 && column("TypeName") != "")
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM TypeDef WHERE Flags = 32 AND TypeName <> ''
+        """)))
+  }
+
+  @Test func `a disjunction and negation lower to OR and NOT`() throws {
+    let built =
+        from("T").where(!(column("a") == 1) || column("b") > 2).statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE NOT a = 1 OR b > 2
+        """)))
+  }
+
+  @Test func `IS NULL and IS NOT NULL lower to the null predicate`() throws {
+    let built = from("T").where(column("a").null && column("b").present)
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE a IS NULL AND b IS NOT NULL
+        """)))
+  }
+
+  @Test func `IN lowers to a membership predicate`() throws {
+    let built = from("T").where(column("a").in(1, 2, 3)).statement
+    #expect(built == (try parsed("SELECT * FROM T WHERE a IN (1, 2, 3)")))
+  }
+
+  @Test func `LIKE lowers to a like predicate`() throws {
+    let built = from("T").where(column("Name").like("IVector%")).statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE Name LIKE 'IVector%'
+        """)))
+  }
+
+  @Test func `BETWEEN lowers to a between predicate`() throws {
+    let built = from("T").where(column("a").between(1, and: 10)).statement
+    #expect(built == (try parsed("SELECT * FROM T WHERE a BETWEEN 1 AND 10")))
+  }
+
+  @Test func `arithmetic in a projection lowers to a binary expression`()
+      throws {
+    let built = from("T").select((column("a") + column("b")).as("s")).statement
+    #expect(built == (try parsed("SELECT a + b AS s FROM T")))
+  }
+
+  @Test func `a scalar call in a projection lowers to a call`() throws {
+    let built = from("T").select(Term.call("UPPER", column("Name")).as("u"))
+        .statement
+    #expect(built == (try parsed("SELECT UPPER(Name) AS u FROM T")))
+  }
+}

--- a/Tests/SQLQueryTests/OperatorTests.swift
+++ b/Tests/SQLQueryTests/OperatorTests.swift
@@ -1,0 +1,146 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLQuery
+import SQLStandard
+import SQLTestSupport
+
+// The LINQ operators added over the rebased builder — `concat` (UNION ALL),
+// `then(by:)` (ThenBy), and the `count`/`all` terminals. The combinators assert
+// the built statement equals the parser's tree for the equivalent SQL (the
+// `Hashable` oracle); every operator is also run over a fixture, so it is
+// checked to both parse-equal and execute to the expected rows.
+
+/// Parses `sql` to the `Statement` the builder should equal.
+private func parsed(_ sql: String) throws -> Statement {
+  try Statement(parsing: sql)
+}
+
+/// The two-relation company fixture the other execution tests use.
+private func company() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Employees",
+             ["Name": .text, "Dept": .integer, "Salary": .integer]) {
+      Row("Alice", 1, 100)
+      Row("Bob", 1, 90)
+      Row("Carol", 2, 120)
+      Row("Dave", 2, 80)
+    }
+    Relation("Departments", ["Id": .integer, "Name": .text]) {
+      Row(1, "Engineering")
+      Row(2, "Sales")
+    }
+  }
+}
+
+struct ConcatTests {
+  @Test func `concat lowers to UNION ALL`() throws {
+    let built = from("a").select("x")
+        .concat(from("b").select("x"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT x FROM a UNION ALL SELECT x FROM b
+        """)))
+  }
+
+  @Test func `a chained concat associates left`() throws {
+    let built = from("a").select("x")
+        .concat(from("b").select("x"))
+        .concat(from("c").select("x"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT x FROM a UNION ALL SELECT x FROM b UNION ALL SELECT x FROM c
+        """)))
+  }
+
+  @Test func `concat keeps duplicates a union would drop`() throws {
+    let catalog = try company()
+    let rows = try from("Employees").select("Dept")
+        .concat(from("Departments").select("Id"))
+        .run(against: catalog, routines: .standard)
+    // Employees.Dept is 1, 1, 2, 2 and Departments.Id is 1, 2 — the append
+    // keeps every one of the six rows, where `union` would collapse to {1, 2}.
+    #expect(rows.count == 6)
+    #expect(rows.filter { $0 == [.integer(1)] }.count == 3)
+    #expect(rows.filter { $0 == [.integer(2)] }.count == 3)
+  }
+}
+
+struct ThenByTests {
+  @Test func `then(by:) appends a minor sort key`() throws {
+    let built = from("T").order(by: "a").then(by: desc("b")).then(by: asc("c"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T ORDER BY a, b DESC, c ASC
+        """)))
+  }
+
+  @Test func `a lone then(by:) starts the ordering`() throws {
+    let built = from("T").then(by: "a").statement
+    #expect(built == (try parsed("SELECT * FROM T ORDER BY a")))
+  }
+
+  @Test func `then(by:) breaks ties by the minor key`() throws {
+    let catalog = try company()
+    let rows = try from("Employees")
+        .select("Name")
+        .order(by: "Dept").then(by: desc("Salary"))
+        .run(against: catalog, routines: .standard)
+    // Dept ascending, ties broken by descending salary: dept 1 (Alice 100,
+    // Bob 90), then dept 2 (Carol 120, Dave 80).
+    #expect(rows == [[.text("Alice")], [.text("Bob")],
+                     [.text("Carol")], [.text("Dave")]])
+  }
+}
+
+struct CountTests {
+  @Test func `count returns the row count`() throws {
+    let catalog = try company()
+    let n = try from("Employees")
+        .count(against: catalog, routines: .standard)
+    #expect(n == 4)
+  }
+
+  @Test func `count reflects a where filter`() throws {
+    let catalog = try company()
+    let n = try from("Employees")
+        .where(column("Salary") >= 100)
+        .count(against: catalog, routines: .standard)
+    #expect(n == 2)
+  }
+
+  @Test func `count reflects distinct`() throws {
+    let catalog = try company()
+    let n = try from("Employees")
+        .select("Dept")
+        .distinct()
+        .count(against: catalog, routines: .standard)
+    #expect(n == 2)
+  }
+}
+
+struct AllTests {
+  @Test func `all is true when every row satisfies the predicate`() throws {
+    let catalog = try company()
+    let everyone = try from("Employees")
+        .all(column("Salary") > 0, against: catalog, routines: .standard)
+    #expect(everyone == true)
+  }
+
+  @Test func `all is false when a row falsifies the predicate`() throws {
+    let catalog = try company()
+    let everyone = try from("Employees")
+        .all(column("Salary") >= 100, against: catalog, routines: .standard)
+    #expect(everyone == false)
+  }
+
+  @Test func `all is vacuously true over an empty source`() throws {
+    let catalog = try company()
+    let everyone = try from("Employees")
+        .where(column("Salary") > 1000)
+        .all(column("Salary") < 0, against: catalog, routines: .standard)
+    #expect(everyone == true)
+  }
+}

--- a/Tests/SQLQueryTests/SubqueryExecutionTests.swift
+++ b/Tests/SQLQueryTests/SubqueryExecutionTests.swift
@@ -1,0 +1,247 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLQuery
+import SQLStandard
+import SQLTestSupport
+
+// Execution of the subquery operators over a small in-memory fixture — the
+// built subquery, handed to `run(against:routines:)`, yields the rows the
+// equivalent SQL would. It proves the subquery lowering runs end to end, not
+// just that it equals the parser's tree.
+
+/// An outer `T` (keys 1…4) and an inner `S` (a two-value subset), the fixture
+/// for the membership, `EXISTS`, quantified, and scalar-subquery chains.
+private func fixture() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["K": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+      Row(4)
+    }
+    Relation("S", ["V": .integer]) {
+      Row(2)
+      Row(3)
+    }
+  }
+}
+
+struct SubqueryExecutionTests {
+  @Test func `IN over a subquery keeps the members`() throws {
+    let catalog = try fixture()
+    let rows = try from("T")
+        .where(column("K").in(from("S").select("V")))
+        .order(by: "K")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `contains keeps the rows the subquery yields`() throws {
+    let catalog = try fixture()
+    let rows = try from("T")
+        .where(from("S").select("V").contains(column("K")))
+        .order(by: "K")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `NOT IN over a subquery keeps the non-members`() throws {
+    let catalog = try fixture()
+    let rows = try from("T")
+        .where(column("K").in(from("S").select("V"), negated: true))
+        .order(by: "K")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(1)], [.integer(4)]])
+  }
+
+  @Test func `EXISTS keeps every row when the subquery is non-empty`()
+      throws {
+    let catalog = try fixture()
+    let rows = try from("T")
+        .where(exists(from("S").select("V")))
+        .order(by: "K")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(1)], [.integer(2)], [.integer(3)],
+                     [.integer(4)]])
+  }
+
+  @Test func `NOT EXISTS drops every row over a non-empty subquery`()
+      throws {
+    let catalog = try fixture()
+    let rows = try from("T")
+        .where(exists(from("S").select("V"), negated: true))
+        .run(against: catalog, routines: .standard)
+    #expect(rows.isEmpty)
+  }
+
+  @Test func `= ANY matches any subquery value`() throws {
+    let catalog = try fixture()
+    let rows = try from("T")
+        .where(column("K") == any(from("S").select("V")))
+        .order(by: "K")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `> ALL matches values above every subquery value`() throws {
+    let catalog = try fixture()
+    let rows = try from("T")
+        .where(column("K") > all(from("S").select("V")))
+        .order(by: "K")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(4)]])
+  }
+
+  @Test func `a scalar subquery projects the same value on every row`()
+      throws {
+    let catalog = try fixture()
+    let inner = from("S").select(Projection(max(column("V"))))
+    let rows = try from("T")
+        .select(column("K").as("K"), scalar(inner).as("m"))
+        .order(by: "K")
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(1), .integer(3)], [.integer(2), .integer(3)],
+                     [.integer(3), .integer(3)], [.integer(4), .integer(3)]])
+  }
+
+  @Test func `a scalar subquery as a comparison operand filters`() throws {
+    let catalog = try fixture()
+    let inner = from("S").select(Projection(min(column("V"))))
+    let rows = try from("T")
+        .where(column("K") == scalar(inner))
+        .run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(2)]])
+  }
+}
+
+// MARK: - Correlated
+
+/// An outer `T(id)` (1…4) and an inner `S(sid, tid)` whose `tid` points back at
+/// a `T.id` — the fixture for the correlated operators, which re-execute the
+/// inner query per outer row against the outer `id`. Each correlated test below
+/// asserts a result that varies by outer row (rows kept, dropped, or a per-row
+/// count), which a once-memoised uncorrelated run could not produce —
+/// proving the engine re-runs the inner plan per outer row (PR243).
+private func linked() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["id": .integer]) {
+      Row(1)
+      Row(2)
+      Row(3)
+      Row(4)
+    }
+    Relation("S", ["sid": .integer, "tid": .integer]) {
+      Row(10, 2)
+      Row(11, 3)
+      Row(12, 3)
+    }
+  }
+}
+
+struct CorrelatedSubqueryExecutionTests {
+  @Test func `a correlated EXISTS keeps only the matched outer rows`()
+      throws {
+    let catalog = try linked()
+    // `EXISTS (SELECT sid FROM S WHERE S.tid = T.id)` is TRUE only for the
+    // outer rows some `S.tid` points at (2, 3), FALSE for 1 and 4 — a per-row
+    // result, not the constant a once-run subquery would give.
+    let inner = from("S").select("sid")
+        .grouping(on: column("S.tid"), equals: outer("T", "id"))
+    let rows = try from("T").select("id").where(exists(inner))
+        .order(by: "id").run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `a correlated NOT EXISTS keeps the unmatched outer rows`()
+      throws {
+    let catalog = try linked()
+    let inner = from("S").select("sid")
+        .grouping(on: column("S.tid"), equals: outer("T", "id"))
+    let rows = try from("T").select("id").where(exists(inner, negated: true))
+        .order(by: "id").run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(1)], [.integer(4)]])
+  }
+
+  @Test func `a correlated IN keeps the rows its own group yields`() throws {
+    let catalog = try linked()
+    // `T.id IN (SELECT S.tid FROM S WHERE S.tid = T.id)` — the inner set is
+    // {T.id} exactly when some `S.tid` equals it, empty otherwise, so it keeps
+    // 2 and 3 — a per-row membership, not a fixed value list.
+    let inner = from("S").select("tid")
+        .grouping(on: column("S.tid"), equals: outer("T", "id"))
+    let rows = try from("T").select("id").where(column("id").in(inner))
+        .order(by: "id").run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(2)], [.integer(3)]])
+  }
+
+  @Test func `a correlated scalar count varies by outer row`() throws {
+    let catalog = try linked()
+    // `(SELECT COUNT(*) FROM S WHERE S.tid = T.id)` is the GROUP size per outer
+    // row — 0 for 1, 1 for 2, 2 for 3, 0 for 4 — the LINQ group-join reduction.
+    // The differing counts prove per-outer-row re-execution.
+    let group = from("S")
+        .grouping(on: column("S.tid"), equals: outer("T", "id"))
+        .select(count())
+    let rows = try from("T")
+        .select(column("id").as("id"), scalar(group).as("n"))
+        .order(by: "id").run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(1), .integer(0)], [.integer(2), .integer(1)],
+                     [.integer(3), .integer(2)], [.integer(4), .integer(0)]])
+  }
+
+  @Test func `a non-equi correlated predicate re-runs per outer row`()
+      throws {
+    let catalog = try linked()
+    // The non-equi correlated form: `EXISTS (SELECT sid FROM S WHERE
+    // S.tid > T.id)` is TRUE for the outer rows some `S.tid` exceeds — 2 and 3
+    // are below the max `S.tid` (3), 1 is too, but 3 is NOT strictly exceeded
+    // and 4 is not — so it keeps 1 and 2, again varying by outer row.
+    let inner = from("S").select("sid")
+        .correlating(where: column("S.tid") > outer("T", "id"))
+    let rows = try from("T").select("id").where(exists(inner))
+        .order(by: "id").run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(1)], [.integer(2)]])
+  }
+
+  @Test func `grouping conjoins the correlation with a prior filter`() throws {
+    let catalog = try flagged()
+    // The inner is pre-filtered to active rows; grouping adds the key
+    // correlation without discarding that filter. T=1 matches only an inactive
+    // S row so EXISTS is false for it, while T=2 matches an active one. Were
+    // grouping to replace the predicate, T=1's inactive match would wrongly
+    // satisfy EXISTS and keep the row.
+    let inner = from("S").select("tid").where(column("active") == 1)
+        .grouping(on: column("S.tid"), equals: outer("T", "id"))
+    let rows = try from("T").select("id").where(exists(inner))
+        .order(by: "id").run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(2)]])
+  }
+
+  @Test func `correlating conjoins the predicate with a prior filter`()
+      throws {
+    let catalog = try flagged()
+    let inner = from("S").select("tid").where(column("active") == 1)
+        .correlating(where: column("S.tid") == outer("T", "id"))
+    let rows = try from("T").select("id").where(exists(inner))
+        .order(by: "id").run(against: catalog, routines: .standard)
+    #expect(rows == [[.integer(2)]])
+  }
+}
+
+/// An outer `T` and an inner `S` whose rows carry an `active` flag — the
+/// fixture proving a group-join correlation keeps a prior `where(_:)` in force.
+private func flagged() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("T", ["id": .integer]) {
+      Row(1)
+      Row(2)
+    }
+    Relation("S", ["tid": .integer, "active": .integer]) {
+      Row(1, 0)
+      Row(2, 1)
+    }
+  }
+}

--- a/Tests/SQLQueryTests/SubqueryTests.swift
+++ b/Tests/SQLQueryTests/SubqueryTests.swift
@@ -1,0 +1,134 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLQuery
+
+// The subquery lowering oracle: a fluent subquery operator builds the same
+// `Statement` AST the parser builds for the equivalent SQL text. Each test
+// asserts the built statement equals `Statement(parsing:)` of the hand-written
+// SQL, the exact `Hashable` oracle the other lowering tests use.
+
+/// Parses `sql` to the `Statement` the builder should equal.
+private func parsed(_ sql: String) throws -> Statement {
+  try Statement(parsing: sql)
+}
+
+struct SubqueryTests {
+  @Test func `IN over a subquery lowers to a within predicate`() throws {
+    let built = from("T")
+        .where(column("K").in(from("S").select("V")))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE K IN (SELECT V FROM S)
+        """)))
+  }
+
+  @Test func `NOT IN over a subquery lowers to a negated within`() throws {
+    let built = from("T")
+        .where(column("K").in(from("S").select("V"), negated: true))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE K NOT IN (SELECT V FROM S)
+        """)))
+  }
+
+  @Test func `contains lowers to a within, the sequence-side in`() throws {
+    let built = from("T")
+        .where(from("S").select("V").contains(column("K")))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE K IN (SELECT V FROM S)
+        """)))
+  }
+
+  @Test func `negated contains lowers to a negated within`() throws {
+    let built = from("T")
+        .where(from("S").select("V").contains(column("K"), negated: true))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE K NOT IN (SELECT V FROM S)
+        """)))
+  }
+
+  @Test func `EXISTS lowers to an exists predicate`() throws {
+    let built = from("T")
+        .where(exists(from("S").select("V")))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE EXISTS (SELECT V FROM S)
+        """)))
+  }
+
+  @Test func `NOT EXISTS lowers to a negated exists`() throws {
+    let built = from("T")
+        .where(exists(from("S").select("V"), negated: true))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE NOT EXISTS (SELECT V FROM S)
+        """)))
+  }
+
+  @Test func `= ANY lowers to a quantified predicate`() throws {
+    let built = from("T")
+        .where(column("K") == any(from("S").select("V")))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE K = ANY (SELECT V FROM S)
+        """)))
+  }
+
+  @Test func `<> ALL lowers to a quantified predicate`() throws {
+    let built = from("T")
+        .where(column("K") != all(from("S").select("V")))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE K <> ALL (SELECT V FROM S)
+        """)))
+  }
+
+  @Test func `< ANY lowers to a quantified predicate`() throws {
+    let built = from("T")
+        .where(column("K") < any(from("S").select("V")))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE K < ANY (SELECT V FROM S)
+        """)))
+  }
+
+  @Test func `a quantified comparison over a union subquery lowers`() throws {
+    let sub = from("S").select("V").union(from("R").select("W"))
+    let built = from("T").where(column("K") > all(sub)).statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T
+        WHERE K > ALL (SELECT V FROM S UNION SELECT W FROM R)
+        """)))
+  }
+
+  @Test func `a scalar subquery in a projection lowers to a subquery`()
+      throws {
+    let inner = from("S").select(Projection(max(column("V"))))
+    let built = from("T").select(scalar(inner).as("m")).statement
+    #expect(built == (try parsed("""
+        SELECT (SELECT MAX(V) FROM S) AS m FROM T
+        """)))
+  }
+
+  @Test func `a scalar subquery as a comparison operand lowers`() throws {
+    let inner = from("S").select(Projection(min(column("V"))))
+    let built = from("T").where(column("V") == scalar(inner)).statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T WHERE V = (SELECT MIN(V) FROM S)
+        """)))
+  }
+
+  @Test func `IN over a set-operation subquery lowers to a within`() throws {
+    let sub = from("S").select("V").intersect(from("R").select("W"))
+    let built = from("T").where(column("K").in(sub)).statement
+    #expect(built == (try parsed("""
+        SELECT * FROM T
+        WHERE K IN (SELECT V FROM S INTERSECT SELECT W FROM R)
+        """)))
+  }
+}

--- a/Tests/SQLQueryTests/WindowTests.swift
+++ b/Tests/SQLQueryTests/WindowTests.swift
@@ -1,0 +1,163 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+import SQLEngine
+import SQLQuery
+import SQLStandard
+import SQLTestSupport
+
+// The window-function surface (`Window.swift`) — ranking, distribution, offset,
+// value, and aggregate windows built with `.over(partitioning:ordering:)`. Each
+// operator asserts the built statement equals the parser's tree for the
+// equivalent SQL (the `Hashable` oracle) and, where it computes a value, runs
+// over a fixture to the rows the SQL would yield.
+
+/// Parses `sql` to the `Statement` the builder should equal.
+private func parsed(_ sql: String) throws -> Statement {
+  try Statement(parsing: sql)
+}
+
+/// A one-relation fixture with ties within each department.
+private func employees() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Employees",
+             ["Name": .text, "Dept": .integer, "Salary": .integer]) {
+      Row("Alice", 1, 100)
+      Row("Bob", 1, 90)
+      Row("Carol", 2, 120)
+      Row("Dave", 2, 80)
+    }
+  }
+}
+
+struct WindowLoweringTests {
+  @Test func `ROW_NUMBER lowers with an ORDER BY`() throws {
+    let built = from("Employees")
+        .select(number().over(ordering: [asc("Salary")]).as("rn"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT ROW_NUMBER() OVER (ORDER BY Salary) AS rn FROM Employees
+        """)))
+  }
+
+  @Test func `RANK lowers with a PARTITION BY and a descending ORDER BY`()
+      throws {
+    let built = from("Employees")
+        .select(rank().over(partitioning: [column("Dept")],
+                            ordering: [desc("Salary")]).as("r"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT RANK() OVER (PARTITION BY Dept ORDER BY Salary DESC) AS r
+        FROM Employees
+        """)))
+  }
+
+  @Test func `an aggregate windows with over`() throws {
+    let built = from("Employees")
+        .select(sum(column("Salary")).over(partitioning: [column("Dept")])
+                    .as("total"))
+        .statement
+    #expect(built == (try parsed("""
+        SELECT SUM(Salary) OVER (PARTITION BY Dept) AS total FROM Employees
+        """)))
+  }
+
+  @Test func `the distribution, offset, and value functions lower`() throws {
+    let cases: [(Term, String)] = [
+      (dense().over(ordering: [asc("Salary")]),
+       "DENSE_RANK() OVER (ORDER BY Salary)"),
+      (ntile(2).over(ordering: [asc("Salary")]),
+       "NTILE(2) OVER (ORDER BY Salary)"),
+      (percent().over(ordering: [asc("Salary")]),
+       "PERCENT_RANK() OVER (ORDER BY Salary)"),
+      (cumulative().over(ordering: [asc("Salary")]),
+       "CUME_DIST() OVER (ORDER BY Salary)"),
+      (lead(column("Salary")).over(ordering: [asc("Salary")]),
+       "LEAD(Salary) OVER (ORDER BY Salary)"),
+      (lag(column("Salary"), offset: 2, default: 0)
+          .over(ordering: [asc("Salary")]),
+       "LAG(Salary, 2, 0) OVER (ORDER BY Salary)"),
+      (first(column("Name")).over(ordering: [asc("Salary")]),
+       "FIRST_VALUE(Name) OVER (ORDER BY Salary)"),
+      (last(column("Name")).over(ordering: [asc("Salary")]),
+       "LAST_VALUE(Name) OVER (ORDER BY Salary)"),
+      (nth(column("Name"), 2).over(ordering: [asc("Salary")]),
+       "NTH_VALUE(Name, 2) OVER (ORDER BY Salary)"),
+    ]
+    for (term, sql) in cases {
+      let built = from("Employees").select(term.as("w")).statement
+      #expect(built == (try parsed("SELECT \(sql) AS w FROM Employees")),
+              "\(sql)")
+    }
+  }
+
+  @Test func `a grouped window orders by an aggregate`() throws {
+    let built = from("Employees")
+        .select(column("Dept").as("Dept"),
+                dense().over(ordering: [asc(sum(column("Salary")))]).as("r"))
+        .group(by: "Dept")
+        .statement
+    #expect(built == (try parsed("""
+        SELECT Dept AS Dept, DENSE_RANK() OVER (ORDER BY SUM(Salary)) AS r
+        FROM Employees GROUP BY Dept
+        """)))
+  }
+}
+
+struct WindowExecutionTests {
+  @Test func `ROW_NUMBER numbers the rows in the window order`() throws {
+    let rows = try from("Employees")
+        .select(column("Name").as("Name"),
+                number().over(ordering: [asc("Salary")]).as("rn"))
+        .order(by: "Name")
+        .run(against: employees(), routines: .standard)
+    // By Salary ascending: Dave 80=1, Bob 90=2, Alice 100=3, Carol 120=4;
+    // the output is ordered by Name.
+    #expect(rows == [[.text("Alice"), .integer(3)],
+                     [.text("Bob"), .integer(2)],
+                     [.text("Carol"), .integer(4)],
+                     [.text("Dave"), .integer(1)]])
+  }
+
+  @Test func `an aggregate window totals each partition`() throws {
+    let rows = try from("Employees")
+        .select(column("Name").as("Name"),
+                sum(column("Salary")).over(partitioning: [column("Dept")])
+                    .as("total"))
+        .order(by: "Name")
+        .run(against: employees(), routines: .standard)
+    // Dept 1 = 100 + 90 = 190; Dept 2 = 120 + 80 = 200.
+    #expect(rows == [[.text("Alice"), .integer(190)],
+                     [.text("Bob"), .integer(190)],
+                     [.text("Carol"), .integer(200)],
+                     [.text("Dave"), .integer(200)]])
+  }
+
+  @Test func `RANK ranks within each partition`() throws {
+    let rows = try from("Employees")
+        .select(column("Name").as("Name"),
+                rank().over(partitioning: [column("Dept")],
+                            ordering: [desc("Salary")]).as("r"))
+        .order(by: "Name")
+        .run(against: employees(), routines: .standard)
+    // Dept 1 by Salary desc: Alice 100=1, Bob 90=2; Dept 2: Carol 120=1,
+    // Dave 80=2.
+    #expect(rows == [[.text("Alice"), .integer(1)],
+                     [.text("Bob"), .integer(2)],
+                     [.text("Carol"), .integer(1)],
+                     [.text("Dave"), .integer(2)]])
+  }
+
+  @Test func `a window over grouped output ranks the groups`() throws {
+    let rows = try from("Employees")
+        .select(column("Dept").as("Dept"),
+                dense().over(ordering: [asc(sum(column("Salary")))]).as("r"))
+        .group(by: "Dept")
+        .order(by: "Dept")
+        .run(against: employees(), routines: .standard)
+    // Group totals: Dept 1 = 190, Dept 2 = 200; DENSE_RANK by total ascending.
+    #expect(rows == [[.integer(1), .integer(1)],
+                     [.integer(2), .integer(2)]])
+  }
+}


### PR DESCRIPTION
Introduce SQLQuery, a fluent, value-typed query builder that lowers directly to the engine's `Query`/`Statement` AST — no SQL text is emitted, so a build carries no lexer/parser round-trip and the built AST equals the tree `Statement(parsing:)` produces for the equivalent SQL (the `Hashable` oracle the lowering tests assert against). The module depends only on `SQLEngine`, not the `SQLStandard` prelude, so the terminals take a `Routines` explicitly.

A chain roots at a relation with `from(_:as:)` and refines through combinators — `where`/`select`/`join`/`order(by:)`/`then(by:)`/`group(by:)`/`having`/`limit`/ `offset`/`distinct` — each returning a copy with one `Select` field replaced. A scalar layer (`Term`, `column`, the arithmetic and comparison operator overloads, the aggregate and scalar-call builders) and a predicate layer (`Filter`, the `&&`/`||`/`!` combinators, `in`/`like`/`between`/`null`) supply the projection- and condition-side vocabulary, lifting bare Swift literals through `TermConvertible`.

A window layer maps the engine's window node: a `Window` seed for each ranking (`number()`/`rank()`/`dense()`), distribution (`ntile(_:)`/`percent()`/ `cumulative()`), offset (`lead(_:)`/`lag(_:)`), and value (`first(_:)`/ `last(_:)`/`nth(_:_:)`) function, completed by `.over(partitioning:ordering:)` into a `.window` `Term`; an aggregate term windows through `Term.over(…)`, which lifts its `.aggregate` into a window aggregate (`sum(x).over(…)`). Each builder is a single word mirroring the engine's `WindowFunction` case (`number` for `ROW_NUMBER`), not the compound SQL keyword. `asc(_:)`/`desc(_:)` gain a `Term` overload so a window `ORDER BY SUM(x)` is expressible, not only a bare column. The frame is the engine default; an explicit frame, a named `WINDOW` clause, and a DISTINCT/FILTER window are unbuilt module surface (all have engine nodes).

The set operators fold two query terms into a `Query.setop`: `union`/`intersect` /`except` (each with an `all:` variant) and `concat` (the LINQ `Concat`, a `UNION ALL` multiset append). The subquery layer nests a built query inside another — `in`/`contains`, `exists`, quantified `any`/`all` comparisons, and a scalar `subquery` in expression position — lowering to the engine's `within`/ `exists`/`quantified` predicates and `subquery` expression; a `negated:` flag threads straight to each node's own flag (a `NOT IN`/`NOT EXISTS` is the flipped node, not a wrapping NOT predicate). `contains` is the sequence-side spelling of `in` (`q.contains(x)` is `x IN (q)`). An uncorrelated nested query runs once and memoises; a correlated one names an enclosing column through `outer(_:_:)`, which the engine resolves outward and re-executes per outer row (PR243). `grouping(on:equals:)`/`correlating(where:)` build the correlated inner a LINQ group-join reduces, and `flatten` (the LINQ `SelectMany`) flattens a correlated inner sequence into the outer set through a LATERAL apply (CROSS, or OUTER for `.left`).

The terminals execute and reduce rather than build a fresh statement: `first`/ `single`/`any` (no-arg)/`count` run the query and fold the result, and `all` lowers to `NOT EXISTS (… WHERE NOT predicate)`, conjoining its predicate with any `where` already set. `default` (the LINQ `DefaultIfEmpty`) yields the source rows, or a single row of given defaults when the source is empty, lowering to `self UNION ALL (SELECT <defaults> FROM (VALUES (0)) AS defaults WHERE NOT EXISTS (self))` — the ISO `VALUES (0)` table value constructor is the one-row derived table that gives the guard arm a FROM to carry its WHERE (a FROM-less SELECT cannot, and is not ISO regardless). `run(against:routines:)`/ `columns(against:routines:)` hand a built query to a borrowing `~Escapable` catalog.

The read-only surface is complete. `Gaps.swift` records only the write combinators (`Insert`/`Update`/`Delete`), still blocked because the engine is read-only — deliberately not offered rather than faked, awaiting the read-write storage roadmap's DML statements.