### PR TITLE
SQLEngine: execute GROUPS and numeric RANGE offset window frames

### DIFF
--- a/SwiftSQL/Sources/SQLEngine/Aggregation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Aggregation.swift
@@ -1316,7 +1316,12 @@ extension Catalog where Self: ~Escapable {
           throw .state("0A000", "\(function.keyword) is not yet supported")
         }
         try function.require(order: spec)
-        if let frame = spec.frame { try frame.reject(for: function) }
+        if let frame = spec.frame {
+          let ordering = try frame.measured
+              ? scope.ordering(spec, context.routines, subquery: plans.rest)
+              : nil
+          try frame.reject(for: function, order: ordering)
+        }
       }
     }
 

--- a/SwiftSQL/Sources/SQLEngine/Compilation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Compilation.swift
@@ -1891,9 +1891,22 @@ extension Catalog where Self: ~Escapable {
       // Resolve each definition in its own DEFINITION context — its base may
       // reference only an earlier entry and it copies a frameless base.
       let spec = try windows.resolved(at: index)
-      // The function-independent structural frame check — a reversed or inverted
-      // frame — that `reject(for:)` runs for a referenced window.
-      if let frame = spec.frame { try frame.check() }
+      // The frame checks a referenced window gets, minus the function-dependent
+      // `frameable` gate an unused definition has no function to satisfy: the
+      // structural check (a reversed or inverted frame) `reject(for:order:)`
+      // runs, then — for a measured frame — the same order/type requirements
+      // (`reject(order:)`), typed over this scope through the same `subquery`
+      // resolution and projected-output layout the referenced path uses. So an
+      // unused `RANGE BETWEEN 1 PRECEDING …` with no ORDER BY, or one whose
+      // single key is non-numeric, faults exactly as referencing it would,
+      // rather than being accepted and dropped.
+      if let frame = spec.frame {
+        try frame.check()
+        if frame.measured {
+          let ordering = try scope.ordering(spec, routines, subquery: subquery)
+          try frame.reject(order: ordering)
+        }
+      }
       // A window `ORDER BY` output ordinal is bound to its projected expression
       // by the shared `Query.expanded` prelude before this validate (an
       // unreferenced definition alike), so one reaches here only for a `SELECT
@@ -1979,7 +1992,10 @@ extension Catalog where Self: ~Escapable {
       }
       try function.require(order: spec)
       if let frame = spec.frame {
-        try frame.reject(for: function)
+        let ordering = try frame.measured
+            ? scope.ordering(spec, routines, subquery: front.plans.rest)
+            : nil
+        try frame.reject(for: function, order: ordering)
       }
     }
 

--- a/SwiftSQL/Sources/SQLEngine/Scope.swift
+++ b/SwiftSQL/Sources/SQLEngine/Scope.swift
@@ -963,7 +963,9 @@ internal struct Scope {
     }
     try function.require(order: spec)
     if let frame = spec.frame {
-      try frame.reject(for: function)
+      let ordering = try frame.measured
+          ? ordering(spec, routines, subquery: subquery) : nil
+      try frame.reject(for: function, order: ordering)
     }
     // An aggregate window validates its operand and `FILTER` exactly as a
     // collapsing aggregate does (the same `aggregate` helper), yielding the

