### PR TITLE
SQLEngine: resolve a window ORDER BY output ordinal

### DIFF
--- a/SwiftSQL/Sources/SQLEngine/AST.swift
+++ b/SwiftSQL/Sources/SQLEngine/AST.swift
@@ -1214,9 +1214,30 @@ public struct Order: Hashable, Sendable {
     /// descending (`DESC`).
     public let ascending: Bool
 
+    /// The 0-based projected output column a window `ORDER BY` output ordinal
+    /// resolved to, or `nil` for a directly written key and for a query-level
+    /// key. A window `ORDER BY n` is bound to its projected expression at the
+    /// shared prelude (`WindowSpec.resolving(ordinals:)`), which substitutes
+    /// the expression here yet records `n - 1` so the origin survives to
+    /// lowering: the window path materialises an ordinal-named computed value
+    /// once below the window and lets the window sort key and the projection
+    /// read that one slot, so a stateful value ranks the row it reports. It is
+    /// the provenance a directly written key that merely equals a projected
+    /// expression (`OVER (ORDER BY tick())`) does not carry, so that key stays
+    /// an independent evaluation. A query-level ordinal resolves at lowering
+    /// through `SortKey.column` instead, so it leaves this `nil`.
+    ///
+    /// The setter is `internal`: the public initializers always construct it
+    /// `nil`, so only the resolver stamps a non-nil value and a module-external
+    /// caller cannot forge one. That keeps the index resolver-generated, hence
+    /// a valid projection ordinal by construction (range-checked to `42703` at
+    /// binding), so `materialise` never reads an out-of-range projected column.
+    public internal(set) var output: Int?
+
     public init(sort: Sort, ascending: Bool = true) {
       self.sort = sort
       self.ascending = ascending
+      self.output = nil
     }
 
     /// A key ordering on a bare (possibly-qualified) column — the common shape,

--- a/SwiftSQL/Sources/SQLEngine/Aggregation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Aggregation.swift
@@ -1363,9 +1363,20 @@ extension Catalog where Self: ~Escapable {
     // filter.
     var source = node
     if let having { source = .select(having, source) }
-    let window = Plan.window(grouped.windowings, source)
-    return window.shaped(distinct: select.distinct, projection: projection,
-                         filter: nil, order: order, limit: select.limit)
+    // Materialise each ordinal-named window ORDER BY value once below the
+    // window, exactly as the plain path does. A grouped projected value is
+    // usually a group-key or aggregate slot (single-evaluation already), but a
+    // non-deterministic scalar naming no ungrouped column (`tick()`) reaches
+    // here too, so an ordinal over one must rank the value it reports rather
+    // than a second evaluation. The window output begins past the grouped slots
+    // — the group keys and the aggregate results.
+    let hoisted = SQLEngine.materialise(grouped.windowings, projection, order,
+                                        width: keys.count + aggregations.count,
+                                        below: source)
+    let window = Plan.window(hoisted.windowings, hoisted.chain)
+    return window.shaped(distinct: select.distinct,
+                         projection: hoisted.projection, filter: nil,
+                         order: hoisted.order, limit: select.limit)
   }
 }
 

--- a/SwiftSQL/Sources/SQLEngine/Compilation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Compilation.swift
@@ -113,6 +113,139 @@ internal func distinct(_ keys: Array<Order.Key>, _ order: Array<SortKey>,
   return bound
 }
 
