### PR TITLE
SQLTests: drop an always-true cast in the parser depth guard

### DIFF
--- a/SwiftSQL/Tests/SQLTests/Syntax/ParserDepthTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Syntax/ParserDepthTests.swift
@@ -13,9 +13,15 @@ import func SQLTestSupport.parse
 /// before faulting — the deep cases here parse to a clean fault, never a crash.
 struct ParserDepthTests {
   private func sqlstate(parsing sql: String) -> String? {
-    do { _ = try parse(query: sql); return nil }
-    catch let error as SQLError { return error.sqlstate }
-    catch { return nil }
+    // `parse(query:)` has typed throws (`throws(SQLError)`), so the caught
+    // `error` is already an `SQLError` — no `as SQLError` cast (always true) or
+    // catch-all needed.
+    do {
+      _ = try parse(query: sql)
+      return nil
+    } catch {
+      return error.sqlstate
+    }
   }
 
   @Test func `deeply nested input faults 54001, not a stack overrun`() throws {


### PR DESCRIPTION
`parse(query:)` has typed throws (`throws(SQLError)`), so the depth test's `sqlstate(parsing:)` helper caught the error with `catch let error as SQLError` — a cast the compiler knows is always true — followed by an unreachable catch-all. A clean build reported the sole compiler warning here ('as' test is always true).

Collapse the two clauses into one `catch { return error.sqlstate }`, whose bound `error` is already an `SQLError` under typed throws. Behaviour is unchanged (the depth cases still fault 54001), and a clean build of both packages — root and the nested SwiftSQL — is now warning-free.