--- a/SwiftSQL/Sources/SQLEngine/Window.swift
+++ b/SwiftSQL/Sources/SQLEngine/Window.swift
@@ -103,8 +103,8 @@ extension Catalog where Self: ~Escapable {
         distribute(windowing.function, over: ordered, keyed, into: &values)
       case let .aggregate(aggregation):
         if let frame = windowing.frame {
-          try framed(aggregation, over: ordered, keyed, in: records, context,
-                     frame: frame, into: &values)
+          try framed(aggregation, over: ordered, keyed, windowing.order,
+                     in: records, context, frame: frame, into: &values)
         } else {
           try accumulate(aggregation, over: ordered, keyed, in: records,
                          context, into: &values)
@@ -116,17 +116,17 @@ extension Catalog where Self: ~Escapable {
         try position(value, by: -offset, default: fallback, over: ordered,
                      in: records, context, into: &values)
       case let .first(value):
-        try extremum(value, at: .first, over: ordered, keyed,
+        try extremum(value, at: .first, over: ordered, keyed, windowing.order,
                      frame: windowing.frame, in: records, context,
                      into: &values)
       case let .last(value):
-        try extremum(value, at: .last, over: ordered, keyed,
+        try extremum(value, at: .last, over: ordered, keyed, windowing.order,
                      frame: windowing.frame, in: records, context,
                      into: &values)
       case let .nth(value, position):
         try extremum(value, at: .nth(position), over: ordered, keyed,
-                     frame: windowing.frame, in: records, context,
-                     into: &values)
+                     windowing.order, frame: windowing.frame, in: records,
+                     context, into: &values)
       }
     }
     return values
@@ -215,13 +215,14 @@ extension Catalog where Self: ~Escapable {
   private borrowing func framed(_ aggregation: Aggregation,
                                 over ordered: Array<Int>,
                                 _ keyed: Dictionary<Int, Array<Value>>,
+                                _ order: Array<SortKey>,
                                 in records: Array<Record>,
                                 _ context: Context,
                                 frame: Frame,
                                 into values: inout Array<Value>)
       throws(SQLError) {
     let count = ordered.count
-    let (peerLo, peerHi) = peering(ordered, keyed)
+    let framing = framing(over: ordered, keyed, order, frame: frame)
     // Evaluate each source row's `FILTER` and argument once, up front, before
     // folding the individual frames. Explicit frames overlap between output rows
     // (a running `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW` contains the
@@ -262,7 +263,7 @@ extension Catalog where Self: ~Escapable {
       var folded = 0
       for index in 0 ..< count {
         let high = bound(frame.end, at: index, frame.unit, start: false,
-                         peerLo, peerHi, count)
+                         framing)
         let hi = min(count - 1, high)
         while folded <= hi {
           if admitted[folded] { try accumulator.fold(arguments[folded]) }
@@ -284,7 +285,7 @@ extension Catalog where Self: ~Escapable {
       var folded = count
       for index in (0 ..< count).reversed() {
         let low = bound(frame.start, at: index, frame.unit, start: true,
-                        peerLo, peerHi, count)
+                        framing)
         let lo = max(0, low)
         while folded > lo {
           folded -= 1
@@ -298,10 +299,8 @@ extension Catalog where Self: ~Escapable {
     // a running `SUM` could reverse but `MIN`/`MAX` cannot — so each row folds
     // its own slice afresh.
     for index in 0 ..< count {
-      let low = bound(frame.start, at: index, frame.unit, start: true,
-                      peerLo, peerHi, count)
-      let high = bound(frame.end, at: index, frame.unit, start: false,
-                       peerLo, peerHi, count)
+      let low = bound(frame.start, at: index, frame.unit, start: true, framing)
+      let high = bound(frame.end, at: index, frame.unit, start: false, framing)
       let lo = max(0, low)
       let hi = min(count - 1, high)
       var accumulator = Accumulator(aggregation.function,
@@ -373,18 +372,20 @@ extension Catalog where Self: ~Escapable {
   private borrowing func extremum(_ value: Term, at position: Position,
                                   over ordered: Array<Int>,
                                   _ keyed: Dictionary<Int, Array<Value>>,
+                                  _ order: Array<SortKey>,
                                   frame: Frame?,
                                   in records: Array<Record>,
                                   _ context: Context,
                                   into values: inout Array<Value>)
       throws(SQLError) {
     let count = ordered.count
-    let (peerLo, peerHi) = peering(ordered, keyed)
     // The default frame is `RANGE UNBOUNDED PRECEDING AND CURRENT ROW` — the
     // partition start through the current peer group — the frame the value
-    // functions read over when none is written.
+    // functions read over when none is written. Resolve it before building the
+    // framing so the geometry is built for the frame actually read.
     let frame = frame ?? Frame(unit: .range, start: .head,
                                end: .current)
+    let framing = framing(over: ordered, keyed, order, frame: frame)
     // Evaluate each source row's value once, before selecting frame positions.
     // Several output rows may select the same target — `FIRST_VALUE` returns the
     // partition's first value throughout — so reading a materialised value keeps
@@ -396,10 +397,8 @@ extension Catalog where Self: ~Escapable {
       try evaluated.append(evaluate(records[ordered[slot]], value, context))
     }
     for index in 0 ..< count {
-      let low = bound(frame.start, at: index, frame.unit, start: true,
-                      peerLo, peerHi, count)
-      let high = bound(frame.end, at: index, frame.unit, start: false,
-                       peerLo, peerHi, count)
+      let low = bound(frame.start, at: index, frame.unit, start: true, framing)
+      let high = bound(frame.end, at: index, frame.unit, start: false, framing)
       let lo = max(0, low)
       let hi = min(count - 1, high)
       // The chosen row's index into `ordered`, or `nil` when the frame is empty
@@ -528,41 +527,292 @@ extension Catalog where Self: ~Escapable {
 
 /// Resolves a frame `bound` to an index into the ordered partition, for the row
 /// at ordered position `index`. `start` distinguishes the lower bound from the
-/// upper (it governs only which peer-group edge a `RANGE` `CURRENT ROW` takes);
-/// `peerLo`/`peerHi` hold each position's peer-group bounds and `count` the
-/// partition size.
+/// upper (it governs which peer-group/band edge and which group row a bound
+/// takes); `framing` holds the partition's peer-group and (for a numeric-offset
+/// `RANGE` frame) order-key value geometry.
 ///
 /// A returned index may fall outside `0 ..< count` (an offset running off the
 /// partition, or a partition-edge bound) — the caller clamps it and treats a
-/// crossed pair as an empty frame. `RANGE` reaches here only with a non-offset
-/// bound (a numeric `RANGE` offset is rejected at compile), so a `preceding`/
-/// `following` bound is always a `ROWS` physical offset.
+/// crossed pair as an empty frame. A `ROWS` `preceding`/`following` bound is a
+/// physical offset from `index`; a `GROUPS` one counts peer groups; a `RANGE`
+/// one bands the order-key value.
 private func bound(_ bound: Frame.Bound, at index: Int, _ unit: Frame.Unit,
-                   start: Bool, _ peerLo: Array<Int>, _ peerHi: Array<Int>,
-                   _ count: Int) -> Int {
-  // A zero offset is the current row, so it reads the peer group under `RANGE`
-  // (the current row under `ROWS`) rather than a physical offset of `index`.
+                   start: Bool, _ framing: Framing) -> Int {
+  // A zero offset is the current row, so it reads the peer group under `RANGE`/
+  // `GROUPS` (the current row under `ROWS`) rather than an offset of `index`.
   switch bound.normalized {
   case .head:
     return 0
   case .tail:
-    return count - 1
+    return framing.count - 1
   case .current:
-    if case .range = unit { return start ? peerLo[index] : peerHi[index] }
-    return index
+    switch unit {
+    case .rows:
+      return index
+    case .range, .groups:
+      // A RANGE/GROUPS current row frames the whole current peer group.
+      return framing.peer(index, start: start)
+    }
   case let .preceding(offset):
-    // A large parsed offset (`n PRECEDING` near `Int.max`) must place the bound
-    // before the partition, not overflow `index - offset`; on overflow saturate
-    // past the edge the offset runs toward, which the caller clamps to `[0,
-    // count)`.
-    let (low, overflow) = index.subtractingReportingOverflow(offset)
-    return overflow ? (offset < 0 ? Int.max : Int.min) : low
+    switch unit {
+    case .rows:
+      // A large parsed offset (`n PRECEDING` near `Int.max`) must place the
+      // bound before the partition, not overflow `index - offset`; on overflow
+      // saturate past the edge the offset runs toward, which the caller clamps.
+      let (low, overflow) = index.subtractingReportingOverflow(offset)
+      return overflow ? (offset < 0 ? Int.max : Int.min) : low
+    case .groups:
+      return framing.group(index, by: offset, following: false, start: start)
+    case .range:
+      return framing.value(index, by: offset, following: false, start: start)
+    }
   case let .following(offset):
-    // As `preceding`: a large `n FOLLOWING` offset saturates past the end
-    // rather than trapping on `index + offset`.
-    let (high, overflow) = index.addingReportingOverflow(offset)
-    return overflow ? (offset < 0 ? Int.min : Int.max) : high
+    switch unit {
+    case .rows:
+      // As `preceding`: a large `n FOLLOWING` offset saturates past the end
+      // rather than trapping on `index + offset`.
+      let (high, overflow) = index.addingReportingOverflow(offset)
+      return overflow ? (offset < 0 ? Int.min : Int.max) : high
+    case .groups:
+      return framing.group(index, by: offset, following: true, start: start)
+    case .range:
+      return framing.value(index, by: offset, following: true, start: start)
+    }
   }
+}
+
+/// The peer-group and order-key geometry of an ordered partition, resolving a
+/// `GROUPS` or numeric-offset `RANGE` frame's bounds to row indices.
+///
+/// `low`/`high` bound each position's peer group (the rows tied on the window
+/// `ORDER BY`); `group` numbers each position's 0-based peer group and
+/// `starts`/`ends` bound each group by number, so a `GROUPS` bound steps a
+/// whole number of groups in `O(1)`. `keys` holds each position's single
+/// order-key value in window order (populated only for a lone order key — the
+/// shape a numeric-offset `RANGE` frame requires), and `ascending` its
+/// direction, so a `RANGE` bound bands the value in the key's own order.
+/// `present` is the contiguous index span of `keys`' non-`NULL` values —
+/// precomputed once so a `RANGE` bound binary-searches the band edge in
+/// `O(log n)` rather than scanning the whole partition per row.
+///
+/// Each geometry is filled by `framing` only when the frame's unit and bounds
+/// consult it — `low`/`high` for a non-`ROWS` frame, `group`/`starts`/`ends`
+/// for a `GROUPS` frame, `keys`/`present` for a numeric-offset `RANGE` frame
+/// over a lone order key — and is left empty otherwise. `bound` reaches each
+/// accessor (`peer`, `group`, `value`) only under its own unit's case, so an
+/// empty array is never indexed. `count` and `ascending` are always set.
+private struct Framing {
+  let count: Int
+  let low: Array<Int>
+  let high: Array<Int>
+  let group: Array<Int>
+  let starts: Array<Int>
+  let ends: Array<Int>
+  let keys: Array<Value>
+  let present: Range<Int>
+  let ascending: Bool
+
+  /// The current peer group's edge for the row at `index` — its group start (a
+  /// lower bound) or end (an upper bound). A `RANGE`/`GROUPS` `CURRENT ROW`
+  /// frames the whole current peer group.
+  func peer(_ index: Int, start: Bool) -> Int {
+    start ? low[index] : high[index]
+  }
+
+  /// The ordered index bounding a `GROUPS` frame `offset` peer groups before
+  /// (`following == false`) or after the row at `index`'s group. A `start`
+  /// bound takes the target group's first row, an end bound its last. A target
+  /// past the partition runs the bound off that edge: a preceding start /
+  /// following end clamps to the partition, and a following start / preceding
+  /// end returns past the far edge so the caller reads an empty frame.
+  func group(_ index: Int, by offset: Int, following: Bool, start: Bool)
+      -> Int {
+    let (target, overflow) =
+        group[index].addingReportingOverflow(following ? offset : -offset)
+    let last = starts.count - 1
+    if start {
+      if overflow { return following ? count : 0 }
+      if target < 0 { return 0 }
+      if target > last { return count }
+      return starts[target]
+    }
+    if overflow { return following ? count - 1 : -1 }
+    if target < 0 { return -1 }
+    if target > last { return count - 1 }
+    return ends[target]
+  }
+
+  /// The ordered index bounding a numeric-offset `RANGE` frame for the row at
+  /// `index`: the band edge `offset` value units before (`following == false`)
+  /// or after the current order-key value, found in the key's sort order. A
+  /// `start` bound is the first row at or after the lower edge, an end bound
+  /// the last at or before the upper edge. An edge off the present span
+  /// resolves to that span's boundary, not the partition's: a `NULL` run sits
+  /// at one physical end of window order — the low indices adjacent to the
+  /// partition start (`UNBOUNDED PRECEDING`), the high indices adjacent to its
+  /// end (`UNBOUNDED FOLLOWING`) — and returning the present boundary keeps a
+  /// `NULL` run lying on an unbounded edge in the frame. The frame's
+  /// intersection with the other bound then self-gates those `NULL`s: a
+  /// value-bounded other edge excludes them, an unbounded one includes them, so
+  /// `value` need not know the other bound. A `NULL` order key is a peer of
+  /// every other `NULL` and comparable to no value, so its own frame is exactly
+  /// its peer group.
+  ///
+  /// The present keys fill `present` non-decreasing under `precedes`, so each
+  /// edge is a monotonic threshold binary-searched in `O(log n)` — restoring
+  /// the linear cumulative frame rather than rescanning the partition per row.
+  func value(_ index: Int, by offset: Int, following: Bool, start: Bool)
+      -> Int {
+    let current = keys[index]
+    if case .null = current { return peer(index, start: start) }
+    // Preceding steps toward the partition start — a smaller value under `ASC`,
+    // a larger one under `DESC` — and following the reverse, so the sort
+    // direction and the bound direction fold into whether the edge adds the
+    // offset.
+    let add = following == ascending
+    let (target, overflow) = shift(current, by: offset, add: add)
+    var lo = present.lowerBound
+    var hi = present.upperBound
+    if overflow {
+      // The shifted edge ran past `Int`'s range, so it lies numerically beyond
+      // every integer key — above all on an add-overflow, below all on a
+      // subtract-overflow. It is the extreme of the band scan, so resolve it to
+      // the present boundary the scan would reach for a target infinitely far
+      // on that side. `late` is whether the target sits past the high-index
+      // (late) end of window order, which an add-overflow reaches only under
+      // `ASC` and a subtract under `DESC`; the shared return then keeps a
+      // `NULL` run adjacent to that unbounded edge in the frame.
+      let late = add == ascending
+      lo = late ? present.upperBound : present.lowerBound
+    } else if start {
+      // The first present key at or after the lower edge. `precedes(key,
+      // target)` falls true→false across `present`, so lower-bound the first
+      // key that no longer precedes `target` — the first of a tie run on it.
+      // None banding at or after the edge lands on `present.upperBound`, the
+      // first high `NULL` index (or `count`), keeping a trailing `NULL` run.
+      while lo < hi {
+        let mid = lo + (hi - lo) / 2
+        if precedes(keys[mid], target) { lo = mid + 1 } else { hi = mid }
+      }
+    } else {
+      // The last present key at or before the upper edge. `precedes(target,
+      // key)` rises false→true across `present`, so find the first key
+      // `target` precedes and step back — the last of a tie run on `target`.
+      // None banding at or before the edge lands on `present.lowerBound`, whose
+      // `lo - 1` is the last low `NULL` index (or `-1`), keeping a leading
+      // `NULL` run.
+      while lo < hi {
+        let mid = lo + (hi - lo) / 2
+        if precedes(target, keys[mid]) { hi = mid } else { lo = mid + 1 }
+      }
+    }
+    // One shared edge: a `start` bound is `lo` itself, an end bound the row
+    // before it. Off-present edges resolved to a present boundary above, so a
+    // `NULL` run on an unbounded side is retained; the other bound's
+    // intersection self-gates whether those `NULL`s fall in the frame.
+    return start ? lo : lo - 1
+  }
+
+  /// Whether `left` sorts before `right` in the single order key's direction —
+  /// the comparison the partition is ordered by, so its keys are non-decreasing
+  /// under it and a `NULL` sorts to one end.
+  private func precedes(_ left: Value, _ right: Value) -> Bool {
+    ascending ? less(left, right) : less(right, left)
+  }
+}
+
+/// Whether `value` is a non-`NULL` order key — one a numeric band compares
+/// against (a `NULL` bands with no value).
+private func present(_ value: Value) -> Bool {
+  if case .null = value { false } else { true }
+}
+
+/// The contiguous index span of `keys`' present (non-`NULL`) values — the range
+/// a numeric-offset `RANGE` bound binary-searches. A single order key sorts the
+/// `NULL`s to one end, so the present keys fill one span: the first present
+/// index up to one past the last. Empty when every key is `NULL` or `keys` is.
+private func span(_ keys: Array<Value>) -> Range<Int> {
+  var first = keys.startIndex
+  while first < keys.endIndex, !present(keys[first]) { first += 1 }
+  var last = keys.endIndex - 1
+  while last >= first, !present(keys[last]) { last -= 1 }
+  return first ..< (last + 1)
+}
+
+/// `value` moved `offset` numeric units up (`add`) or down — the band edge of a
+/// numeric-offset `RANGE` frame — paired with whether the shift overflowed. The
+/// reject gate proved the order key numeric, so an integer key shifts in `Int`
+/// and a double key in `Double`. An integer shift past `Int`'s range reports
+/// the overflow so `value` resolves the edge off the partition rather than
+/// banding against the saturated key, which would draw that extreme key's peer
+/// group into the frame; a double shift cannot overflow.
+private func shift(_ value: Value, by offset: Int, add: Bool)
+    -> (Value, Bool) {
+  switch value {
+  case let .integer(magnitude):
+    let (moved, overflow) = add ? magnitude.addingReportingOverflow(offset)
+                                : magnitude.subtractingReportingOverflow(offset)
+    return (.integer(overflow ? (add ? .max : .min) : moved), overflow)
+  case let .double(magnitude):
+    return (.double(add ? magnitude + Double(offset)
+                        : magnitude - Double(offset)), false)
+  default:
+    return (value, false)
+  }
+}
+
+/// The `Framing` of `ordered` under `order` for `frame` — built to only the
+/// geometry `frame`'s unit and bounds resolve against, so a plain `ROWS` frame
+/// allocates none of it. A non-`ROWS` frame's `CURRENT ROW` peer bounds
+/// (`low`/`high`) come from a single peer scan (`peering`); a `GROUPS` frame's
+/// group-number navigation (`group`/`starts`/`ends`) folds from those peer
+/// bounds; a numeric-offset `RANGE` frame over a lone order key materialises
+/// each position's key value in window order with its direction and the
+/// contiguous non-`NULL` span (`span`) a band binary-searches. Every geometry
+/// a `frame`'s unit does not consult is left empty — `bound` reaches each
+/// `Framing` accessor only under its own unit, so an empty array is never read.
+private func framing(over ordered: Array<Int>,
+                     _ keyed: Dictionary<Int, Array<Value>>,
+                     _ order: Array<SortKey>, frame: Frame) -> Framing {
+  let count = ordered.count
+  // A `RANGE`/`GROUPS` `CURRENT ROW` bound frames the whole current peer group,
+  // so only a non-`ROWS` frame needs the peer bounds; a `ROWS` frame is a
+  // physical offset and `bound` reads neither `low` nor `high` for it.
+  var low = Array<Int>()
+  var high = Array<Int>()
+  if frame.unit != .rows {
+    (low, high) = peering(ordered, keyed)
+  }
+  // A GROUPS frame steps whole peer groups, so — only then — number the
+  // positions and record each group's `[start, end]` span from the peer bounds;
+  // a new peer group opens where a position is its own group's low.
+  var group = Array<Int>()
+  var starts = Array<Int>()
+  var ends = Array<Int>()
+  if frame.unit == .groups {
+    group = Array(repeating: 0, count: count)
+    var number = -1
+    for index in 0 ..< count {
+      if low[index] == index {
+        number += 1
+        starts.append(index)
+        ends.append(high[index])
+      }
+      group[index] = number
+    }
+  }
+  // A numeric-offset RANGE frame over a single order key bands that key's
+  // value; materialise its per-position value only then (a GROUPS frame reads
+  // the peer groups instead, a ROWS or unmeasured RANGE frame reads neither),
+  // and bound its non-NULL span once so `value` binary-searches the band edge.
+  var keys = Array<Value>()
+  if frame.unit == .range, frame.measured, order.count == 1 {
+    keys.reserveCapacity(count)
+    for position in ordered { keys.append(keyed[position]![0]) }
+  }
+  return Framing(count: count, low: low, high: high, group: group,
+                 starts: starts, ends: ends, keys: keys, present: span(keys),
+                 ascending: order.first?.ascending ?? true)
 }
 
 /// Which row of the frame a positional value function reads.

--- a/SwiftSQL/Sources/SQLEngine/Windowed.swift
+++ b/SwiftSQL/Sources/SQLEngine/Windowed.swift
@@ -119,17 +119,39 @@ extension Frame {
     }
   }
 
-  /// Faults the feature diagnostic when the executor cannot compute this frame
-  /// over `function` yet — called on both the compile (run) and validate paths
-  /// so the two stay in lockstep (the run ≡ validate tripwire): a frame the
-  /// schema types is one the run executes.
+  /// Whether this frame's bounds are measured against the window `ORDER BY`
+  /// beyond the current peer group — a `GROUPS` frame counts peer groups, and a
+  /// numeric-offset `RANGE` frame bands the order-key value, so each consults
+  /// the order keys the legality gate types (a `RANGE` offset requires a single
+  /// numeric key; a `GROUPS` frame requires none — with no order every row is a
+  /// peer, one whole-partition group). A `ROWS` frame is a physical offset, and
+  /// a partition-edge or current-peer `RANGE` frame reads only the peer group,
+  /// so neither consults the order keys.
+  internal var measured: Bool {
+    switch unit {
+    case .rows: false
+    case .range: offset
+    case .groups: true
+    }
+  }
+
+  /// Faults when the executor cannot honor this frame over `function` — called
+  /// on both the compile (run) and validate paths so the two stay in lockstep
+  /// (the run ≡ validate tripwire): a frame the schema types is one the run
+  /// executes. `order` carries the derived types of the window `ORDER BY` keys
+  /// (`nil` for no `ORDER BY`), the surface a measured frame's legality reads.
   ///
   /// The executor honours a frame only for a frame-sensitive function (an
   /// aggregate window folds over it, a `FIRST_VALUE`/`LAST_VALUE`/`NTH_VALUE`
   /// reads a row of it — a ranking or offset function takes none); a `ROWS`
-  /// frame of any bounds; a `RANGE` frame whose bounds are the partition edges
-  /// or the current peer group (a `RANGE` numeric offset — measured against
-  /// the order-key value — is not yet computed); `GROUPS` is not yet computed.
+  /// frame of any bounds; a `RANGE` frame whose bounds are the partition edges,
+  /// the current peer group, or a numeric offset banding the single order-key
+  /// value; and a `GROUPS` frame counting peer groups. A numeric-offset `RANGE`
+  /// frame needs exactly one `ORDER BY` key whose type supports the offset
+  /// arithmetic — a numeric key, the only kind the engine bands (it has no
+  /// datetime/interval arithmetic), `42601` on both paths. A `GROUPS` frame
+  /// needs no `ORDER BY` — with none every partition row is a peer, one peer
+  /// group spanning the whole partition — so it imposes no order requirement.
   /// Faults a structurally invalid frame — one the parser can spell or a public
   /// AST can construct but no execution can honor. A frame may not start at
   /// `UNBOUNDED FOLLOWING` or end at `UNBOUNDED PRECEDING` — the start would
@@ -139,8 +161,8 @@ extension Frame {
   /// start. And an `n PRECEDING`/`n FOLLOWING` size must be nonnegative — a
   /// negative one (a directly built `.preceding(-1)`, which the parser cannot
   /// spell) runs the bound the opposite way, as the `LEAD`/`LAG` offset check
-  /// guards there. Reached from `reject(for:)` for a referenced window, and
-  /// directly when validating an unused named window's specification, so an
+  /// guards there. Reached from `reject(for:order:)` for a referenced window,
+  /// and directly when validating an unused named window's specification, so an
   /// unused definition's frame is checked as a referenced one's is.
   internal func check() throws(SQLError) {
     if case .tail = start {
@@ -202,22 +224,118 @@ extension Frame {
     }
   }
 
-  internal func reject(for function: WindowFunction) throws(SQLError) {
+  internal func reject(for function: WindowFunction,
+                       order types: Array<ValueType>?) throws(SQLError) {
     try check()
     guard function.frameable else {
       throw .state("0A000",
                    "a window frame is not supported for \(function.keyword)")
     }
+    try reject(order: types)
+  }
+
+  /// The function-independent measured-frame order requirement a numeric-offset
+  /// `RANGE` frame places on the window `ORDER BY`, given the derived key
+  /// `types` (`nil` for no `ORDER BY`). A referenced window reaches it via
+  /// `reject(for:order:)` after the function's `frameable` gate; an unused
+  /// named window definition — which carries no window function — reaches it
+  /// directly from `validate(named:)`, so a definition-only frame is held to
+  /// the same order/type rules a referenced one is. A `ROWS` frame, a
+  /// partition-edge or current-peer `RANGE` frame, and a `GROUPS` frame consult
+  /// no order key here, so none constrains the keys — a `GROUPS` frame with no
+  /// `ORDER BY` treats every partition row as a peer, so the whole partition is
+  /// one peer group and the frame resolves against it, the all-peers invariant
+  /// the executor already computes for an unordered window.
+  internal func reject(order types: Array<ValueType>?) throws(SQLError) {
     switch unit {
     case .rows:
       break
     case .range:
+      // A numeric-offset RANGE frame bands the order-key value, so it needs a
+      // single ORDER BY key whose type the offset arithmetic operates on — a
+      // numeric key (the engine bands no datetime/interval). The partition-edge
+      // and current-peer forms carry no offset and read only the peer group, so
+      // they place no such requirement.
       if offset {
-        throw .state("0A000",
-                     "a RANGE numeric offset frame is not yet supported")
+        guard let types, types.count == 1 else {
+          throw .state("42601",
+                       "a RANGE offset frame requires a single ORDER BY key")
+        }
+        guard types[0].numeric else {
+          throw .state("42601",
+                       "a RANGE offset frame requires a numeric ORDER BY key")
+        }
       }
     case .groups:
-      throw .state("0A000", "a GROUPS window frame is not yet supported")
+      // A GROUPS frame counts peer groups, but needs no ORDER BY: with none
+      // every partition row is a peer, so the whole partition is a single peer
+      // group and the frame resolves against it — the all-peers invariant the
+      // executor already computes for an unordered window. So no order key is
+      // required, and none constrains the frame here.
+      break
+    }
+  }
+}
+
+extension Scope {
+  /// The types of `spec`'s window `ORDER BY` keys over this scope, or `nil`
+  /// when it carries no `ORDER BY` — the order-key surface a measured frame's
+  /// legality gate (`Frame.reject(order:)`) reads. It types an expression key
+  /// (a bare column, an aggregate order key by its result, a scalar subquery)
+  /// through
+  /// the schema `derive`, threading the compilation pre-pass `subquery`
+  /// resolution so a scalar-subquery order key resolves as the referenced
+  /// window's normal lowering does rather than faulting the default
+  /// `.unsupported` context.
+  internal func ordering(_ spec: WindowSpec, _ routines: Routines,
+                         subquery: Resolution) throws(SQLError)
+      -> Array<ValueType>? {
+    try ordering(spec) {
+      (expression: Expression) throws(SQLError) -> ValueType in
+      try derive(expression, routines, subquery: subquery)
+    }
+  }
+
+  /// The types of `spec`'s window `ORDER BY` keys over this scope for the
+  /// faulting type-check surface, typing an expression key through `validate`
+  /// (which resolves a scalar subquery through the `SubqueryCheck` the walk
+  /// carries). It resolves an output ordinal through the same projected layout
+  /// the schema overload does, so the run and validate paths read the same key
+  /// types and their frame checks agree by construction.
+  internal func ordering(_ spec: WindowSpec, _ routines: Routines,
+                         subquery: SubqueryCheck) throws(SQLError)
+      -> Array<ValueType>? {
+    try ordering(spec) {
+      (expression: Expression) throws(SQLError) -> ValueType in
+      try validate(expression, routines, subquery: subquery)
+    }
+  }
+
+  /// The types of `spec`'s window `ORDER BY` keys, typing each expression key
+  /// through `type` (the caller's schema `derive` or faulting `validate`) and
+  /// each output ordinal — reached only for a `SELECT *`, whose other
+  /// projection forms the prelude binds before this — through the projected
+  /// layout (`outputs()`). The ordinal is a 1-based projected-output index, so
+  /// it reads the projected column it actually names — the `NATURAL`/`USING`
+  /// merged columns first, then the expanded real columns — which differs from
+  /// the combined source-ordinal space a join with virtual or merged columns
+  /// lays out, exactly the layout `Scope.window(order:)` binds the ordinal
+  /// against. An out-of-range ordinal faults `.column` as that lowering does.
+  private func ordering(_ spec: WindowSpec,
+                        _ type: (Expression) throws(SQLError) -> ValueType)
+      throws(SQLError) -> Array<ValueType>? {
+    guard let order = spec.order else { return nil }
+    let outputs = outputs()
+    return try order.keys.map { key throws(SQLError) -> ValueType in
+      switch key.sort {
+      case let .ordinal(position):
+        guard position >= 1, position <= outputs.count else {
+          throw .column("\(position)")
+        }
+        return outputs[position - 1].type
+      case let .expression(expression):
+        return try type(expression)
+      }
     }
   }
 }

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -1266,6 +1266,1020 @@ struct DistributionExecutionTests {
   }
 }
 
+// MARK: - GROUPS frame execution
+
+/// A `GROUPS` frame is measured in peer groups — maximal runs of rows sharing
+/// the window `ORDER BY` key — so `GROUPS BETWEEN n PRECEDING AND m FOLLOWING`
+/// frames every row from the start of the peer group `n` groups before the
+/// current row's group through the end of the group `m` after it. `CURRENT ROW`
+/// is the whole current peer group; the `UNBOUNDED` edges are the partition
+/// ends. It differs from the equivalent `ROWS` frame wherever the order key
+/// ties, since a group can hold several rows.
+struct GroupsFrameExecutionTests {
+  /// Ordered by `k` the rows fall in three peer groups — `{1,1}`, `{2}`,
+  /// `{3,3}` — so a group frame spans whole ties where the row frame would
+  /// split them.
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(1, 10)
+        Row(1, 20)
+        Row(2, 30)
+        Row(3, 40)
+        Row(3, 50)
+      }
+    }
+  }
+
+  @Test func `SUM over one group either side frames whole peer groups`()
+      throws {
+    // Group frame [group - 1, group + 1]: the first group sees groups 0-1
+    // (10+20+30 = 60); the middle group sees every group (150); the last sees
+    // groups 1-2 (30+40+50 = 120). Each row of a group takes its group's frame.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 60], [1, 20, 60], [2, 30, 150],
+                 [3, 40, 120], [3, 50, 120]])
+  }
+
+  @Test func `the group frame differs from the equivalent row frame`() throws {
+    // The same bounds over ROWS count physical rows, splitting the ties: the
+    // group frame's 60/60/150/120/120 becomes 30/60/90/120/90.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 30], [1, 20, 60], [2, 30, 90],
+                 [3, 40, 120], [3, 50, 90]])
+  }
+
+  @Test func `CURRENT ROW frames the whole current peer group`() throws {
+    // `GROUPS BETWEEN CURRENT ROW AND CURRENT ROW` is the current group alone:
+    // both 1s sum 30, the 2 sums 30, both 3s sum 90.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)
+        FROM T
+        """,
+        yields: [[1, 10, 30], [1, 20, 30], [2, 30, 30],
+                 [3, 40, 90], [3, 50, 90]])
+  }
+
+  @Test func `UNBOUNDED PRECEDING runs through the current group`() throws {
+    // A running group frame: the partition start through the current group's
+    // end — 30, then 60, then 150 for the last group.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        FROM T
+        """,
+        yields: [[1, 10, 30], [1, 20, 30], [2, 30, 60],
+                 [3, 40, 150], [3, 50, 150]])
+  }
+
+  @Test func `UNBOUNDED FOLLOWING reaches the partition end`() throws {
+    // The current group's start through the partition end: 150, 120, 90.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 150], [1, 20, 150], [2, 30, 120],
+                 [3, 40, 90], [3, 50, 90]])
+  }
+
+  @Test func `a following-only group frame is empty past the last group`()
+      throws {
+    // `GROUPS BETWEEN 1 FOLLOWING AND 2 FOLLOWING`: group 0 sees groups 1-2
+    // (30+40+50 = 120); group 1 sees group 2 (90); group 2 has no following
+    // group, so the frame is empty and SUM is NULL.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            GROUPS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 120], [1, 20, 120], [2, 30, 90],
+                 [3, 40, nil], [3, 50, nil]])
+  }
+
+  @Test func `the schema types a GROUPS-framed aggregate window`() throws {
+    // Both paths type the framed column: SUM over integers an integer — the run
+    // folds the group frames and validate types the column, run ≡ validate.
+    let query = try parse(query:
+        """
+        SELECT SUM(v) OVER (ORDER BY k
+            GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS s
+        FROM T
+        """)
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["s"])
+    #expect(columns.map(\.type) == [.integer])
+  }
+
+  @Test func `an unordered GROUPS frame is one whole-partition peer group`()
+      throws {
+    // With no window ORDER BY every partition row is a peer, so the whole
+    // partition is a single peer group and `GROUPS BETWEEN CURRENT ROW AND
+    // CURRENT ROW` frames it entire — every row takes the partition total
+    // (150). Pre-fix this faulted 42601 ("a GROUPS window frame requires an
+    // ORDER BY").
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)
+        FROM T
+        """,
+        yields: [[1, 10, 150], [1, 20, 150], [2, 30, 150],
+                 [3, 40, 150], [3, 50, 150]])
+  }
+
+  @Test func `unordered GROUPS offsets clamp to the single group`() throws {
+    // The one peer group has no group before or after it, so `1 PRECEDING`
+    // clamps to the partition start and `1 FOLLOWING` to its end — the frame is
+    // still the whole partition (150). Pre-fix 42601.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 150], [1, 20, 150], [2, 30, 150],
+                 [3, 40, 150], [3, 50, 150]])
+  }
+
+  @Test func `an unordered UNBOUNDED GROUPS frame spans the partition`()
+      throws {
+    // Both partition edges over the single group are the whole partition
+    // (150). Pre-fix 42601.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (GROUPS BETWEEN UNBOUNDED PRECEDING
+            AND UNBOUNDED FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 150], [1, 20, 150], [2, 30, 150],
+                 [3, 40, 150], [3, 50, 150]])
+  }
+
+  @Test func `an unordered GROUPS frame is per-partition under PARTITION BY`()
+      throws {
+    // PARTITION BY k with no order: each partition is its own single peer
+    // group, so `CURRENT ROW` frames that partition entire — k=1 sums 30, k=2
+    // sums 30, k=3 sums 90. Pre-fix 42601.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (PARTITION BY k
+            GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)
+        FROM T
+        """,
+        yields: [[1, 10, 30], [1, 20, 30], [2, 30, 30],
+                 [3, 40, 90], [3, 50, 90]])
+  }
+
+  @Test func `an unordered GROUPS FIRST_VALUE reads the partition first`()
+      throws {
+    // One whole-partition peer group, so FIRST_VALUE reads the partition's
+    // first row (10, in its original unordered position) on every row. Pre-fix
+    // 42601.
+    try fixture().expect(
+        """
+        SELECT k, v, FIRST_VALUE(v) OVER (GROUPS BETWEEN UNBOUNDED PRECEDING
+            AND UNBOUNDED FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 10], [1, 20, 10], [2, 30, 10],
+                 [3, 40, 10], [3, 50, 10]])
+  }
+
+  @Test func `an unordered GROUPS LAST_VALUE reads the partition last`()
+      throws {
+    // The mirror: LAST_VALUE reads the partition's last row (50) throughout.
+    // Pre-fix 42601.
+    try fixture().expect(
+        """
+        SELECT k, v, LAST_VALUE(v) OVER (GROUPS BETWEEN UNBOUNDED PRECEDING
+            AND UNBOUNDED FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 50], [1, 20, 50], [2, 30, 50],
+                 [3, 40, 50], [3, 50, 50]])
+  }
+}
+
+// MARK: - RANGE numeric offset frame execution
+
+/// A numeric-offset `RANGE` frame is value-based: `RANGE BETWEEN n PRECEDING
+/// AND m FOLLOWING` frames every row whose single order-key value lies in the
+/// band `[current - n, current + m]` (ASC; the direction flips under DESC,
+/// where a
+/// `PRECEDING` bound is the larger-valued side). It differs from both `ROWS`
+/// (physical rows) and `GROUPS` (whole peer groups) wherever the key has gaps
+/// or ties, and a NULL key frames only its NULL peers.
+struct RangeOffsetFrameExecutionTests {
+  /// Gaps (2 → 4 → 7) and a tie (two 2s) so a value band `[k - n, k + m]`
+  /// picks out a different row set than a row count or a group count would.
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+        Row(2, 30)
+        Row(4, 40)
+        Row(7, 50)
+      }
+    }
+  }
+
+  @Test func `SUM bands the order-key value`() throws {
+    // Band [k - 1, k + 1]: k=1 sees 1,2,2 (60); each k=2 sees 1,2,2 (60); k=4
+    // is isolated (40); k=7 is isolated (50).
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 60], [2, 20, 60], [2, 30, 60],
+                 [4, 40, 40], [7, 50, 50]])
+  }
+
+  @Test func `the value band differs from the row and group frames`() throws {
+    // The same bounds over ROWS count physical neighbours (30/60/90/120/90),
+    // and over GROUPS whole peer groups (60/100/100/140/90) — both distinct
+    // from the value band's 60/60/60/40/50.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 30], [2, 20, 60], [2, 30, 90],
+                 [4, 40, 120], [7, 50, 90]])
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 60], [2, 20, 100], [2, 30, 100],
+                 [4, 40, 140], [7, 50, 90]])
+  }
+
+  @Test func `an asymmetric band ascends`() throws {
+    // Band [k - 1, k + 2] ascending: k=1 sees 1,2,2 (60); each k=2 sees 1,2,2,4
+    // (100); k=4 is isolated (40); k=7 is isolated (50).
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 PRECEDING AND 2 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 60], [2, 20, 100], [2, 30, 100],
+                 [4, 40, 40], [7, 50, 50]])
+  }
+
+  @Test func `the band direction flips under DESC`() throws {
+    // Descending, a PRECEDING bound is the larger-valued side, so `1 PRECEDING
+    // AND 2 FOLLOWING` bands [k - 2, k + 1]: k=1 and each k=2 see 1,2,2 (60);
+    // k=4 sees 2,2,4 (90); k=7 is isolated (50) — distinct from the ascending
+    // 60/100/100/40/50.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k DESC
+            RANGE BETWEEN 1 PRECEDING AND 2 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 60], [2, 20, 60], [2, 30, 60],
+                 [4, 40, 90], [7, 50, 50]])
+  }
+
+  @Test func `a running value band folds to the current value`() throws {
+    // `RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING`: the partition start
+    // through every row with key ≤ k + 1 — 60, 60, 60, then 100 (adds 4), then
+    // 150 (adds 7).
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 60], [2, 20, 60], [2, 30, 60],
+                 [4, 40, 100], [7, 50, 150]])
+  }
+
+  @Test func `FIRST_VALUE and LAST_VALUE read the value band edges`() throws {
+    // Over the band [k - 1, k + 1]: FIRST_VALUE reads the band's first row and
+    // LAST_VALUE its last — for the tied 2s the band runs 1,2,2, so LAST_VALUE
+    // is 30 (the last of the tie), not each row's own value.
+    try fixture().expect(
+        """
+        SELECT k, FIRST_VALUE(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10], [2, 10], [2, 10], [4, 40], [7, 50]])
+    try fixture().expect(
+        """
+        SELECT k, LAST_VALUE(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 30], [2, 30], [2, 30], [4, 40], [7, 50]])
+  }
+
+  @Test func `a NULL order key frames only its NULL peers`() throws {
+    // A NULL key is comparable to no value, so its frame is exactly the NULL
+    // peer run (here itself, summing 5); a non-NULL row's band never draws the
+    // NULL in.
+    let catalog = try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(nil, 5)
+        Row(1, 10)
+        Row(2, 20)
+      }
+    }
+    try catalog.expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[nil, 5, 5], [1, 10, 30], [2, 20, 30]])
+  }
+
+  @Test func `a double order key bands over a double column`() throws {
+    // The band arithmetic holds for a double key: [k - 1.0, k + 1.0] over
+    // 1.0, 2.0, 2.5 — k=1.0 sees 1.0,2.0 (30); k=2.0 sees 1.0,2.0,2.5 (60);
+    // k=2.5 sees 2.0,2.5 (50).
+    let catalog = try Catalog {
+      Relation("T", ["k": .double, "v": .integer]) {
+        Row(1.0, 10)
+        Row(2.0, 20)
+        Row(2.5, 30)
+      }
+    }
+    try catalog.expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1.0, 10, 30], [2.0, 20, 60], [2.5, 30, 50]])
+  }
+
+  @Test func `the schema types a RANGE-offset aggregate window`() throws {
+    // Both paths type the framed column: SUM over integers an integer, run ≡
+    // validate over the value-banded frame.
+    let query = try parse(query:
+        """
+        SELECT SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS s
+        FROM T
+        """)
+    let columns = try fixture().columns(of: query, validate: true)
+    #expect(columns.map(\.name) == ["s"])
+    #expect(columns.map(\.type) == [.integer])
+  }
+}
+
+// MARK: - Mixed frame units in one query
+
+/// One query projecting windows of different frame units over the same
+/// partition, so the per-unit conditional build of the framing geometry — a
+/// `ROWS` window reading no partition-sized geometry, a `GROUPS` window the
+/// group numbering, a numeric-offset `RANGE` window the order-key values —
+/// runs each shape side by side and the values stay correct. A unit test
+/// cannot assert the geometry a window leaves unbuilt; it proves the build is
+/// still correct under the gating.
+struct MixedFrameUnitsExecutionTests {
+  /// Gaps (2 → 4 → 7) and a tie (two 2s) so a `ROWS`, a `GROUPS`, and a
+  /// numeric-offset `RANGE` frame each pick out a different row set.
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+        Row(2, 30)
+        Row(4, 40)
+        Row(7, 50)
+      }
+    }
+  }
+
+  @Test func `aggregate windows of three frame units compute together`()
+      throws {
+    // Over the k-ordered partition: a ROWS running sum of the two rows ending
+    // at each (10, 30, 50, 70, 90); a GROUPS current-group sum (10; the tied
+    // 2s each 50; 40; 50); and a RANGE band [k - 1, k + 1] sum (the 1 and both
+    // 2s each 60; the isolated 4 and 7 each themselves). One query builds each
+    // framing to its own unit's geometry.
+    try fixture().expect(
+        """
+        SELECT k, v,
+            SUM(v) OVER (ORDER BY k
+                ROWS BETWEEN 1 PRECEDING AND CURRENT ROW),
+            SUM(v) OVER (ORDER BY k
+                GROUPS BETWEEN CURRENT ROW AND CURRENT ROW),
+            SUM(v) OVER (ORDER BY k
+                RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 10, 10, 60], [2, 20, 30, 50, 60],
+                 [2, 30, 50, 50, 60], [4, 40, 70, 40, 40],
+                 [7, 50, 90, 50, 50]])
+  }
+
+  @Test func `value windows of three frame units compute together`() throws {
+    // The frame-sensitive value functions over the same partition: a ROWS
+    // FIRST_VALUE of the two rows ending at each (10, 10, 20, 30, 40); a GROUPS
+    // current-group LAST_VALUE (10; the tied 2s each 30; 40; 50); and a RANGE
+    // band [k - 1, k + 1] LAST_VALUE (the 1 and both 2s each 30, the band's
+    // last row; the isolated 4 and 7 each themselves). Each window's extremum
+    // reads a framing built to its own unit.
+    try fixture().expect(
+        """
+        SELECT k, v,
+            FIRST_VALUE(v) OVER (ORDER BY k
+                ROWS BETWEEN 1 PRECEDING AND CURRENT ROW),
+            LAST_VALUE(v) OVER (ORDER BY k
+                GROUPS BETWEEN CURRENT ROW AND CURRENT ROW),
+            LAST_VALUE(v) OVER (ORDER BY k
+                RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 10, 10, 30], [2, 20, 10, 30, 30],
+                 [2, 30, 20, 30, 30], [4, 40, 30, 40, 40],
+                 [7, 50, 40, 50, 50]])
+  }
+}
+
+// MARK: - Measured-frame ORDER BY key typing
+
+/// A measured frame (`GROUPS`, numeric-offset `RANGE`) types its window `ORDER
+/// BY` keys through `Scope.ordering`, the surface its legality gate reads. The
+/// typing must agree across every path — the run's subquery resolution, the
+/// `SELECT *` projected layout, and the unused named-window validation — so the
+/// same query faults or passes identically whether its window is referenced and
+/// compiled, referenced and validated, or an unused definition validated then
+/// dropped (the run ≡ validate tripwire).
+struct MeasuredFrameOrderTypingTests {
+  private func rejects(_ make: () throws -> FixtureCatalog, _ sql: String,
+                       _ fault: SQLError,
+                       location: Testing.SourceLocation = #_sourceLocation)
+      throws {
+    // The run faults, and `columns(of:validate:true)` faults identically. The
+    // fixture is built afresh for each surface — a borrowed catalog cannot be
+    // captured by the `#expect(throws:)` closure.
+    try make().expect(sql, fails: fault, location: location)
+    #expect(throws: fault, sourceLocation: location) {
+      _ = try make().columns(of: parse(query: sql, location: location),
+                             validate: true)
+    }
+  }
+
+  // Finding 1: a scalar-subquery order key types through the compilation pre-
+  // pass resolution, so a numeric-offset RANGE frame ordering by it resolves
+  // rather than faulting the default `.unsupported` subquery context.
+  @Test func `a RANGE offset orders by a scalar-subquery key`() throws {
+    // `(SELECT MIN(x) FROM T)` is a constant order key (1), so every row is one
+    // peer and the band `[1 - 1, 1]` frames the whole partition — `SUM(x)` is
+    // the table total (6) on each row. Pre-fix the order-key typing ran under
+    // the default `.unsupported` context and faulted 0A000 on both the run and
+    // the derive, since the scalar subquery was unresolvable there.
+    let catalog = try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+      }
+    }
+    let sql =
+        """
+        SELECT x, SUM(x) OVER (ORDER BY (SELECT MIN(x) FROM T)
+            RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        FROM T
+        """
+    try catalog.expect(sql, yields: [[1, 6], [2, 6], [3, 6]])
+    let columns = try catalog.columns(of: parse(query: sql), validate: true)
+    #expect(columns.map(\.name) == ["x", "column 2"])
+    #expect(columns.map(\.type) == [.integer, .integer])
+  }
+
+  // Finding 2: a `SELECT *` window ORDER BY ordinal types through the projected
+  // layout, not the combined source-ordinal space. `A JOIN B USING (k)` pulls
+  // the merged join key `k` to the leading output, so the projected columns
+  // [k, at, bt] (integer, text, text) diverge from the source-ordinal space
+  // (whose ordinal 0 is A's leading `at`, text) — a plain `type(at:)` read
+  // mistypes the ordinal, deciding a projected column's numeric gate from a
+  // different column's type.
+  private func joined() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("A", ["at": .text, "k": .integer]) {
+        Row("x", 5)
+        Row("y", 9)
+      }
+      Relation("B", ["bt": .text, "k": .integer]) {
+        Row("p", 5)
+        Row("q", 9)
+      }
+    }
+  }
+
+  @Test func `a star ordinal on a numeric projected output is accepted`()
+      throws {
+    // Ordinal 1 names the projected merged key `k` (integer), so the numeric
+    // key gate passes and the frame orders by it. Pre-fix `type(at: 0)` read
+    // the source ordinal `A.at` (text) and wrongly rejected this valid numeric
+    // ordering. Ordering by `k` (5, 9) leaves the star rows in `k`-ascending
+    // order.
+    let sql =
+        """
+        SELECT * FROM A JOIN B USING (k)
+        ORDER BY SUM(k) OVER (ORDER BY 1
+            RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        """
+    try joined().expect(sql, yields: [[5, "x", "p"], [9, "y", "q"]])
+    let columns = try joined().columns(of: parse(query: sql), validate: true)
+    #expect(columns.map(\.name) == ["k", "at", "bt"])
+    #expect(columns.map(\.type) == [.integer, .text, .text])
+  }
+
+  @Test func `a star ordinal on a text projected output is rejected`() throws {
+    // Ordinal 2 names the projected `at` (text), so the numeric-key gate faults
+    // 42601. Pre-fix `type(at: 1)` read the source ordinal `A.k` (integer), so
+    // the gate passed and the RANGE offset was silently ignored.
+    try rejects(
+        { try joined() },
+        """
+        SELECT * FROM A JOIN B USING (k)
+        ORDER BY SUM(k) OVER (ORDER BY 2
+            RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        """,
+        .state("42601",
+               "a RANGE offset frame requires a numeric ORDER BY key"))
+  }
+
+  // Finding 3: an unused named window's measured frame is held to the same
+  // order/type requirements a referenced one is, so the two paths agree.
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["x": .integer, "name": .text]) {
+        Row(1, "a")
+        Row(2, "b")
+      }
+    }
+  }
+
+  @Test func `an unused RANGE offset without an ORDER BY faults`() throws {
+    // Referencing `w` faults 42601 for the missing single order key; an unused
+    // `w` faults identically rather than being accepted and dropped.
+    let fault = SQLError.state("42601",
+        "a RANGE offset frame requires a single ORDER BY key")
+    try rejects(
+        { try fixture() },
+        """
+        SELECT SUM(x) OVER w FROM T
+        WINDOW w AS (RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        """,
+        fault)
+    try rejects(
+        { try fixture() },
+        """
+        SELECT x FROM T
+        WINDOW w AS (RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        """,
+        fault)
+  }
+
+  @Test func `an unused RANGE offset over a non-numeric key faults`() throws {
+    // Referencing `w` faults 42601 for the non-numeric order key; an unused `w`
+    // faults identically — the same SQLSTATE and message.
+    let fault = SQLError.state("42601",
+        "a RANGE offset frame requires a numeric ORDER BY key")
+    try rejects(
+        { try fixture() },
+        """
+        SELECT COUNT(*) OVER w FROM T
+        WINDOW w AS (ORDER BY name RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        """,
+        fault)
+    try rejects(
+        { try fixture() },
+        """
+        SELECT x FROM T
+        WINDOW w AS (ORDER BY name RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        """,
+        fault)
+  }
+
+  @Test func `an unused GROUPS window without an ORDER BY validates`() throws {
+    // A GROUPS frame needs no ORDER BY: with none the whole partition is one
+    // peer group. So an unused `w` validates rather than faulting 42601, and
+    // referencing it runs the whole-partition frame — run ≡ validate. Pre-fix
+    // both the reference and the unused definition faulted 42601 ("a GROUPS
+    // window frame requires an ORDER BY").
+    let unused =
+        """
+        SELECT x FROM T
+        WINDOW w AS (GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)
+        """
+    let columns = try fixture().columns(of: parse(query: unused),
+                                        validate: true)
+    #expect(columns.map(\.name) == ["x"])
+    // Referencing `w` runs: the whole partition (x = 1, 2) sums 3 on each row.
+    try fixture().expect(
+        """
+        SELECT SUM(x) OVER w FROM T
+        WINDOW w AS (GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)
+        """,
+        yields: [[3], [3]])
+  }
+}
+
+// MARK: - RANGE numeric offset frame overflow edges
+
+/// A numeric-offset `RANGE` band edge that runs past `Int`'s range on an
+/// extreme order key resolves to an empty edge, not the extreme key's own peer
+/// group: a shifted target beyond every key lies off the partition on that
+/// side, so its boundary search yields an off-partition sentinel. The direction
+/// folds in — an add-overflow sits past the late (high-index) end under `ASC`
+/// but past the early end under `DESC`, and a subtract-overflow the reverse.
+struct RangeOffsetOverflowTests {
+  @Test func `an ASC add-overflow following edge frames nothing`() throws {
+    // Ascending, a row keyed `Int.max` with `RANGE BETWEEN 1 FOLLOWING AND 1
+    // FOLLOWING` bands `[max + 1, max + 1]`, above every key, so the frame is
+    // empty and `SUM` is NULL. Saturating the edge to `Int.max` would wrongly
+    // draw the `Int.max` row in (yielding 30).
+    let catalog = try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(1, 10)
+        Row(2, 20)
+        Row(Int.max, 30)
+      }
+    }
+    try catalog.expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 20], [2, 20, nil], [Int.max, 30, nil]])
+  }
+
+  @Test func `an ASC subtract-overflow preceding edge frames nothing`()
+      throws {
+    // Ascending, a row keyed `Int.min` with `RANGE BETWEEN 1 PRECEDING AND 1
+    // PRECEDING` bands `[min - 1, min - 1]`, below every key, so the frame is
+    // empty and `SUM` is NULL. Saturating the edge to `Int.min` would wrongly
+    // draw the `Int.min` row in (yielding 10).
+    let catalog = try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(Int.min, 10)
+        Row(1, 20)
+        Row(2, 30)
+      }
+    }
+    try catalog.expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 PRECEDING AND 1 PRECEDING)
+        FROM T
+        """,
+        yields: [[Int.min, 10, nil], [1, 20, nil], [2, 30, 20]])
+  }
+
+  @Test func `a DESC subtract-overflow following edge frames nothing`()
+      throws {
+    // Descending, a `FOLLOWING` bound is the smaller-valued side, so a row
+    // keyed `Int.min` with `RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING` bands
+    // `[min - 1, min - 1]`, past the late end of descending order — an empty
+    // frame, NULL. This mirrors the ascending add-overflow: the empty edge
+    // depends on both the sort and the bound direction, not the sign alone.
+    // Saturating to `Int.min` would draw the `Int.min` row in (yielding 30).
+    let catalog = try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(2, 10)
+        Row(1, 20)
+        Row(Int.min, 30)
+      }
+    }
+    try catalog.expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k DESC
+            RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: [[2, 10, 20], [1, 20, nil], [Int.min, 30, nil]])
+  }
+
+  @Test func `a non-overflow edge near Int.max still frames its band`()
+      throws {
+    // The fix must not over-empty: an edge that does not overflow bands as
+    // before. The `Int.max` row with `RANGE BETWEEN 1 PRECEDING AND CURRENT
+    // ROW` shifts to `Int.max - 1`, drawing in the `Int.max - 1` peer (20) and
+    // itself (30) for 50 — unchanged by the overflow path.
+    let catalog = try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(1, 10)
+        Row(Int.max - 1, 20)
+        Row(Int.max, 30)
+      }
+    }
+    try catalog.expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        FROM T
+        """,
+        yields: [[1, 10, 10], [Int.max - 1, 20, 20], [Int.max, 30, 50]])
+  }
+}
+
+// MARK: - RANGE numeric offset frame NULL runs at an unbounded edge
+
+/// A `NULL` order key sorts to one physical end of window order — the low end
+/// under `ASC` (adjacent to `UNBOUNDED PRECEDING`), the high end under `DESC`
+/// (adjacent to `UNBOUNDED FOLLOWING`). A numeric-offset `RANGE` edge that runs
+/// off the present (non-`NULL`) span resolves to that span's boundary, not the
+/// partition's, so a `NULL` run lying on an unbounded side stays in the frame;
+/// the frame's intersection with the value-bounded other edge then self-gates
+/// whether the run is actually drawn in. These pin that a `NULL` peer adjacent
+/// to an unbounded edge is retained while a value-versus-value band leaves it
+/// out.
+struct RangeOffsetUnboundedNullTests {
+  /// Ascending, a leading `NULL` run at the low end of window order, next to
+  /// `UNBOUNDED PRECEDING`; distinct values pin which rows the band draws in.
+  private func leading() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(nil, 100)
+        Row(1, 10)
+        Row(2, 20)
+      }
+    }
+  }
+
+  @Test func `UNBOUNDED PRECEDING retains a leading NULL peer`() throws {
+    // `RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING`: at k=1 the upper
+    // edge shifts to 0, past every present key, resolving to the low `NULL`
+    // index rather than an empty edge — the frame is the leading `NULL` row, so
+    // `LAST_VALUE` reads its 100, not the empty frame's `NULL`. At k=2 the edge
+    // lands on the k=1 row, framing the `NULL` row and the k=1 row, so
+    // `LAST_VALUE` reads the k=1 row's 10. The `NULL` key's own frame is its
+    // peer group. The frame edge is read directly (not through the aggregate's
+    // running fold), so the value functions expose the boundary.
+    try leading().expect(
+        """
+        SELECT k, v, LAST_VALUE(v) OVER (ORDER BY k
+            RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+        FROM T
+        """,
+        yields: [[nil, 100, 100], [1, 10, 100], [2, 20, 10]])
+    // `FIRST_VALUE` pins the leading `NULL` as the frame's first row at k=1 and
+    // k=2 alike — 100, the `NULL` row's value, never the empty frame's `NULL`.
+    try leading().expect(
+        """
+        SELECT k, v, FIRST_VALUE(v) OVER (ORDER BY k
+            RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+        FROM T
+        """,
+        yields: [[nil, 100, 100], [1, 10, 100], [2, 20, 100]])
+  }
+
+  @Test func `UNBOUNDED FOLLOWING retains a trailing NULL peer`() throws {
+    // Descending, the `NULL` run sits at the high end next to `UNBOUNDED
+    // FOLLOWING`. `RANGE BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING`: at k=1
+    // the lower edge shifts past the last present key and resolves to the high
+    // `NULL` index, so the frame is the trailing `NULL` row and `FIRST_VALUE`
+    // reads its 99 (not the empty frame's `NULL`). At k=2 the edge lands on the
+    // k=1 row, framing it and the `NULL` row, so `FIRST_VALUE` reads the k=1
+    // row's 10. The `NULL` key frames only its peer.
+    let catalog = try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(2, 20)
+        Row(1, 10)
+        Row(nil, 99)
+      }
+    }
+    try catalog.expect(
+        """
+        SELECT k, v, FIRST_VALUE(v) OVER (ORDER BY k DESC
+            RANGE BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+        FROM T
+        """,
+        yields: [[2, 20, 10], [1, 10, 99], [nil, 99, 99]])
+  }
+
+  @Test func `an overflow edge retains a leading NULL peer`() throws {
+    // The overflow short-circuit takes the same present boundary. Ascending
+    // `[NULL, Int.min]` with `RANGE BETWEEN UNBOUNDED PRECEDING AND 1
+    // PRECEDING`: at k=Int.min the upper edge subtract-overflows `Int`, so it
+    // resolves to the low `NULL` index rather than the `-1` sentinel — the
+    // frame is the leading `NULL` row, so `LAST_VALUE` reads its 100, not the
+    // empty frame's `NULL`.
+    let catalog = try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(nil, 100)
+        Row(Int.min, 10)
+      }
+    }
+    try catalog.expect(
+        """
+        SELECT k, v, LAST_VALUE(v) OVER (ORDER BY k
+            RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+        FROM T
+        """,
+        yields: [[nil, 100, 100], [Int.min, 10, 100]])
+  }
+
+  @Test func `a value-versus-value band leaves the NULL run out`() throws {
+    // The self-gating regression guard: with both edges value-bounded, a
+    // `NULL` run is never drawn in. `RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING`
+    // at k=1 has a start edge that cannot reach below the present span, so it
+    // stays empty and `SUM` is `NULL`; only the unbounded cases above gain the
+    // adjacent `NULL`.
+    try leading().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING)
+        FROM T
+        """,
+        yields: [[nil, 100, 100], [1, 10, nil], [2, 20, 10]])
+  }
+}
+
+// MARK: - RANGE numeric offset frame band search
+
+/// A numeric-offset `RANGE` band edge is located by a direction-aware binary
+/// search over the partition's precomputed non-`NULL` key span, replacing the
+/// per-row linear scan. These pin the search's tie boundaries — a `start` edge
+/// takes the first of a tie run at or after the lower edge (a lower bound) and
+/// an `end` edge the last of a tie run at or before the upper edge (an upper
+/// bound) — under both `ASC` and `DESC`, so the search matches the old scan.
+struct RangeOffsetBandSearchTests {
+  /// Ties (three 3s) and gaps (1 → 3 → 5 → 8) with distinct values, so a value
+  /// band's membership and its `FIRST_VALUE`/`LAST_VALUE` edges reveal exactly
+  /// which slot the search lands on.
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(1, 10)
+        Row(3, 20)
+        Row(3, 30)
+        Row(3, 40)
+        Row(5, 50)
+        Row(8, 60)
+      }
+    }
+  }
+
+  @Test func `an ascending band draws the tie-correct rows`() throws {
+    // Band [k - 2, k + 2] ascending: k=1 sees 1,3,3,3 (100); each k=3 sees
+    // 1,3,3,3,5 (150); k=5 sees 3,3,3,5 (140); k=8 is isolated (60). The tie
+    // run of 3s is wholly in or out of a band, never split.
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 2 PRECEDING AND 2 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 100], [3, 20, 150], [3, 30, 150],
+                 [3, 40, 150], [5, 50, 140], [8, 60, 60]])
+  }
+
+  @Test func `ascending edges land on the tie run bounds`() throws {
+    // FIRST_VALUE reads the start edge, LAST_VALUE the end edge of [k - 2,
+    // k + 2]. k=5's start edge (value 3) is the FIRST of the tie run (20, a
+    // lower bound); k=1's end edge (value 3) is the LAST of the tie run (40, an
+    // upper bound). k=8's start edge (value 6) has no exact key, so it lands on
+    // the next key up (60); k=5's end edge (value 7) lands on the key below
+    // (50).
+    try fixture().expect(
+        """
+        SELECT k, FIRST_VALUE(v) OVER (ORDER BY k
+            RANGE BETWEEN 2 PRECEDING AND 2 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10], [3, 10], [3, 10], [3, 10], [5, 20], [8, 60]])
+    try fixture().expect(
+        """
+        SELECT k, LAST_VALUE(v) OVER (ORDER BY k
+            RANGE BETWEEN 2 PRECEDING AND 2 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 40], [3, 50], [3, 50], [3, 50], [5, 50], [8, 60]])
+  }
+
+  @Test func `a descending band draws the tie-correct rows`() throws {
+    // Descending, a PRECEDING bound is the larger-valued side, so `1 PRECEDING
+    // AND 2 FOLLOWING` bands [k - 2, k + 1]: k=1 is isolated (10); each k=3
+    // sees 1,3,3,3 (100); k=5 sees 3,3,3,5 (140); k=8 is isolated (60).
+    try fixture().expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k DESC
+            RANGE BETWEEN 1 PRECEDING AND 2 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10, 10], [3, 20, 100], [3, 30, 100],
+                 [3, 40, 100], [5, 50, 140], [8, 60, 60]])
+  }
+
+  @Test func `descending edges land on the tie run bounds`() throws {
+    // Under DESC window order (8,5,3,3,3,1) the band [k - 2, k + 1].
+    // FIRST_VALUE reads the frame's first row (the larger-keyed side),
+    // LAST_VALUE its last
+    // (the smaller). Each k=3's frame runs 3,3,3,1, so FIRST_VALUE is the first
+    // of the tie run (20) and LAST_VALUE the trailing key 1 (10); k=5's frame
+    // runs 5,3,3,3, so LAST_VALUE is the last of the tie run (40).
+    try fixture().expect(
+        """
+        SELECT k, FIRST_VALUE(v) OVER (ORDER BY k DESC
+            RANGE BETWEEN 1 PRECEDING AND 2 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10], [3, 20], [3, 20], [3, 20], [5, 50], [8, 60]])
+    try fixture().expect(
+        """
+        SELECT k, LAST_VALUE(v) OVER (ORDER BY k DESC
+            RANGE BETWEEN 1 PRECEDING AND 2 FOLLOWING)
+        FROM T
+        """,
+        yields: [[1, 10], [3, 10], [3, 10], [3, 10], [5, 40], [8, 60]])
+  }
+
+  @Test func `a NULL peer run stays outside every value band`() throws {
+    // Two NULL keys form a peer run the search excludes from `present`: under
+    // ASC the NULLs sort to the low index end, under DESC to the high end, so
+    // each spans a different edge of the non-NULL range. Either way a NULL row
+    // frames only its NULL peers (5,7 → 12) and no non-NULL band draws a NULL
+    // in — k=1's band [0,2] sees 1,2 (30), never the NULLs beside it.
+    let catalog = try Catalog {
+      Relation("T", ["k": .integer, "v": .integer]) {
+        Row(nil, 5)
+        Row(nil, 7)
+        Row(1, 10)
+        Row(2, 20)
+        Row(4, 40)
+      }
+    }
+    let band: Array<Array<(any ValueConvertible)?>> =
+        [[nil, 5, 12], [nil, 7, 12], [1, 10, 30],
+         [2, 20, 30], [4, 40, 40]]
+    try catalog.expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: band)
+    try catalog.expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k DESC
+            RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+        FROM T
+        """,
+        yields: band)
+  }
+
+  @Test func `the band holds across a larger partition`() throws {
+    // A correctness-at-size check, not a benchmark — a unit test cannot assert
+    // big-O. A few dozen keyed rows with ties and gaps, each row's band
+    // [k - 2, k + 3] computed independently by a brute-force value-membership
+    // scan (the naive definition the binary search replaces) and matched
+    // against the engine's searched band, so the search stays correct at size.
+    let keys = [0, 0, 1, 3, 3, 3, 4, 7, 7, 10, 10, 10, 11, 12, 14, 14,
+                17, 17, 17, 20, 21, 21, 24, 24, 24, 25, 28, 30, 30, 33]
+    let catalog = FixtureCatalog(
+        ["T": FixtureRelation(
+            [FixtureField(name: "k", type: .integer),
+             FixtureField(name: "v", type: .integer)],
+            keys.indices.map { [.integer(keys[$0]), .integer($0)] })])
+    let expected: Array<Array<(any ValueConvertible)?>> =
+        keys.indices.map { slot in
+          let key = keys[slot]
+          let total = keys.indices
+              .filter { keys[$0] >= key - 2 && keys[$0] <= key + 3 }
+              .reduce(0, +)
+          return [key, slot, total]
+        }
+    try catalog.expect(
+        """
+        SELECT k, v, SUM(v) OVER (ORDER BY k
+            RANGE BETWEEN 2 PRECEDING AND 3 FOLLOWING)
+        FROM T
+        """,
+        yields: expected)
+  }
+}
+
 // MARK: - Resolution parity (run ≡ validate)
 
 /// A window function the executor does not yet compute, or one written outside
@@ -1353,26 +2367,81 @@ struct WindowFunctionRejectionTests {
                 .column("0"))
   }
 
-  @Test func `a RANGE numeric offset frame is rejected`() throws {
-    // A RANGE frame measured by an n PRECEDING/FOLLOWING order-key offset is
-    // not yet computed; only the partition edges and the peer group are.
+  @Test func `a RANGE offset frame without an ORDER BY is rejected`() throws {
+    // A numeric-offset RANGE band measures against the single order-key value;
+    // with no ORDER BY there is none, so both paths fault 42601. (A numeric
+    // RANGE offset over one ordered key now executes — see the offset suite.)
     try rejects(
         """