+/// The window `chain`, its `windowings`, `projection`, and query `order`
+/// rewritten so a window `ORDER BY` value the projection also reports is
+/// evaluated once below the window rather than in both the window node and the
+/// projection.
+///
+/// The shared `Query.expanded` prelude binds a window `ORDER BY` output ordinal
+/// to the projected expression it names, so `OVER (ORDER BY 1)` orders on the
+/// value of projected column 1. Lowering that binding as the window's sort key
+/// and again as the projection column would evaluate the expression twice —
+/// once inside the window node to fix the row order, once in the projection to
+/// report the value — so a stateful or non-deterministic value (a registered
+/// `tick()`, `random()`) would order the ranking on one set of values yet
+/// report another, the ranking not matching the reported column. This mirrors
+/// the query-level ordinal's materialisation (`Plan.materialised`): each such
+/// value is computed once in a projection below the window (a fresh source slot
+/// the passed-through rows carry), the window's sort key reads that slot, and
+/// the projection reads it too, so the value is evaluated once and the ranking
+/// matches the reported column.
+///
+/// Only an ordinal-named computed value is materialised, decided by provenance
+/// rather than by structural equality. A window `ORDER BY` sort key carries the
+/// projected output it named (`SortKey.column`, set from the ordinal the
+/// prelude resolved) only when it originated from an ordinal; a directly
+/// written key carries none. So a key that names an output is shared with that
+/// projection column, while a directly written `OVER (ORDER BY tick())` — even
+/// one equal to a projected `tick()` — carries no output and is left an
+/// independent evaluation, ranking the row on its own values and reporting the
+/// projection's separately. Inferring the relationship from `Term` equality
+/// instead would fold those two `tick()` occurrences into one, changing both
+/// the reported values and the ranking of a stateful routine. For the same
+/// reason the output index — not the term — allocates the hoisted slots: two
+/// distinct outputs an ordinal names (`ORDER BY 1, 2` over two `tick()`
+/// columns) take independent slots and evaluate independently, sharing a slot
+/// only when two keys name the one output.
+///
+/// A key that names an output but is a bare slot or constant already reads a
+/// stored cell — a plain projected column, a `SELECT *` output, a grouped
+/// key/aggregate slot — so reading it twice yields the same value; it is left
+/// in place and, when no key needs materialising, the plan is unchanged.
+/// `width` is the source slot count — the window results begin past it — so a
+/// materialised value takes a slot after the source and the window results
+/// shift right by the count materialised.
+internal func materialise(_ windowings: Array<Windowing>,
+                          _ projection: Array<Term>, _ order: Array<SortKey>,
+                          width: Int, below chain: Plan)
+    -> (chain: Plan, windowings: Array<Windowing>,
+        projection: Array<Term>, order: Array<SortKey>) {
+  // Map each distinct ordinal-named output column to a fresh source slot at
+  // `width + its offset in `carriers``, in first-seen order. Provenance
+  // (`key.column`) is the sole key — never `Term` equality. A window ORDER BY
+  // key carries the output it named only when it came from an ordinal, so two
+  // keys naming the one output share a slot, while two keys naming separate
+  // outputs take independent slots even when those outputs hold an equal
+  // stateful term (`SELECT tick(), tick(), … OVER (ORDER BY 1, 2)` hoists both
+  // occurrences, each evaluated once). A directly written key carries no output
+  // and is never hoisted, so an `OVER (ORDER BY tick())` merely equal to a
+  // projected `tick()` stays a separate evaluation rather than folding into the
+  // ordinal's slot.
+  var slot = Dictionary<Int, Int>()
+  var carriers = Array<Term>()
+  for windowing in windowings {
+    for key in windowing.order {
+      guard let column = key.column, slot[column] == nil else { continue }
+      // Defense in depth: provenance is resolver-generated and unforgeable, so
+      // `column` is always a valid projection index — the ordinal was range
+      // checked to 42703 at binding — and this guard never fires on real input.
+      // It keeps `materialise` total: a future internal miscompile skips
+      // hoisting rather than trapping on an out-of-range `projection[column]`.
+      // It never throws, so the validate path — which skips `materialise` —
+      // still agrees with the run path.
+      guard projection.indices.contains(column) else { continue }
+      switch key.term {
+      case .slot, .constant, .parameter:
+        // A bare slot or constant output already reads a stored cell, so
+        // reading it twice yields the same value — left in place, not hoisted.
+        continue
+      default:
+        break
+      }
+      slot[column] = width + carriers.count
+      carriers.append(projection[column])
+    }
+  }
+  guard !carriers.isEmpty else {
+    return (chain, windowings, projection, order)
+  }
+  let count = carriers.count
+  // The below-window projection passes every source slot through, then appends
+  // each hoisted output value once.
+  let passed = (0 ..< width).map { Term.slot($0) }
+  let source = Plan.project(passed + carriers, chain)
+  // The window results shift right past the hoisted slots; source slots keep
+  // their positions. The map is complete, since `remapped` demands every read
+  // slot resolve.
+  var shift = Dictionary<Int, Int>(minimumCapacity: width + windowings.count)
+  for index in 0 ..< width { shift[index] = index }
+  for index in windowings.indices {
+    shift[width + index] = width + count + index
+  }
+  // A window ORDER BY key that named a hoisted output reads that output's slot;
+  // every other key — a directly written one, or an ordinal over a bare cell —
+  // reads a source slot below `width`, preserved by the passthrough, unchanged.
+  let ordered = windowings.map { windowing in
+    Windowing(function: windowing.function, partition: windowing.partition,
+              order: windowing.order.map { key in
+                if let column = key.column, let hoisted = slot[column] {
+                  SortKey(term: .slot(hoisted), ascending: key.ascending,
+                          column: column)
+                } else {
+                  key
+                }
+              }, frame: windowing.frame)
+  }
+  // The projection reads a hoisted output from its slot; every other term
+  // shifts its window-slot reads past the hoisted slots (a source-slot read is
+  // unchanged).
+  let projected = projection.indices.map { column -> Term in
+    if let hoisted = slot[column] {
+      .slot(hoisted)
+    } else {
+      projection[column].remapped(through: shift)
+    }
+  }
+  // A query ORDER BY key likewise shifts its window-slot reads; a key naming an
+  // output keeps its column, since the outer materialisation reads the
+  // rewritten projection.
+  let keys = order.map { key in
+    SortKey(term: key.term.remapped(through: shift), ascending: key.ascending,
+            column: key.column)
+  }
+  return (source, ordered, projected, keys)
+}
+
 extension Plan {
   /// This source plan wrapped in the projection/limit/sort/select operators,
   /// omitting each layer when its clause is absent. The `projection`, `filter`,
@@ -1475,6 +1608,21 @@ extension Catalog where Self: ~Escapable {
   internal borrowing func compile(_ select: Select,
                                   _ context: Context = Context())
       throws(SQLError) -> Plan {
+    // Run the window-resolution prelude the `Query` wrapper runs (via
+    // `Query.expanded`) before it reaches here: inline every `OVER w` named-
+    // window reference to its `WINDOW` definition and bind every window
+    // `ORDER BY` output ordinal to the projected expression it names
+    // (`Select.inlined`). A select reaching this entry directly (a bare
+    // `compile(select)`, not through the wrapper) would else skip it, so
+    // `SELECT b, ROW_NUMBER() OVER (ORDER BY 1) FROM T` binds the ordinal
+    // against the source columns in the window lowering rather than the
+    // projected `b`, ranking differently from the same statement compiled
+    // through the wrapper. Running it here is the one normalization both
+    // entries share, so the two agree by construction and the window lowering
+    // only ever meets an unbound ordinal from a genuine `SELECT *`. It is
+    // idempotent — a select the wrapper already inlined carries no ordinal or
+    // reference for the second pass to rewrite.
+    let select = try select.inlined
     // A `GROUP BY GROUPING SETS (…)` never reaches here: `Query.expanded` (run
     // at every pipeline entry) has already rewritten it to a `UNION ALL` of
     // `.arm` selects, so `compile(_ select:)` sees only `.keys`/`.arm`.
@@ -1746,12 +1894,20 @@ extension Catalog where Self: ~Escapable {
       // The function-independent structural frame check — a reversed or inverted
       // frame — that `reject(for:)` runs for a referenced window.
       if let frame = spec.frame { try frame.check() }
-      // A window `ORDER BY` output ordinal has no meaning — there is no output
-      // to name — rejected here as it is for a referenced window's spec.
+      // A window `ORDER BY` output ordinal is bound to its projected expression
+      // by the shared `Query.expanded` prelude before this validate (an
+      // unreferenced definition alike), so one reaches here only for a `SELECT
+      // *`, whose outputs the prelude cannot name before the source scope
+      // resolves. It names the position-th `SELECT *` output column,
+      // range-checked here against the scope as a query-level ordinal is — an
+      // out-of-range one faults `.column` (42703) — the same source column a
+      // referenced definition binds through `Scope.window`.
       for key in spec.order?.keys ?? [] {
-        if case .ordinal = key.sort {
-          throw .state("0A000",
-                       "a window ORDER BY output ordinal is not supported")
+        if case let .ordinal(position) = key.sort {
+          let width = scope.width(of: .all)
+          guard position >= 1, position <= width else {
+            throw .column("\(position)")
+          }
         }
       }
       // A definition is validated for well-formedness against the input scope,
@@ -1926,8 +2082,16 @@ extension Catalog where Self: ~Escapable {
     if let predicate {
       chain = .select(predicate.remapped(through: slot), chain)
     }
-    let node = Plan.window(windowed.windowings, chain)
-    return node.shaped(distinct: select.distinct, projection: projection,
-                       filter: nil, order: order, limit: select.limit)
+    // Materialise each window ORDER BY value the projection also reports once
+    // below the window, so a stateful ordinal-named value is evaluated once and
+    // the ranking matches the reported column (mirroring the query-level
+    // ordinal). A window over only bare-column or unshared values is unchanged.
+    let hoisted = SQLEngine.materialise(windowed.windowings, projection,
+                                        order, width: combined.count,
+                                        below: chain)
+    let node = Plan.window(hoisted.windowings, hoisted.chain)
+    return node.shaped(distinct: select.distinct,
+                       projection: hoisted.projection, filter: nil,
+                       order: hoisted.order, limit: select.limit)
   }
 }

--- a/SwiftSQL/Sources/SQLEngine/Grouped.swift
+++ b/SwiftSQL/Sources/SQLEngine/Grouped.swift
@@ -606,8 +606,11 @@ extension Grouped: WindowSurface {
   /// Lowers a window's `ORDER BY` to grouped-space sort keys, major to minor —
   /// each key a value expression over the grouped record (an aggregate result
   /// or a `GROUP BY` key, a non-grouped column faulting `.grouping`). An output
-  /// ordinal names a projected column, meaningless as the window order fixing
-  /// the input row order, so it faults as it does over a plain source.
+  /// ordinal naming a projected column is bound to that column's expression by
+  /// the shared `Query.expanded` prelude before this lowering. The one form the
+  /// prelude cannot name — a `SELECT *` — is independently rejected over a
+  /// grouped source (a grouped `SELECT *` is ill-defined), before this lowering
+  /// runs, so an ordinal cannot reach here; the guard is defensive.
   internal func window(order: Order, _ routines: Routines = [:],
                        subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
@@ -617,11 +620,18 @@ extension Grouped: WindowSurface {
       switch key.sort {
       case .ordinal:
         throw .state("0A000",
-                     "a window ORDER BY output ordinal is not supported")
+                     "a window ORDER BY output ordinal is not allowed with "
+                     + "SELECT *")
       case let .expression(expression):
+        // A window `ORDER BY` ordinal was substituted for its projected
+        // expression at the prelude, recording the 0-based output it named in
+        // `key.output`; carry it as the sort key's `column` so a grouped
+        // window's ordinal-named computed value materialises once below the
+        // window (a directly written key carries no output, staying
+        // independent).
         try keys.append(SortKey(term: resolve(expression, routines,
                                               subquery: subquery),
-                                ascending: key.ascending, column: nil))
+                                ascending: key.ascending, column: key.output))
       }
     }
     return keys

--- a/SwiftSQL/Sources/SQLEngine/Resolution.swift
+++ b/SwiftSQL/Sources/SQLEngine/Resolution.swift
@@ -1702,6 +1702,15 @@ internal struct SortKey: Equatable {
     SortKey(term: term.remapped(through: slot), ascending: ascending,
             column: column)
   }
+
+  /// Two keys are equal when they order on the same value in the same
+  /// direction. The `column` is provenance — which projected output an ordinal
+  /// named — not part of the ordered value, so it is excluded: two windows
+  /// ordering on the same term share one appended slot (`Windowing` equality)
+  /// whether one came from an ordinal and the other was written directly.
+  internal static func ==(lhs: SortKey, rhs: SortKey) -> Bool {
+    lhs.term == rhs.term && lhs.ascending == rhs.ascending
+  }
 }
 
 /// The resolved sort keys `order` lowers to, in major-to-minor order — each

--- a/SwiftSQL/Sources/SQLEngine/Scope.swift
+++ b/SwiftSQL/Sources/SQLEngine/Scope.swift
@@ -949,9 +949,11 @@ internal struct Scope {
   /// The result type of a window function under `validate` — its result type
   /// (the ranking functions `.integer`), validating each `PARTITION BY` key and
   /// window `ORDER BY` key as a run evaluates them (an unknown column, a bad
-  /// operand, or an ill-typed call inside one faults). An unsupported function,
-  /// or an output-ordinal window sort key (meaningless for the input order),
-  /// faults the feature diagnostic in parity with the run's compile.
+  /// operand, or an ill-typed call inside one faults). An unsupported function
+  /// faults the feature diagnostic in parity with the run's compile; an output
+  /// ordinal is bound to its projected expression before this validate, so one
+  /// survives only for a `SELECT *`, whose position-th output column it names —
+  /// range-checked as a query-level ordinal is.
   private func window(_ function: WindowFunction, over spec: WindowSpec,
                       _ routines: Routines,
                       subquery: SubqueryCheck = .unsupported)
@@ -1000,9 +1002,18 @@ internal struct Scope {
     }
     for key in spec.order?.keys ?? [] {
       switch key.sort {
-      case .ordinal:
-        throw .state("0A000",
-                     "a window ORDER BY output ordinal is not supported")
+      case let .ordinal(position):
+        // An output ordinal is bound to its projected expression by the shared
+        // `Query.expanded` prelude before this validate, so one reaches here
+        // only for a `SELECT *`, whose outputs the prelude cannot name before
+        // the source scope resolves. It names the position-th `SELECT *`
+        // output column, range-checked here as a query-level ordinal is — an
+        // out-of-range one faults `.column` (42703) — in parity with the
+        // compile that binds it to that source column.
+        let width = self.width(of: .all)
+        guard position >= 1, position <= width else {
+          throw .column("\(position)")
+        }
       case let .expression(expression):
         _ = try validate(expression, routines, subquery: subquery)
       }

--- a/SwiftSQL/Sources/SQLEngine/Windowed.swift
+++ b/SwiftSQL/Sources/SQLEngine/Windowed.swift
@@ -869,6 +869,52 @@ extension WindowSpec {
                       order: referenced.order ?? order,
                       frame: frame ?? referenced.frame)
   }
+
+  /// This specification with each `ORDER BY` output-ordinal sort key resolved
+  /// to the projected expression it names — `outputs[n - 1]` for `ORDER BY n`,
+  /// the same 1-based projected column a query-level `ORDER BY` ordinal names,
+  /// so a window `ORDER BY 1` orders on the value of projected column 1. It is
+  /// run at the shared `Query.expanded` prelude, so the compile and validate
+  /// paths bind an ordinal identically by construction.
+  ///
+  /// `outputs` are the query's projected expressions in output order, or `nil`
+  /// for a `SELECT *` whose outputs are not statically named here — an ordinal
+  /// against one is left in place for the window path to bind against the
+  /// expanded `SELECT *` columns once the source scope resolves
+  /// (`Scope.window(order:)`). An `n` outside `1 ... outputs.count` faults
+  /// `SQLError.column` (spelled as the ordinal), the same out-of-range fault a
+  /// query-level ordinal raises. A named projected column that is itself a
+  /// window faults: a window `ORDER BY` fixes the source row order the ranking
+  /// reads, and a window value does not exist until every windowing is computed
+  /// from those rows, so it cannot be an input sort key.
+  internal func resolving(ordinals outputs: Array<Expression>?)
+      throws(SQLError) -> WindowSpec {
+    guard let outputs, let order else { return self }
+    let keys = try order.keys.map { key throws(SQLError) -> Order.Key in
+      guard case let .ordinal(position) = key.sort else { return key }
+      guard position >= 1, position <= outputs.count else {
+        throw .column("\(position)")
+      }
+      let expression = outputs[position - 1]
+      guard !expression.windowed else {
+        throw .state("0A000",
+                     "a window ORDER BY cannot order by a window output column")
+      }
+      // Substitute the named expression, but record the 0-based output it came
+      // from (`position - 1`) so lowering can materialise that projected value
+      // once below the window and rank the row it reports — provenance a
+      // directly written key equal to a projection does not carry. The setter
+      // is internal, so only this resolver stamps it; a public caller's key
+      // always carries `nil`.
+      var resolved = Order.Key(sort: .expression(expression),
+                               ascending: key.ascending)
+      resolved.output = position - 1
+      return resolved
+    }
+    return WindowSpec(base: base, parenthesized: parenthesized,
+                      partition: partition, order: Order(keys: keys),
+                      frame: frame)
+  }
 }
 
 extension Array where Element == NamedWindow {
@@ -959,6 +1005,49 @@ extension Expression {
       })
     }
   }
