### PR TITLE
SQLEngine: resolve named-window refinement and chaining

### DIFF
--- a/SwiftSQL/Sources/SQLEngine/AST+Expression.swift
+++ b/SwiftSQL/Sources/SQLEngine/AST+Expression.swift
@@ -165,13 +165,23 @@ extension WindowFunction {
 /// written).
 public struct WindowSpec: Hashable, Sendable {
   /// The name of a `WINDOW` clause window this specification references
-  /// (`OVER w`), or `nil` for an inline specification (`OVER (…)`). A reference
-  /// is a forward one — the `WINDOW` clause follows the projection — so it
-  /// carries no `PARTITION`/`ORDER`/frame of its own here; it is inlined to the
-  /// named window's specification by the `Query.expanded` prelude before any
-  /// structural walk descends it, so a bare reference and the inline form
-  /// resolve identically.
+  /// (`OVER w`, `OVER (w …)`), or `nil` for an inline specification naming no
+  /// base. It is resolved to the named window's specification by the
+  /// `Query.expanded` prelude before any structural walk descends it, so a
+  /// reference and the inline form resolve identically.
   public let base: String?
+
+  /// Whether this is a parenthesized in-line specification that references a
+  /// base (`OVER (w)`, `OVER (w …)`, or a `WINDOW name AS (…)` definition)
+  /// rather than a bare window-name reference (`OVER w`). ISO 9075 splits a
+  /// bare `<window name>`, which uses the named window wholesale (frame
+  /// included), from an `<in-line window specification>` `(w …)`, which copies
+  /// the named window and so cannot copy a framed one — even `OVER (w)` adding
+  /// nothing. It defaults to `false`, so a programmatic `WindowSpec(base: "w")`
+  /// is the wholesale bare form; the parser passes `true` for a parenthesized
+  /// spec. It matters only with a `base`, so a base-less spec normalizes to
+  /// `false` — its value never distinguishes two otherwise-equal specs.
+  public let parenthesized: Bool
 
   /// The `PARTITION BY` keys — the rows split into one partition per distinct
   /// key combination — empty when no `PARTITION BY` is written.
@@ -186,9 +196,13 @@ public struct WindowSpec: Hashable, Sendable {
   /// through the current peer group with one).
   public let frame: Frame?
 
-  public init(base: String? = nil, partition: Array<Expression> = [],
-              order: Order? = nil, frame: Frame? = nil) {
+  public init(base: String? = nil, parenthesized: Bool = false,
+              partition: Array<Expression> = [], order: Order? = nil,
+              frame: Frame? = nil) {
     self.base = base
+    // The flag is meaningful only for a base reference; normalize a base-less
+    // spec to `false` so two otherwise-equal specs never differ on a dead flag.
+    self.parenthesized = base == nil ? false : parenthesized
     self.partition = partition
     self.order = order
     self.frame = frame

--- a/SwiftSQL/Sources/SQLEngine/Compilation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Compilation.swift
@@ -1739,8 +1739,10 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func validate(
       named windows: Array<NamedWindow>, against scope: Scope,
       _ routines: Routines, subquery: Resolution) throws(SQLError) {
-    for definition in windows {
-      let spec = try definition.spec.resolved(against: windows)
+    for index in windows.indices {
+      // Resolve each definition in its own DEFINITION context — its base may
+      // reference only an earlier entry and it copies a frameless base.
+      let spec = try windows.resolved(at: index)
       // The function-independent structural frame check — a reversed or inverted
       // frame — that `reject(for:)` runs for a referenced window.
       if let frame = spec.frame { try frame.check() }

--- a/SwiftSQL/Sources/SQLEngine/Parser+Projection.swift
+++ b/SwiftSQL/Sources/SQLEngine/Parser+Projection.swift
@@ -468,6 +468,8 @@ extension Parser {
     // specification. A window name is an identifier, distinct from the
     // parenthesised inline specification.
     guard current?.kind == .lparen else {
+      // A bare `<window name>` uses the named window wholesale (the default
+      // `parenthesized: false`); a parenthesized `( … )` copies it (`true`).
       return WindowSpec(base: try identifier())
     }
     return try windowspec()
@@ -494,8 +496,10 @@ extension Parser {
     let order: Order? = try match(.order) ? self.order() : nil
     let frame = try self.frame()
     try expect(.rparen)
-    return WindowSpec(base: base, partition: partition, order: order,
-                      frame: frame)
+    // A parenthesized spec — the init normalizes the flag back to `false` when
+    // it names no base, so only a base reference carries the copy flag.
+    return WindowSpec(base: base, parenthesized: true, partition: partition,
+                      order: order, frame: frame)
   }
 
   /// Parses a `SELECT`'s `WINDOW` clause — `WINDOW name AS (<window spec>) (','

--- a/SwiftSQL/Sources/SQLEngine/Windowed.swift
+++ b/SwiftSQL/Sources/SQLEngine/Windowed.swift
@@ -817,29 +817,103 @@ extension Predicate {
 // MARK: - Named-window inlining
 
 extension WindowSpec {
-  /// This specification with a named-window reference (`OVER w`) resolved to
-  /// the specification `windows` defines under that name, an inline spec (`OVER
-  /// (…)`) returned unchanged. A reference to an undefined window faults
-  /// `42704`; a refinement (a base name with added `PARTITION`/`ORDER`/frame
-  /// clauses) and a chained reference (a named window that itself references
-  /// another) are not yet supported and fault `0A000`. Each fault is on both
-  /// the run and validate paths, since the inlining runs at the shared
-  /// `Query.expanded` prelude.
+  /// This projection reference (`OVER w` / `OVER (w …)`) resolved to the ISO
+  /// 9075 window it names in `windows`, merged with the referencing clauses; an
+  /// inline spec (no base) is returned unchanged. It is the USE context — a
+  /// function's `OVER` clause — where the `WINDOW` clause is fully in scope, so
+  /// the base is looked up across the whole list. The named window is itself
+  /// resolved (`Array.resolved(at:)`, the DEFINITION context) first, so a chain
+  /// collapses to a base-free spec.
+  ///
+  /// A bare `OVER w` uses the named window wholesale — its partitioning, `ORDER
+  /// BY`, and frame — so a framed window is usable by a bare reference. A
+  /// parenthesized form (`OVER (w)`, or `OVER (w …)` adding an `ORDER BY`
+  /// and/or a frame) is an in-line specification that copies the base — even
+  /// `OVER (w)` adding nothing — so it may not copy a framed base. The merged
+  /// spec takes the base's partitioning, the base's `ORDER BY` else the
+  /// reference's, and the reference's frame else the base's.
+  ///
+  /// Faults, each on both the run and validate paths (the inlining runs at the
+  /// shared `Query.expanded` prelude): an undefined window `42704`; a reference
+  /// adding a `PARTITION BY`, a parenthesized copy of a framed window, or an
+  /// added `ORDER BY` overriding the base's, `42601`.
   internal func resolved(against windows: Array<NamedWindow>)
       throws(SQLError) -> WindowSpec {
     guard let base else { return self }
-    guard partition.isEmpty, order == nil, frame == nil else {
-      throw .state("0A000", "refining a named window is not yet supported")
+    // A reference inherits the base's partitioning; it may not add its own.
+    guard partition.isEmpty else {
+      throw .state("42601",
+                   "a window referencing \"\(base)\" cannot add a PARTITION BY")
     }
-    guard let named = windows.first(where: {
+    guard let index = windows.firstIndex(where: {
       $0.name.lowercased() == base.lowercased()
-    })?.spec else {
+    }) else {
       throw .state("42704", "window \"\(base)\" is not defined")
     }
-    guard named.base == nil else {
-      throw .state("0A000", "a chained window reference is not yet supported")
+    let referenced = try windows.resolved(at: index)
+    // A parenthesized reference (`OVER (w …)`, or even a bare `OVER (w)`) is an
+    // in-line specification that copies the named window, so it cannot copy a
+    // framed base; a bare `OVER w` uses the window wholesale, inheriting its
+    // frame.
+    if parenthesized, referenced.frame != nil {
+      throw .state("42601",
+                   "window \"\(base)\" has a frame and cannot be copied")
     }
-    return named
+    // An added `ORDER BY` cannot override the base's.
+    if order != nil, referenced.order != nil {
+      throw .state("42601",
+                   "window \"\(base)\" already orders and its ORDER BY "
+                   + "cannot be overridden")
+    }
+    return WindowSpec(base: nil, partition: referenced.partition,
+                      order: referenced.order ?? order,
+                      frame: frame ?? referenced.frame)
+  }
+}
+
+extension Array where Element == NamedWindow {
+  /// The named window at `index` resolved for its own definition — the
+  /// DEFINITION context, distinct from a projection's `OVER` reference. A
+  /// definition references only an earlier window (its preceding prefix — ISO
+  /// scoping: a `WINDOW` entry sees only those before it), and it copies its
+  /// base into a new window, so the base must carry no frame even for a bare
+  /// reference (`v AS (w)`) — unlike a direct `OVER w`, which may use a framed
+  /// window wholesale. Because a base is always strictly earlier, a chain is
+  /// acyclic by construction and the recursion terminates without a cycle
+  /// guard.
+  ///
+  /// Faults mirror the USE context: an out-of-scope base (not in the prefix)
+  /// `42704`; a definition adding a `PARTITION BY`, copying a framed base, or
+  /// adding an `ORDER BY` over one the base already has, `42601`.
+  internal func resolved(at index: Int) throws(SQLError) -> WindowSpec {
+    let spec = self[index].spec
+    guard let base = spec.base else { return spec }
+    let key = base.lowercased()
+    guard spec.partition.isEmpty else {
+      throw .state("42601",
+                   "a window referencing \"\(base)\" cannot add a PARTITION BY")
+    }
+    // A definition sees only the windows defined before it — its prefix.
+    guard let baseIndex = self[..<index].firstIndex(where: {
+      $0.name.lowercased() == key
+    }) else {
+      throw .state("42704", "window \"\(base)\" is not defined")
+    }
+    let referenced = try resolved(at: baseIndex)
+    // A definition copies its base, so the base carries no frame of its own —
+    // even a bare `v AS (w)` cannot inherit one (only a direct `OVER w` may).
+    guard referenced.frame == nil else {
+      throw .state("42601",
+                   "window \"\(base)\" has a frame and cannot be a base")
+    }
+    // An added `ORDER BY` cannot override the base's.
+    if spec.order != nil, referenced.order != nil {
+      throw .state("42601",
+                   "window \"\(base)\" already orders and its ORDER BY "
+                   + "cannot be overridden")
+    }
+    return WindowSpec(base: nil, partition: referenced.partition,
+                      order: referenced.order ?? spec.order, frame: spec.frame)
   }
 }
 

--- a/SwiftSQL/Tests/SQLTests/Queries/NamedWindowTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/NamedWindowTests.swift
@@ -28,15 +28,20 @@ private func projected(_ sql: String,
 /// a bare `OVER name` reference into a `WindowSpec` carrying only the base name
 /// — the forward reference the resolution prelude later inlines.
 struct NamedWindowParsingTests {
-  @Test func `a bare OVER name parses as a window reference`() throws {
+  @Test func `a bare OVER name parses as a wholesale window reference`()
+      throws {
+    // A bare `OVER w` is a window-name reference — the default, unparenthesized
+    // `WindowSpec(base:)` — using the named window wholesale, framed or not.
     #expect(try projected("SELECT ROW_NUMBER() OVER w FROM T")
                 == .window(function: .number, spec: WindowSpec(base: "w")))
   }
 
-  @Test func `a parenthesised OVER (name) parses as a window reference`()
-      throws {
+  @Test func `a parenthesised OVER (name) parses as an in-line copy`() throws {
+    // `OVER (w)` is a parenthesized in-line specification — `parenthesized:
+    // true` — that copies `w`, distinct from the bare form above.
     #expect(try projected("SELECT ROW_NUMBER() OVER (w) FROM T")
-                == .window(function: .number, spec: WindowSpec(base: "w")))
+                == .window(function: .number,
+                           spec: WindowSpec(base: "w", parenthesized: true)))
   }
 
   @Test func `the WINDOW clause populates the select's named windows`() throws {
@@ -63,10 +68,12 @@ struct NamedWindowParsingTests {
   @Test func `a named window definition may itself carry a base reference`()
       throws {
     // A named window that references another (`v AS (w …)`) parses with the
-    // base name recorded; the prelude rejects the chained reference at use.
+    // base name recorded and `parenthesized: true` (an `AS (…)` definition
+    // copies its base); the prelude resolves the chained reference through to
+    // the base window at use.
     let select = try parse(select:
         "SELECT ROW_NUMBER() OVER v FROM T WINDOW w AS (ORDER BY x), v AS (w)")
-    #expect(select.window[1].spec == WindowSpec(base: "w"))
+    #expect(select.window[1].spec == WindowSpec(base: "w", parenthesized: true))
   }
 }
 
@@ -129,6 +136,60 @@ struct NamedWindowExecutionTests {
         equals:
         "SELECT ROW_NUMBER() OVER (ORDER BY x), "
         + "RANK() OVER (PARTITION BY d ORDER BY x) FROM T")
+  }
+
+  @Test func `a refinement adds an ORDER BY to the base partition`() throws {
+    // `OVER (w ORDER BY x)` refines the base `w` (a PARTITION BY) by adding an
+    // ORDER BY — the ISO merge equals the fully-spelled inline window.
+    try partitioned().expect(
+        "SELECT d, x, ROW_NUMBER() OVER (w ORDER BY x) FROM T "
+        + "WINDOW w AS (PARTITION BY d)",
+        equals:
+        "SELECT d, x, ROW_NUMBER() OVER (PARTITION BY d ORDER BY x) FROM T")
+  }
+
+  @Test func `a chained reference resolves through to the base`() throws {
+    // `v AS (w)` chains to `w`; `OVER v` resolves through both to `w`'s spec.
+    try partitioned().expect(
+        "SELECT d, x, ROW_NUMBER() OVER v FROM T "
+        + "WINDOW w AS (PARTITION BY d ORDER BY x), v AS (w)",
+        equals:
+        "SELECT d, x, ROW_NUMBER() OVER (PARTITION BY d ORDER BY x) FROM T")
+  }
+
+  @Test func `a refinement adds a frame to a frameless base`() throws {
+    // A reference may add a frame the base lacks; the merged window equals the
+    // inline form carrying the base's PARTITION/ORDER plus the added frame.
+    try partitioned().expect(
+        "SELECT d, x, SUM(x) OVER (w ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) "
+        + "FROM T WINDOW w AS (PARTITION BY d ORDER BY x)",
+        equals:
+        "SELECT d, x, SUM(x) OVER (PARTITION BY d ORDER BY x "
+        + "ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM T")
+  }
+
+  @Test func `a parenthesised copy equals the bare form when frameless`()
+      throws {
+    // `OVER (w)` copies a frameless `w`, yielding the same rows as the bare
+    // `OVER w` and the fully inline form.
+    try partitioned().expect(
+        "SELECT d, x, ROW_NUMBER() OVER (w) FROM T "
+        + "WINDOW w AS (PARTITION BY d ORDER BY x)",
+        equals:
+        "SELECT d, x, ROW_NUMBER() OVER (PARTITION BY d ORDER BY x) FROM T")
+  }
+
+  @Test func `a bare reference to a framed window uses it wholesale`() throws {
+    // A bare `OVER w` inherits the named window entirely — its frame included —
+    // so a framed named window is usable by reference (only a refinement is
+    // barred from building on a framed base).
+    try partitioned().expect(
+        "SELECT d, x, SUM(x) OVER w FROM T "
+        + "WINDOW w AS (PARTITION BY d ORDER BY x "
+        + "ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)",
+        equals:
+        "SELECT d, x, SUM(x) OVER (PARTITION BY d ORDER BY x "
+        + "ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM T")
   }
 
   @Test func `a named window orders the query result the same as inline`()
@@ -207,9 +268,10 @@ struct NamedWindowSpecWalkTests {
 // MARK: - Faults
 
 /// A named window reference to an undefined window, a duplicate `WINDOW` name,
-/// and the not-yet-supported refinement / chained-reference shapes each fault a
-/// clean diagnostic on both the run and validate paths — the prelude runs in the
-/// shared `Query.expanded`, so the two cannot diverge.
+/// and the ISO refinement violations — adding a `PARTITION BY`, refining a
+/// framed window, overriding the base's `ORDER BY`, and a cyclic reference —
+/// each fault a clean diagnostic on both run and validate paths, the prelude
+/// running in the shared `Query.expanded` so the two cannot diverge.
 struct NamedWindowFaultTests {
   private func fixture() throws -> FixtureCatalog {
     try Catalog {
@@ -246,18 +308,72 @@ struct NamedWindowFaultTests {
         fails: .state("42601", "window \"W\" is already defined"))
   }
 
-  @Test func `refining a named window is unsupported`() throws {
+  @Test func `a reference that adds a PARTITION BY faults`() throws {
+    // A reference inherits the base's partitioning; it may not add its own.
     try fixture().expect(
-        "SELECT ROW_NUMBER() OVER (w ORDER BY x) FROM T "
-        + "WINDOW w AS (PARTITION BY d)",
-        fails: .state("0A000", "refining a named window is not yet supported"))
+        "SELECT ROW_NUMBER() OVER (w PARTITION BY d) FROM T "
+        + "WINDOW w AS (ORDER BY x)",
+        fails: .state("42601",
+                      "a window referencing \"w\" cannot add a PARTITION BY"))
   }
 
-  @Test func `a chained named-window reference is unsupported`() throws {
+  @Test func `refining a framed window faults`() throws {
+    // A refinement copies the base, so it cannot copy a framed one — here the
+    // reference adds its own frame over an already-framed `w`.
+    try fixture().expect(
+        "SELECT SUM(x) OVER (w ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) "
+        + "FROM T WINDOW w AS (ORDER BY x ROWS BETWEEN 1 PRECEDING AND "
+        + "CURRENT ROW)",
+        fails: .state("42601",
+                      "window \"w\" has a frame and cannot be copied"))
+  }
+
+  @Test func `a parenthesised copy of a framed window faults`() throws {
+    // `OVER (w)` is an in-line spec that copies `w`, so a framed `w` is
+    // rejected even though the reference adds no clauses — unlike a bare
+    // `OVER w`, which uses the framed window wholesale.
+    try fixture().expect(
+        "SELECT SUM(x) OVER (w) FROM T "
+        + "WINDOW w AS (ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)",
+        fails: .state("42601",
+                      "window \"w\" has a frame and cannot be copied"))
+  }
+
+  @Test func `overriding the base's ORDER BY faults`() throws {
+    // A reference adds an ORDER BY only when the base has none.
+    try fixture().expect(
+        "SELECT ROW_NUMBER() OVER (w ORDER BY d) FROM T "
+        + "WINDOW w AS (ORDER BY x)",
+        fails: .state("42601",
+                      "window \"w\" already orders and its ORDER BY "
+                      + "cannot be overridden"))
+  }
+
+  @Test func `a definition referencing a later window is out of scope`()
+      throws {
+    // A definition sees only earlier `WINDOW` entries, so `v AS (w)` cannot
+    // reference a `w` defined after it — even though a projection's `OVER w`
+    // could, the whole clause being in scope there.
     try fixture().expect(
         "SELECT ROW_NUMBER() OVER v FROM T "
-        + "WINDOW w AS (ORDER BY x), v AS (w)",
-        fails: .state("0A000",
-                      "a chained window reference is not yet supported"))
+        + "WINDOW v AS (w), w AS (ORDER BY x)",
+        fails: .state("42704", "window \"w\" is not defined"))
+  }
+
+  @Test func `a self-referencing window is out of its own scope`() throws {
+    // A window references only an earlier definition; a self-reference names a
+    // not-yet-defined window — undefined under the prefix rule, not a cycle.
+    try fixture().expect(
+        "SELECT ROW_NUMBER() OVER w FROM T WINDOW w AS (w)",
+        fails: .state("42704", "window \"w\" is not defined"))
+  }
+
+  @Test func `a definition copying a framed window faults`() throws {
+    // A bare `v AS (w)` copies `w` into a new window, so `w` may carry no frame
+    // — unlike a direct `OVER w`, which uses a framed `w` wholesale.
+    try fixture().expect(
+        "SELECT SUM(x) OVER v FROM T WINDOW w AS "
+        + "(ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW), v AS (w)",
+        fails: .state("42601", "window \"w\" has a frame and cannot be a base"))
   }
 }


### PR DESCRIPTION
`WindowSpec.resolved(against:)` inlined a bare `OVER w` reference and faulted a refinement (`OVER (w …)` with added clauses) or a chained definition (`v AS (w)`) with `0A000`. Implement both per ISO 9075, at the same `Query.expanded` prelude, so run and validate stay in lockstep.

A reference is resolved against the window it names, itself resolved first so a chain (`v AS (w)`) collapses to a base-free spec. A bare reference uses the named window wholesale — its partitioning, `ORDER BY`, and frame. A refinement inherits the base's partitioning, adds its own `ORDER BY` (only when the base has none) and its own frame, but may not build on a framed base. The merged spec takes the base's partitioning, the base's `ORDER BY` else the reference's, and the reference's frame else the base's.

The ISO constraints each fault on both paths: a reference adding a `PARTITION BY`, a refinement of a framed window, or an added `ORDER BY` overriding the base's fault `42601`; an undefined window keeps `42704`; and a reference that cycles back to a window already on the resolution chain (`WINDOW w AS (w)`) faults `SQLError.recursion` rather than recursing until the stack overflows.

NamedWindowTests gains refinement (add ORDER BY, add a frame), chaining, and a bare reference to a framed window as `equals`-the-inline-form execution cases, and the four constraint/cycle faults; the two former not-yet-supported assertions are replaced. Full SwiftSQL and root suites pass, zero warnings.