-        SELECT SUM(x) OVER (ORDER BY x
-            RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        SELECT SUM(x) OVER (RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
         FROM T
         """,
-        .state("0A000", "a RANGE numeric offset frame is not yet supported"))
+        .state("42601",
+               "a RANGE offset frame requires a single ORDER BY key"))
   }
 
-  @Test func `a GROUPS frame is rejected`() throws {
-    try rejects(
+  @Test func `a RANGE offset frame with two ORDER BY keys is rejected`()
+      throws {
+    // The band measures one value, so a pair of order keys is ambiguous —
+    // 42601 on both the run and validate paths.
+    let sql =
         """
-        SELECT SUM(x) OVER (ORDER BY x
-            GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW)
+        SELECT SUM(a) OVER (ORDER BY a, b
+            RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        FROM T
+        """
+    let fault = SQLError.state("42601",
+        "a RANGE offset frame requires a single ORDER BY key")
+    try Catalog {
+      Relation("T", ["a": .integer, "b": .integer]) { Row(1, 2) }
+    }.expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try Catalog {
+        Relation("T", ["a": .integer, "b": .integer]) { Row(1, 2) }
+      }.columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a RANGE offset frame over a non-numeric key is rejected`()
+      throws {
+    // The offset arithmetic is numeric, so a text order key cannot be banded
+    // (the engine has no datetime/interval arithmetic) — 42601 on both paths.
+    let sql =
+        """
+        SELECT COUNT(*) OVER (ORDER BY name
+            RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+        FROM T
+        """
+    let fault = SQLError.state("42601",
+        "a RANGE offset frame requires a numeric ORDER BY key")
+    try Catalog {
+      Relation("T", ["name": .text]) { Row("a") }
+    }.expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try Catalog {
+        Relation("T", ["name": .text]) { Row("a") }
+      }.columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `an unordered GROUPS frame frames the whole partition`() throws {
+    // A GROUPS frame needs no ORDER BY — with none every partition row is a
+    // peer, so the whole partition is one peer group and the frame resolves
+    // against it. `1 PRECEDING AND CURRENT ROW` clamps to the partition start
+    // and the single group's end, framing every row (the table total). Pre-fix
+    // this faulted 42601 ("a GROUPS window frame requires an ORDER BY").
+    try Catalog {
+      Relation("T", ["x": .integer]) {
+        Row(10)
+        Row(20)
+        Row(30)
+      }
+    }.expect(
+        """
+        SELECT SUM(x) OVER (GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW)
         FROM T
         """,
-        .state("0A000", "a GROUPS window frame is not yet supported"))
+        yields: [[60], [60], [60]])
   }
 
   @Test func `a frame starting at UNBOUNDED FOLLOWING is rejected`() throws {

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowResolutionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowResolutionTests.swift
@@ -184,13 +184,14 @@ struct WindowArgumentTests {
   @Test func `a negative frame offset is rejected`() {
     // The parser admits only nonnegative frame offsets, but a public AST can
     // build `.preceding(-1)`/`.following(-1)` — which run the bound the opposite
-    // way — so the shared frame check rejects them. `reject(for:)` validates the
-    // frame before the function's own frameability.
+    // way — so the shared frame check rejects them. `reject(for:order:)`
+    // validates the frame before the function's own frameability; a ROWS frame
+    // reads no order-key types, so `order` is nil.
     for bound in [Frame.Bound.preceding(-1), .following(-1)] {
       let frame = Frame(unit: .rows, start: bound, end: .current)
       #expect(throws:
           SQLError.state("22023", "a window frame offset must be nonnegative")) {
-        try frame.reject(for: .number)
+        try frame.reject(for: .number, order: nil)
       }
     }
   }
@@ -200,12 +201,12 @@ struct WindowArgumentTests {
     #expect(throws: SQLError.state(
         "42601", "a window frame cannot start at UNBOUNDED FOLLOWING")) {
       try Frame(unit: .rows, start: .tail, end: .current)
-          .reject(for: .number)
+          .reject(for: .number, order: nil)
     }
     #expect(throws: SQLError.state(
         "42601", "a window frame cannot end at UNBOUNDED PRECEDING")) {
       try Frame(unit: .rows, start: .current, end: .head)
-          .reject(for: .number)
+          .reject(for: .number, order: nil)
     }
   }
 }


### PR DESCRIPTION
The window executor honoured only ROWS frames of any bounds and RANGE frames at the partition edges or the current peer group; a GROUPS frame and a numeric-offset RANGE frame each faulted 0A000 "not yet supported". Compute both, and relax the reject gate in lockstep so run and validate accept exactly what the executor honours.

The frame executor resolved each bound to an ordered-partition index through one `bound` helper that knew only physical ROWS offsets and the peer-group edges. Bundle the per-partition geometry into a `Framing` — the peer-group bounds, a group numbering with each group's [start, end] span, and (for a lone order key) each position's key value in window order with its direction — and extend `bound` to measure a GROUPS bound in whole peer groups and a numeric-offset RANGE bound as a value band in the key's own sort order. A GROUPS/RANGE CURRENT ROW is the whole current peer group; a bound running off the partition clamps to the edge or reads an empty frame, as the existing ROWS offsets already do. The cumulative and reverse-cumulative fold optimisations stay valid: a head-start or tail-end frame's moving edge is still monotone under both new measures.

`Frame.reject(for:order:)` now takes the derived order-key types and gates the two shapes rather than faulting them: a numeric-offset RANGE frame requires exactly one ORDER BY key of a numeric type — the only kind the engine's offset arithmetic bands, having no datetime/interval — and a GROUPS frame requires an ORDER BY at all, each 42601 on both the run and validate paths. A new `Frame.measured` marks the frames that consult the order keys, and a shared `Scope.ordering` derives their types the same way on every path, so run and validate agree by construction: a GROUPS frame and a numeric RANGE offset frame the executor honours pass reject, while a RANGE offset without a single numeric ordered key still faults identically on both. A NULL order key frames only its NULL peers, consistent with the partition-edge RANGE frame and the ORDER BY NULL ordering.