+
+  /// This expression with every window's `ORDER BY` output ordinal resolved to
+  /// the projected expression it names (`WindowSpec.resolving(ordinals:)`) —
+  /// the companion pass to `resolving(_:)`, over the already-inlined projection
+  /// and `ORDER BY` so a window `OVER (ORDER BY 1)` orders on projected column
+  /// 1. It descends exactly as `collect(windows:)` does: a nested scalar
+  /// `subquery` or an aggregate's argument is its own scope, so neither is
+  /// descended, and a window cannot nest another so its own spec is not
+  /// re-descended past the ordinal rewrite.
+  internal func resolving(ordinals outputs: Array<Expression>?)
+      throws(SQLError) -> Expression {
+    switch self {
+    case .column, .literal, .subquery, .aggregate:
+      self
+    case let .window(function, spec):
+      .window(function: function, spec: try spec.resolving(ordinals: outputs))
+    case let .call(name, arguments):
+      .call(name: name, arguments: try arguments.map { argument throws(SQLError)
+        in try argument.resolving(ordinals: outputs)
+      })
+    case let .binary(op, lhs, rhs):
+      .binary(op, try lhs.resolving(ordinals: outputs),
+              try rhs.resolving(ordinals: outputs))
+    case let .case(whens, otherwise):
+      .case(try whens.map { branch throws(SQLError) in
+        When(when: try branch.when.resolving(ordinals: outputs),
+             then: try branch.then.resolving(ordinals: outputs))
+      }, else: try otherwise?.resolving(ordinals: outputs))
+    case let .cast(operand, type):
+      .cast(try operand.resolving(ordinals: outputs), type)
+    case let .coalesce(arguments):
+      .coalesce(try arguments.map { argument throws(SQLError) in
+        try argument.resolving(ordinals: outputs)
+      })
+    case let .nullif(lhs, rhs):
+      .nullif(try lhs.resolving(ordinals: outputs),
+              try rhs.resolving(ordinals: outputs))
+    case let .grouping(arguments):
+      .grouping(try arguments.map { argument throws(SQLError) in
+        try argument.resolving(ordinals: outputs)
+      })
+    }
+  }
 }
 
 extension Predicate.Operand {
@@ -969,6 +1058,18 @@ extension Predicate.Operand {
     switch self {
     case let .expression(expression):
       .expression(try expression.resolving(windows))
+    case .parameter:
+      self
+    }
+  }
+
+  /// This operand with any window ordinal in an expression operand bound to its
+  /// projected expression — a `:parameter` carries none.
+  fileprivate func resolving(ordinals outputs: Array<Expression>?)
+      throws(SQLError) -> Predicate.Operand {
+    switch self {
+    case let .expression(expression):
+      .expression(try expression.resolving(ordinals: outputs))
     case .parameter:
       self
     }
@@ -1032,6 +1133,74 @@ extension Predicate {
       .not(try operand.resolving(windows))
     }
   }
+
+  /// This predicate with every window's `ORDER BY` output ordinal bound to its
+  /// projected expression — the `Expression.resolving(ordinals:)` companion for
+  /// a `CASE` guard's predicate. It mirrors `resolving(_:)`'s descent; an
+  /// `EXISTS`/`IN (Q)` subquery is its own scope, so a window inside it is not
+  /// descended here.
+  internal func resolving(ordinals outputs: Array<Expression>?)
+      throws(SQLError) -> Predicate {
+    switch self {
+    case let .comparison(left, op, right):
+      .comparison(left: try left.resolving(ordinals: outputs), op: op,
+                  right: try right.resolving(ordinals: outputs))
+    case let .bound(left, op, parameter):
+      .bound(left: try left.resolving(ordinals: outputs), op: op,
+             parameter: parameter)
+    case let .null(expression, negated):
+      .null(try expression.resolving(ordinals: outputs), negated: negated)
+    case let .membership(operand, values, negated):
+      .membership(try operand.resolving(ordinals: outputs),
+                  try values.map { value throws(SQLError) in
+                    try value.resolving(ordinals: outputs)
+                  }, negated: negated)
+    case let .rows(lhs, op, rhs):
+      .rows(try lhs.map { l throws(SQLError) in
+        try l.resolving(ordinals: outputs)
+      }, op, try rhs.map { r throws(SQLError) in
+        try r.resolving(ordinals: outputs)
+      })
+    case let .among(lhs, rows, negated):
+      .among(try lhs.map { l throws(SQLError) in
+        try l.resolving(ordinals: outputs)
+      }, try rows.map { row throws(SQLError) in
+        try row.map { r throws(SQLError) in try r.resolving(ordinals: outputs) }
+      }, negated: negated)
+    case let .like(operand, pattern, escape, negated):
+      .like(try operand.resolving(ordinals: outputs),
+            pattern: try pattern.resolving(ordinals: outputs),
+            escape: try escape?.resolving(ordinals: outputs), negated: negated)
+    case let .between(test, lower, upper, negated):
+      .between(try test.resolving(ordinals: outputs),
+               try lower.resolving(ordinals: outputs),
+               try upper.resolving(ordinals: outputs), negated: negated)
+    case let .distinct(lhs, rhs, negated):
+      .distinct(try lhs.resolving(ordinals: outputs),
+                try rhs.resolving(ordinals: outputs), negated: negated)
+    case .exists:
+      self
+    case let .within(lhs, query, negated):
+      .within(try lhs.map { l throws(SQLError) in
+        try l.resolving(ordinals: outputs)
+      }, query, negated: negated)
+    case let .quantified(lhs, op, quantifier, query):
+      .quantified(try lhs.map { l throws(SQLError) in
+        try l.resolving(ordinals: outputs)
+      }, op, quantifier, query)
+    case let .truth(inner, value, negated):
+      .truth(try inner.resolving(ordinals: outputs), value: value,
+             negated: negated)
+    case let .and(lhs, rhs):
+      .and(try lhs.resolving(ordinals: outputs),
+           try rhs.resolving(ordinals: outputs))
+    case let .or(lhs, rhs):
+      .or(try lhs.resolving(ordinals: outputs),
+          try rhs.resolving(ordinals: outputs))
+    case let .not(operand):
+      .not(try operand.resolving(ordinals: outputs))
+    }
+  }
 }
 
 extension Select {
@@ -1048,6 +1217,14 @@ extension Select {
   /// undefined window faults `42704` — each on both paths, since the prelude is
   /// shared. A select with no window clause and no window function is returned
   /// unchanged.
+  ///
+  /// The prelude also binds every window `ORDER BY` output ordinal to the
+  /// projected expression it names (`resolving(ordinals:)`), so a named window
+  /// definition, an inline `OVER (…)`, and a `OVER w` reference resolve an
+  /// ordinal identically. The query's projected expressions are the ordinal
+  /// surface, so the rewrite runs after the columns/expressions projection is
+  /// known but reads its pre-inline form (a window a column names is rejected,
+  /// not inlined into another window's order).
   internal var inlined: Select {
     get throws(SQLError) {
       // A duplicate named-window definition is a semantic error regardless of
@@ -1059,17 +1236,33 @@ extension Select {
                        "window \"\(definition.name)\" is already defined")
         }
       }
+      // The projected expressions a window `ORDER BY` ordinal names, in output
+      // order (nil for a `SELECT *`, whose outputs are not statically known).
+      let outputs = projection.positional
+      // Bind each named-window definition's ORDER BY ordinal — an unreferenced
+      // definition is validated only by `validate(named:)`, so its ordinal must
+      // resolve here exactly as a referenced one's does below.
+      let definitions = try window.map { definition throws(SQLError) in
+        NamedWindow(name: definition.name,
+                    spec: try definition.spec.resolving(ordinals: outputs))
+      }
       // Nothing to inline unless the projection or `ORDER BY` bears a window.
       // The clause is kept either way — compile validates every named
       // definition against the source scope, whether or not it is referenced,
       // rather than silently discarding an unused one.
-      guard windows else { return self }
+      guard windows else {
+        return Select(distinct: distinct, projection: projection, from: from,
+                      joins: joins, predicate: predicate, grouping: grouping,
+                      having: having, window: definitions, order: order,
+                      limit: limit)
+      }
       let projection: Projection = switch projection {
       case .all, .columns:
         projection
       case let .expressions(items):
         .expressions(try items.map { item throws(SQLError) in
-          Projected(expression: try item.expression.resolving(window),
+          Projected(expression: try item.expression.resolving(window)
+                        .resolving(ordinals: outputs),
                     alias: item.alias)
         })
       }
@@ -1079,7 +1272,8 @@ extension Select {
           case .ordinal:
             key
           case let .expression(expression):
-            Order.Key(sort: .expression(try expression.resolving(window)),
+            Order.Key(sort: .expression(try expression.resolving(window)
+                          .resolving(ordinals: outputs)),
                       ascending: key.ascending)
           }
         })
@@ -1088,7 +1282,27 @@ extension Select {
       }
       return Select(distinct: distinct, projection: projection, from: from,
                     joins: joins, predicate: predicate, grouping: grouping,
-                    having: having, window: window, order: order, limit: limit)
+                    having: having, window: definitions, order: order,
+                    limit: limit)
+    }
+  }
+}
+
+extension Projection {
+  /// The projected expressions a positional `ORDER BY` ordinal names, in output
+  /// order — a bare-column list yields each column reference, an `expressions`
+  /// list each item's expression, and a `*` `nil` (its outputs are not
+  /// statically known before expansion). A window `ORDER BY` ordinal binds
+  /// against this list exactly as a query-level ordinal binds against the
+  /// projection.
+  internal var positional: Array<Expression>? {
+    switch self {
+    case .all:
+      nil
+    case let .columns(columns):
+      columns.map { Expression.column($0) }
+    case let .expressions(items):
+      items.map(\.expression)
     }
   }
 }
@@ -1101,12 +1315,15 @@ extension Scope {
   /// its direction preserved.
   ///
   /// A window `ORDER BY` fixes the input row order the ranking reads, so each
-  /// key is a value expression over the source columns — never an output
-  /// ordinal or alias (there is no projected output to name at this point). An
-  /// integer-literal sort key parses as an `ordinal`, which names an output
-  /// column, so it is meaningless here and faults the feature diagnostic on
-  /// both the run and validate paths (kept in parity through the shared
-  /// resolver).
+  /// key is a value expression over the source columns. An integer-literal sort
+  /// key parses as an `ordinal` naming a projected output column; the shared
+  /// `Query.expanded` prelude binds it to that column's expression
+  /// (`resolving(ordinals:)`) before this lowering, so a resolvable ordinal
+  /// never reaches here — except a `SELECT *`, whose outputs are not statically
+  /// named before the source scope resolves, so its ordinals reach here
+  /// unbound. Such an ordinal binds to the source column `SELECT *` projects at
+  /// that position (`terms(.all)`), so `OVER (ORDER BY 1)` orders on projected
+  /// column 1 exactly as a query-level ordinal does over `SELECT *`.
   internal func window(order: Order, _ routines: Routines = [:],
                        subquery: Resolution = .unsupported)
       throws(SQLError) -> Array<SortKey> {
@@ -1114,13 +1331,28 @@ extension Scope {
     keys.reserveCapacity(order.keys.count)
     for key in order.keys {
       switch key.sort {
-      case .ordinal:
-        throw .state("0A000",
-                     "a window ORDER BY output ordinal is not supported")
+      case let .ordinal(position):
+        // Reached only for a `SELECT *` (the prelude binds every other
+        // projection form's ordinal before this); bind it to the position-th
+        // source column `SELECT *` projects. An out-of-range ordinal faults
+        // `.column` (42703), the same fault a query-level out-of-range ordinal
+        // raises.
+        let outputs = try terms(.all)
+        guard position >= 1, position <= outputs.count else {
+          throw .column("\(position)")
+        }
+        keys.append(SortKey(term: outputs[position - 1],
+                            ascending: key.ascending, column: nil))
       case let .expression(expression):
+        // A window `ORDER BY` ordinal was substituted for its projected
+        // expression at the prelude, which recorded the 0-based output it
+        // named in `key.output`; carry it as the sort key's `column` so the
+        // materialisation below the window shares one evaluation with the
+        // projection. A directly written key carries no output, so it stays an
+        // independent evaluation.
         try keys.append(SortKey(term: term(expression, routines,
                                             subquery: subquery),
-                                ascending: key.ascending, column: nil))
+                                ascending: key.ascending, column: key.output))
       }
     }
     return keys
@@ -1325,8 +1557,10 @@ internal struct Windowed {
   }
 
   /// The output-space projected terms, recording each item's output name for an
-  /// `ORDER BY` to name. A `SELECT *` over a window query has no well-defined
-  /// meaning (which windows?), so it faults.
+  /// `ORDER BY` to name. A `SELECT *` projects every source column — a `*`
+  /// holds no window itself, so the only window query it appears in orders by a
+  /// window in the query `ORDER BY`, over the plain source columns `*` names —
+  /// exactly as a plain `SELECT *` does.
   internal mutating func terms(_ projection: Projection,
                                _ routines: Routines = [:],
                                subquery: Resolution = .unsupported)
@@ -1336,8 +1570,21 @@ internal struct Windowed {
     // that `subquery` carries.
     switch projection {
     case .all:
-      throw .state("0A000",
-                   "SELECT * is not allowed with a window function")
+      // Every source column the `SELECT *` names, in chain order — the merged
+      // `NATURAL`/`USING` columns then each real column (`Scope.terms(.all)`),
+      // each remapped into the packed source slot space and recorded under its
+      // output name so a query `ORDER BY` may name it. A window `ORDER BY`
+      // ordinal binds against these outputs (`window(order:)`).
+      let outputs = try scope.terms(.all)
+      let names = scope.names
+      var terms = Array<Term>()
+      terms.reserveCapacity(outputs.count)
+      for index in outputs.indices {
+        let term = outputs[index].remapped(through: slot)
+        terms.append(term)
+        record(names[index], index, term)
+      }
+      return terms
     case let .columns(columns):
       var terms = Array<Term>()
       terms.reserveCapacity(columns.count)

--- a/SwiftSQL/Tests/SQLTests/Queries/NamedWindowTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/NamedWindowTests.swift
@@ -377,3 +377,49 @@ struct NamedWindowFaultTests {
         fails: .state("42601", "window \"w\" has a frame and cannot be a base"))
   }
 }
+
+// MARK: - A named window ORDER BY output ordinal
+
+/// A `WINDOW` clause definition's `ORDER BY` ordinal binds to the projected
+/// column it names, exactly as an inline one does — a referenced definition
+/// through the same inlining, and an unreferenced one through the
+/// definition-only `validate(named:)`, so the two agree on the ordinal.
+struct NamedWindowOrdinalTests {
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["d": .integer, "x": .integer]) {
+        Row(2, 10)
+        Row(1, 30)
+        Row(3, 20)
+      }
+    }
+  }
+
+  @Test func `a referenced definition's ordinal names the projected column`()
+      throws {
+    // Ordinal 2 names projected column x, so `w` orders by x — the same rows as
+    // the fully-spelled inline window.
+    try fixture().expect(
+        "SELECT d, x, ROW_NUMBER() OVER w FROM T WINDOW w AS (ORDER BY 2)",
+        equals: "SELECT d, x, ROW_NUMBER() OVER (ORDER BY x) FROM T")
+  }
+
+  @Test func `an unreferenced definition's ordinal resolves and is accepted`()
+      throws {
+    // An unused `WINDOW` definition is validated by `validate(named:)`; its
+    // ordinal 1 binds to projected column d and resolves cleanly, so the query
+    // yields the plain projection rather than faulting the ordinal.
+    try fixture().expect(
+        "SELECT d, x FROM T WINDOW w AS (ORDER BY 1)",
+        equals: "SELECT d, x FROM T")
+  }
+
+  @Test func `an unreferenced definition's out-of-range ordinal faults`()
+      throws {
+    // Two projected columns, so ordinal 9 is out of range — `validate(named:)`
+    // binds it against the same projection a reference would and faults
+    // `.column`, on both paths.
+    try fixture().expect(
+        "SELECT d, x FROM T WINDOW w AS (ORDER BY 9)", fails: .column("9"))
+  }
+}

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -365,6 +365,255 @@ struct RowNumberExecutionTests {
   }
 }
 
+// MARK: - Window ORDER BY output ordinal
+
+/// A window `ORDER BY` may name a projected output column by its 1-based
+/// ordinal — `OVER (ORDER BY 1)` orders on the value of projected column 1,
+/// exactly as a query-level `ORDER BY` ordinal names an output. The shared
+/// `Query.expanded` prelude binds the ordinal to that column's expression, so
+/// the inline form, a `WINDOW` clause definition, and the compile and validate
+/// paths resolve it identically.
+struct WindowOrderOrdinalTests {
+  private func fixture() throws -> FixtureCatalog {
+    // Ordering by a (1, 2, 3) differs from ordering by b (also from the source
+    // order), so an ordinal naming a distinct column yields a distinct ranking.
+    try Catalog {
+      Relation("T", ["a": .integer, "b": .integer]) {
+        Row(3, 1)
+        Row(1, 3)
+        Row(2, 2)
+      }
+    }
+  }
+
+  @Test func `an ordinal orders the window by the projected column`() throws {
+    // Ordinal 1 names projected column a, so the window orders by a: the row
+    // with a=1 numbers 1, a=2 numbers 2, a=3 numbers 3, kept in source order.
+    try fixture().expect(
+        "SELECT a, b, ROW_NUMBER() OVER (ORDER BY 1) FROM T",
+        yields: [[3, 1, 3], [1, 3, 1], [2, 2, 2]])
+  }
+
+  @Test func `an ordinal equals the named projected column`() throws {
+    try fixture().expect(
+        "SELECT a, b, ROW_NUMBER() OVER (ORDER BY 1) FROM T",
+        equals: "SELECT a, b, ROW_NUMBER() OVER (ORDER BY a) FROM T")
+  }
+
+  @Test func `a second ordinal names the second projected column`() throws {
+    try fixture().expect(
+        "SELECT a, b, ROW_NUMBER() OVER (ORDER BY 2) FROM T",
+        equals: "SELECT a, b, ROW_NUMBER() OVER (ORDER BY b) FROM T")
+  }
+
+  @Test func `a named window ORDER BY ordinal equals its inline form`() throws {
+    try fixture().expect(
+        "SELECT a, b, ROW_NUMBER() OVER w FROM T WINDOW w AS (ORDER BY 1)",
+        equals: "SELECT a, b, ROW_NUMBER() OVER (ORDER BY a) FROM T")
+  }
+
+  @Test func `a named window ordinal equals its inline ordinal form`() throws {
+    try fixture().expect(
+        "SELECT a, b, ROW_NUMBER() OVER w FROM T WINDOW w AS (ORDER BY 2)",
+        equals: "SELECT a, b, ROW_NUMBER() OVER (ORDER BY 2) FROM T")
+  }
+
+  @Test func `a bare-column projection binds a window ORDER BY ordinal`()
+      throws {
+    // The projection is a plain column list (a, b), so the ordinal binds
+    // against the columns positionally — ordinal 1 is a — while the window sits
+    // in the query ORDER BY.
+    try fixture().expect(
+        "SELECT a, b FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY 1)",
+        equals: "SELECT a, b FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY a)")
+  }
+
+  @Test func `the schema advertises the ordinal window's columns`() throws {
+    let query = try parse(query:
+        "SELECT a, b, ROW_NUMBER() OVER (ORDER BY 1) AS rn FROM T")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["a", "b", "rn"])
+    #expect(columns.map(\.type) == [.integer, .integer, .integer])
+  }
+}
+
+// MARK: - A SELECT * window ORDER BY ordinal
+
+/// A window `ORDER BY` ordinal over a `SELECT *` projection binds against the
+/// expanded star columns once the source scope resolves — `OVER (ORDER BY 1)`
+/// orders the window on the first projected source column, exactly as the
+/// equivalent query-level `ORDER BY 1` resolves `*`. A `*` names no window
+/// itself, so the window sits in the query `ORDER BY`; the source columns `*`
+/// projects are the ordinal surface.
+struct StarWindowOrdinalTests {
+  private func fixture() throws -> FixtureCatalog {
+    // Ordering by column 1 (a) — (1, 2, 3) — differs from the source order, so
+    // the ordering the window fixes is observable in the result.
+    try Catalog {
+      Relation("T", ["a": .integer, "b": .integer]) {
+        Row(3, 1)
+        Row(1, 3)
+        Row(2, 2)
+      }
+    }
+  }
+
+  private func rejects(_ sql: String, _ fault: SQLError,
+                       location: Testing.SourceLocation = #_sourceLocation)
+      throws {
+    // The run faults, and `columns(of:validate:true)` faults identically — the
+    // schema never types a shape the run rejects.
+    try fixture().expect(sql, fails: fault, location: location)
+    #expect(throws: fault, sourceLocation: location) {
+      _ = try fixture().columns(of: parse(query: sql, location: location),
+                                validate: true)
+    }
+  }
+
+  @Test func `an inline ordinal orders the star projection by column one`()
+      throws {
+    // Ordinal 1 names the first star output column a, so the window orders on
+    // a — the rows come out in a order (1, 2, 3), not source order.
+    try fixture().expect(
+        "SELECT * FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY 1)",
+        yields: [[1, 3], [2, 2], [3, 1]])
+  }
+
+  @Test func `an inline ordinal over star equals the named-column form`()
+      throws {
+    try fixture().expect(
+        "SELECT * FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY 1)",
+        equals: "SELECT a, b FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY a)")
+  }
+
+  @Test func `a second inline ordinal over star names the second column`()
+      throws {
+    try fixture().expect(
+        "SELECT * FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY 2)",
+        equals: "SELECT a, b FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY b)")
+  }
+
+  @Test func `a named window ordinal over star equals its column form`()
+      throws {
+    try fixture().expect(
+        "SELECT * FROM T WINDOW w AS (ORDER BY 1) "
+        + "ORDER BY ROW_NUMBER() OVER w",
+        equals: "SELECT a, b FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY a)")
+  }
+
+  @Test func `an unreferenced star window definition ordinal resolves`()
+      throws {
+    // An unused `WINDOW` definition is validated by `validate(named:)`; its
+    // ordinal 1 range-checks against the star columns and resolves cleanly, so
+    // the query yields the plain star projection rather than faulting.
+    try fixture().expect(
+        "SELECT * FROM T WINDOW w AS (ORDER BY 1)",
+        equals: "SELECT * FROM T")
+  }
+
+  @Test func `the schema advertises the star window's source columns`() throws {
+    let query = try parse(query:
+        "SELECT * FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY 1)")
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["a", "b"])
+    #expect(columns.map(\.type) == [.integer, .integer])
+  }
+
+  @Test func `an inline ordinal past the star columns faults`() throws {
+    // Two star output columns (a, b), so ordinal 9 is out of range — the same
+    // `.column` (42703) fault a query-level out-of-range ordinal raises, on
+    // both the run and validate paths.
+    try rejects(
+        "SELECT * FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY 9)",
+        .column("9"))
+  }
+
+  @Test func `an unreferenced star window definition out-of-range faults`()
+      throws {
+    try rejects("SELECT * FROM T WINDOW w AS (ORDER BY 9)", .column("9"))
+  }
+}
+
+// MARK: - Bare compile entry ordinal binding
+
+extension FixtureCatalog {
+  /// The rows `select` yields compiled through the bare `Catalog.compile(_
+  /// select:)` entry — the documented direct compile a caller reaches without
+  /// the `Query` wrapper `run` enters through (`Query.expanded`/
+  /// `Select.inlined`). It optimises and executes the bare plan so a test can
+  /// prove the bare entry ranks a window exactly as the `Query` entry does.
+  fileprivate func run(bare select: Select)
+      throws(SQLError) -> Array<Array<Value>> {
+    let context = Context().validating(false).resolving(Subqueries())
+    let plan = try compile(select, context).demoted().pushdown()
+    return try execute(optimise(plan, context), context).map(\.values)
+  }
+}
+
+/// The documented bare `Catalog.compile(_ select:)` entry and the `run`
+/// (`Query`) entry must bind a window `ORDER BY` output ordinal identically —
+/// both against the projected surface — so the two compilation entries yield
+/// one window ranking (PR #322). The bare entry runs the same `Select.inlined`
+/// prelude the `Query` wrapper runs, so a non-star projection's ordinal is
+/// resolved before either reaches the window lowering, which then meets an
+/// unbound ordinal only for a genuine `SELECT *`.
+struct BareCompileEntryOrdinalTests {
+  private func fixture() throws -> FixtureCatalog {
+    // a order (3, 1, 2), b order (1, 3, 2), and source order all differ, so
+    // which column an ordinal binds to is observable in the ranking.
+    try Catalog {
+      Relation("T", ["a": .integer, "b": .integer]) {
+        Row(3, 1)
+        Row(1, 3)
+        Row(2, 2)
+      }
+    }
+  }
+
+  @Test func `the bare entry ranks a window like the query entry`() throws {
+    let catalog = try fixture()
+    let sql = "SELECT b, ROW_NUMBER() OVER (ORDER BY 1) FROM T"
+    // Projected column 1 is b, so ordinal 1 orders the window on b (1, 2, 3):
+    // b=1 ranks 1, b=2 ranks 2, b=3 ranks 3, kept in source order. Binding to
+    // source column a instead would rank the first row 3 — the drift #322
+    // reported — so the two results would differ.
+    let expected: Array<Array<Value>> = [[.integer(1), .integer(1)],
+                                         [.integer(3), .integer(3)],
+                                         [.integer(2), .integer(2)]]
+    let bare = try catalog.run(bare: parse(select: sql))
+    let query = try catalog.run(parse(query: sql), [:])
+    #expect(bare == expected)
+    #expect(query == expected)
+    #expect(bare == query)
+  }
+
+  @Test func `the bare entry binds a star ordinal like the query entry`()
+      throws {
+    let catalog = try fixture()
+    let sql = "SELECT * FROM T ORDER BY ROW_NUMBER() OVER (ORDER BY 1)"
+    // A `SELECT *` leaves the ordinal for the window lowering, which binds it
+    // against the expanded star columns — ordinal 1 is a — so the rows come
+    // out in a order (1, 2, 3). Both entries agree.
+    let expected: Array<Array<Value>> = [[.integer(1), .integer(3)],
+                                         [.integer(2), .integer(2)],
+                                         [.integer(3), .integer(1)]]
+    let bare = try catalog.run(bare: parse(select: sql))
+    let query = try catalog.run(parse(query: sql), [:])
+    #expect(bare == expected)
+    #expect(bare == query)
+  }
+
+  @Test func `the bare entry faults an out-of-range ordinal`() throws {
+    let catalog = try fixture()
+    // Two projected columns, so ordinal 9 is out of range — `.column` (42703),
+    // the same fault the `Query` entry raises on both paths.
+    let sql = "SELECT b, ROW_NUMBER() OVER (ORDER BY 9) FROM T"
+    #expect(throws: SQLError.column("9")) {
+      _ = try catalog.run(bare: parse(select: sql))
+    }
+  }
+}
+
 // MARK: - RANK / DENSE_RANK execution
 
 /// `RANK()` and `DENSE_RANK()` rank each row within its partition by the window
@@ -1078,11 +1327,30 @@ struct WindowFunctionRejectionTests {
                "a window function is not allowed in a window function"))
   }
 
-  @Test func `a window ORDER BY output ordinal is rejected`() throws {
+  @Test func `a window ORDER BY ordinal naming a window output is rejected`()
+      throws {
+    // Ordinal 1 names the sole projected column, which is the window itself; a
+    // window cannot order by another window's value (it does not exist until
+    // every windowing is computed from the source rows), so it faults on both
+    // paths.
     try rejects(
         "SELECT ROW_NUMBER() OVER (ORDER BY 1) FROM T",
         .state("0A000",
-               "a window ORDER BY output ordinal is not supported"))
+               "a window ORDER BY cannot order by a window output column"))
+  }
+
+  @Test func `a window ORDER BY ordinal past the projection faults`() throws {
+    // Two projected columns (x and the window), so ordinal 5 is out of range —
+    // the same `.column` (42703) fault, spelled as the ordinal, a query-level
+    // out-of-range ORDER BY ordinal raises, on both paths.
+    try rejects("SELECT x, ROW_NUMBER() OVER (ORDER BY 5) FROM T",
+                .column("5"))
+  }
+
+  @Test func `a window ORDER BY ordinal below one faults`() throws {
+    // An ordinal is 1-based, so 0 is out of range and faults `.column`.
+    try rejects("SELECT x, ROW_NUMBER() OVER (ORDER BY 0) FROM T",
+                .column("0"))
   }
 
   @Test func `a RANGE numeric offset frame is rejected`() throws {
@@ -1828,6 +2096,89 @@ struct WindowNonDeterminismTests {
         FROM T
         """,
         yields: [[1, 4], [1, 4], [1, 4]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `a window ORDER BY ordinal orders on the reported value`()
+      throws {
+    // The window ORDER BY names projected column 1 — the tick() value — so the
+    // ordering key and the reported value are one output, a single evaluation.
+    // tick() yields 1, 2, 3 once per row, the window orders on those, and the
+    // row numbered k reports tick() k, so the ranking matches the reported
+    // column. Evaluating the ordinal-named value twice would order on 1, 2, 3
+    // yet report 4, 5, 6 — six calls, the ranking not matching the value.
+    let (counter, routines) = try ticking()
+    try fixture().expect(
+        "SELECT tick(), ROW_NUMBER() OVER (ORDER BY 1) FROM T",
+        yields: [[1, 1], [2, 2], [3, 3]], routines: routines)
+    #expect(counter.count == 3)
+  }
+
+  @Test func `a grouped window ORDER BY ordinal orders on the reported value`()
+      throws {
+    // Each row groups alone (x is distinct), so the ordinal-named tick() value
+    // reaches the window over grouped output. Materialised once below the
+    // window, tick() yields 1, 2, 3 per group, the window orders on those, and
+    // the row numbered k reports tick() k — the ranking matches the reported
+    // column, three calls. Building the window without the materialisation
+    // evaluates the ordinal-named value twice, ordering on 1, 2, 3 yet
+    // reporting 4, 5, 6 over six calls, the ranking not matching the value.
+    let (counter, routines) = try ticking()
+    try fixture().expect(
+        "SELECT tick(), ROW_NUMBER() OVER (ORDER BY 1) FROM T GROUP BY x",
+        yields: [[1, 1], [2, 2], [3, 3]], routines: routines)
+    #expect(counter.count == 3)
+  }
+
+  @Test func `an explicit window key equal to a projection stays independent`()
+      throws {
+    // The window key is written directly, not as an ordinal — it merely equals
+    // the projected tick(). The two occurrences must evaluate independently:
+    // the window orders on its own tick() (1, 2, 3, so the rows rank 1, 2, 3)
+    // and the projection reports a separate tick() (4, 5, 6), six calls in all.
+    // Treating the coincidental equality as an ordinal reference would fold the
+    // two into one hoisted tick(), collapsing to three calls and reporting the
+    // ordered 1, 2, 3 — a changed ranking and changed values.
+    let (counter, routines) = try ticking()
+    try fixture().expect(
+        "SELECT tick(), ROW_NUMBER() OVER (ORDER BY tick()) FROM T",
+        yields: [[4, 1], [5, 2], [6, 3]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `distinct ordinal outputs hoist to independent slots`() throws {
+    // Two select-list columns hold the same stateful expression and the window
+    // orders on both by ordinal (`ORDER BY 1, 2`). The ordinals name separate
+    // outputs, so each is hoisted to its own slot and evaluated independently.
+    // The below-window projection computes both columns per row, left to right,
+    // so column 0 yields tick() 1, 3, 5 and column 1 yields 2, 4, 6 — six calls
+    // in all — and the window orders by (column 0, column 1). Keying the hoist
+    // on term equality instead of the output index would fold the two
+    // occurrences into one shared slot, calling tick() three times and
+    // reporting identical columns.
+    let (counter, routines) = try ticking()
+    try fixture().expect(
+        "SELECT tick(), tick(), ROW_NUMBER() OVER (ORDER BY 1, 2) FROM T",
+        yields: [[1, 2, 1], [3, 4, 2], [5, 6, 3]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `an ordinal and an explicit equal key stay independent`() throws {
+    // One window orders on projected column 0 by ordinal, a second orders on a
+    // directly written `tick()` that merely equals that column. The ordinal key
+    // shares its one hoisted tick() with output 0 (three calls, 1, 2, 3, the
+    // rows ranking 1, 2, 3), while the explicit key carries no output and stays
+    // an independent evaluation (its own tick() 4, 5, 6, ranking 1, 2, 3). Six
+    // calls in all. Redirecting every structurally equal key would collapse the
+    // explicit key onto the ordinal's slot, calling tick() only three times.
+    let (counter, routines) = try ticking()
+    try fixture().expect(
+        """
+        SELECT tick(), ROW_NUMBER() OVER (ORDER BY 1),
+               ROW_NUMBER() OVER (ORDER BY tick())
+        FROM T
+        """,
+        yields: [[1, 1, 1], [2, 2, 2], [3, 3, 3]], routines: routines)
     #expect(counter.count == 6)
   }
 }

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowResolutionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowResolutionTests.swift
@@ -46,16 +46,31 @@ struct WindowResolutionTests {
     #expect(windowing.order.isEmpty)
   }
 
-  @Test func `a window ORDER BY output ordinal is unsupported`() {
-    // A window ORDER BY fixes the input row order, so an integer sort key —
-    // which parses as an output ordinal — is meaningless and faults 0A000, in
-    // parity across the run and validate paths.
+  @Test func `an unbound window ORDER BY ordinal binds to a SELECT star column`()
+      throws {
+    // The `Query.expanded` prelude binds a window ORDER BY ordinal to its
+    // projected expression before this lowering, except a `SELECT *`, whose
+    // outputs are not named before the source scope resolves. A raw spec
+    // resolved directly here carries the ordinal, so the lowering binds it to
+    // the source column `SELECT *` projects at that position — ordinal 1 the
+    // first source column `d` at combined ordinal `0` — on the run and validate
+    // paths alike.
     let window = Expression.window(
         function: .number,
         spec: WindowSpec(order: Order(keys: [Order.Key(sort: .ordinal(1))])))
-    #expect(throws:
-        SQLError.state("0A000",
-                       "a window ORDER BY output ordinal is not supported")) {
+    let windowing = try window.windowing(scope())
+    #expect(windowing.order == [SortKey(term: .slot(0), ascending: true,
+                                        column: nil)])
+  }
+
+  @Test func `a window ORDER BY ordinal past the SELECT star columns faults`() {
+    // The scope names two source columns, so ordinal 3 is out of range and
+    // faults `.column` (42703), spelled as the ordinal — the same fault a
+    // query-level out-of-range ordinal raises.
+    let window = Expression.window(
+        function: .number,
+        spec: WindowSpec(order: Order(keys: [Order.Key(sort: .ordinal(3))])))
+    #expect(throws: SQLError.column("3")) {
       _ = try window.windowing(scope())
     }
   }
@@ -192,5 +207,54 @@ struct WindowArgumentTests {
       try Frame(unit: .rows, start: .current, end: .head)
           .reject(for: .number)
     }
+  }
+}
+
+// MARK: - Ordinal provenance (public AST)
+
+/// The output an ordinal named (`Order.Key.output`) is resolver-generated
+/// provenance, not a public input: the setter is `internal`, so a key built
+/// through a public initializer carries no provenance and only the resolver
+/// stamps one. That keeps the index a valid projection ordinal by construction,
+/// so `materialise` never reads an out-of-range projected column — and the
+/// guard below keeps it total even against a future internal bug.
+struct OrdinalProvenanceTests {
+  @Test func `a public initializer carries no ordinal provenance`() {
+    // Every public initializer constructs `output` as `nil`; there is no public
+    // parameter to supply one, so a module-external caller building the AST —
+    // an ordinal, a bare column, an expression key — cannot forge a provenance
+    // the run path would trust as a projection index.
+    #expect(Order.Key(sort: .ordinal(1)).output == nil)
+    #expect(Order.Key(column: Column("x")).output == nil)
+    #expect(Order.Key(sort: .expression(.column(Column("x"))),
+                      ascending: false).output == nil)
+  }
+
+  @Test func `the resolver stamps the output an ordinal named`() throws {
+    // The one producer of provenance: resolving a window ORDER BY ordinal
+    // substitutes the projected expression and stamps the 0-based output it
+    // came from. Ordinal 1 binds to the first output and records `0`.
+    let spec = WindowSpec(order: Order(keys: [Order.Key(sort: .ordinal(1))]))
+    let outputs = [Expression.column(Column("x")),
+                   Expression.column(Column("d"))]
+    let key = try spec.resolving(ordinals: outputs).order?.keys.first
+    #expect(key?.sort == .expression(.column(Column("x"))))
+    #expect(key?.output == 0)
+  }
+
+  @Test func `materialise skips an out-of-range provenance column`() {
+    // Unreachable on real input — provenance is resolver-generated and always a
+    // valid projection index — this exercises the total guard directly. A key
+    // naming output 9 over a two-column projection hoists nothing and returns
+    // rather than trapping on `projection[9]`.
+    let stray = Windowing(function: .number, partition: [],
+                          order: [SortKey(term: .apply(name: "tick",
+                                                       arguments: []),
+                                          ascending: true, column: 9)])
+    let projection = [Term.slot(0), Term.slot(1)]
+    let result = materialise([stray], projection, [], width: 2,
+                             below: .values(rows: [], types: []))
+    #expect(result.projection == projection)
+    #expect(result.windowings == [stray])
   }
 }


### PR DESCRIPTION
A window specification's ORDER BY rejected an integer output ordinal (ROW_NUMBER() OVER (ORDER BY 1)) as a feature gap. Bind it instead to the projected output column it names, exactly as a query-level ORDER BY ordinal does: OVER (ORDER BY 1) orders the window on the value of projected column 1.

The binding runs once, in the shared Query.expanded prelude (Select.inlined), beside the named-window inlining. A new WindowSpec.resolving(ordinals:) rewrites each ORDER BY ordinal sort key to its projected expression, and an Expression/Predicate walk applies it across the projection and ORDER BY (mirroring the window-inlining walk and collect(windows:)). It is also applied to every WINDOW clause definition, so an unreferenced definition validated only by validate(named:) binds an ordinal identically to a referenced one. Because the prelude is the one point both the compile and validate paths enter, an ordinal is gone before any window lowering or type-check sees it, so run and validate agree by construction rather than by four parallel rewrites. The four former reject sites (the plain and grouped lowering, the inline-window validate, and validate(named:)) become the residual for the one case an ordinal cannot bind.

Edge cases, matching the query-level ordinal where a mapping exists:

  - An ordinal outside 1 ... width faults SQLError.column spelled as the ordinal (42703), the same fault a query-level out-of-range ordinal raises.
  - A projected column that is itself a window faults 0A000: a window ORDER BY fixes the source row order the ranking reads, and a window value does not exist until every windowing is computed from those rows, so it cannot be an input sort key. An aggregate-valued column is left to substitute, reducing to the already-parity expression case a directly-written OVER (ORDER BY <aggregate>) takes over grouped output.
  - A SELECT * projection has no statically-named output, so an ordinal is left in place and the window path's existing SELECT * rejection raises (a window query forbids SELECT * regardless); the four residual sites report this.