### PR TITLE
SQLEngine: lower a window function over GROUPING SETS directly

### DIFF
--- a/SwiftSQL/Sources/SQLEngine/Aggregation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Aggregation.swift
@@ -1275,14 +1275,10 @@ extension Catalog where Self: ~Escapable {
     }
     // A window function beside the aggregation computes over the grouped rows —
     // one output row per group, widened by the window slots — via a `window`
-    // node above the aggregate. A `GROUPING SETS` arm is deferred: its window
-    // would see only that arm's grouped rows, not the union of every set's the
-    // ISO semantics prescribe, so it faults the feature diagnostic on both the
-    // run and validate paths (this compile is the parity gate).
-    if select.windows, case .arm = select.grouping {
-      throw .state("0A000",
-                   "a window function with GROUPING SETS is not yet supported")
-    }
+    // node above the aggregate. A `GROUPING SETS` window rides above the union
+    // of arms instead (ISO: it sees every set's rows), lowered by
+    // `expand(windowed:sets:)` before an arm ever reaches here, so no windowed
+    // `.arm` select is compiled at this seam.
 
     // Lower the projection, HAVING, and ORDER BY against the grouped slot
     // space, enforcing the projection rule (every non-aggregated column must be

--- a/SwiftSQL/Sources/SQLEngine/Compilation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Compilation.swift
@@ -1647,6 +1647,31 @@ extension Catalog where Self: ~Escapable {
     // a same-named derived alias here shadows stays visible. The layered
     // overlay never overwrote the CTE, so no separate pre-augment context runs.
     let context = try augment(context, for: .select(select), rows: false)
+    // Validate the row limit ahead of any lowering — including the windowed
+    // grouping-sets early return below, which else bypasses it. The parser
+    // yields only non-negative counts (a `-` is its own token), but a direct
+    // `Limit(count:offset:)` may carry negatives the executor's skip and take
+    // would trap on, so a public-AST-built negative offset/count must fault the
+    // query error here on every path (ordinary and windowed-sets alike), rather
+    // than reach `limited` and precondition-trap on a negative slice.
+    if let limit = select.limit {
+      guard limit.offset >= 0 else {
+        throw .state("2201X", "OFFSET row count must be non-negative")
+      }
+      guard (limit.count ?? 0) >= 0 else {
+        throw .state("2201W", "FETCH row count must be non-negative")
+      }
+    }
+    // A windowed `GROUP BY GROUPING SETS` select lowers directly here — the
+    // window node above the arm union's `setop` plan, over the union-output
+    // scope — rather than through a derived-table AST rewrite. `Query.expanded`
+    // leaves it un-desugared for this seam (a non-windowed one it desugars to
+    // its `UNION ALL` before reaching here). The union compiles in this
+    // enclosing `context`, so a correlated arm reference (an enclosing LATERAL
+    // `T.Id`) resolves natively.
+    if select.windows, case let .sets(sets) = select.grouping {
+      return try windowed(sets: select, sets, context)
+    }
     let relation = select.from
     // A LATERAL first FROM item has no preceding relation to correlate against,
     // so it is meaningless (and ISO forbids it) — fault rather than resolve a
@@ -1656,19 +1681,6 @@ extension Catalog where Self: ~Escapable {
                    "a LATERAL derived table needs a preceding FROM item")
     }
     let from = try resolve(relation, context)
-
-    if let limit = select.limit {
-      // The parser yields only non-negative counts (a `-` is its own token),
-      // but a direct `Limit(count:offset:)` may carry negatives the executor's
-      // skip and take would trap on. Reject them as a query error rather than
-      // crash.
-      guard limit.offset >= 0 else {
-        throw .state("2201X", "OFFSET row count must be non-negative")
-      }
-      guard (limit.count ?? 0) >= 0 else {
-        throw .state("2201W", "FETCH row count must be non-negative")
-      }
-    }
 
     // A window function is allowed only in the SELECT list and `ORDER BY` (ISO
     // 9075); one in a WHERE, HAVING, GROUP BY, or JOIN ON has no per-row meaning
@@ -2105,6 +2117,124 @@ extension Catalog where Self: ~Escapable {
     let hoisted = SQLEngine.materialise(windowed.windowings, projection,
                                         order, width: combined.count,
                                         below: chain)
+    let node = Plan.window(hoisted.windowings, hoisted.chain)
+    return node.shaped(distinct: select.distinct,
+                       projection: hoisted.projection, filter: nil,
+                       order: hoisted.order, limit: select.limit)
+  }
+
+  /// Compiles a windowed `GROUP BY GROUPING SETS` `select` into a window over
+  /// the arm union — the window layer riding above the union of arm-aggregate
+  /// nodes rather than inside any one arm, so the window sees the whole result
+  /// set (the per-set grouped rows and the NULL-extended super-aggregate rows
+  /// alike, ISO 9075) in one compilation, with no derived-table boundary.
+  ///
+  /// `decompose` splits the query into the window-free arm `union` and the
+  /// outer window layer's `projection`/`order` over it (each window-free
+  /// operand a window or the surviving projection reads lifted to a synthetic
+  /// `*gwN` union column). This seam then:
+  ///
+  ///   - compiles the `union` to a `setop` plan in the enclosing `context`, so
+  ///     a correlated arm reference (an enclosing LATERAL `T.Id`) resolves
+  ///     natively — no `VALUES (1)` unit or LATERAL apply is needed;
+  ///   - builds the union-output `Scope` over its `0 ..< arity` slots, keyed by
+  ///     the empty alias (as the `ordered` set-op carrier does), so a bare
+  ///     `*gwN` resolves against it by name;
+  ///   - drives the same `Windowed` machinery the plain window path and the
+  ///     grouped-window path drive — an identity slot map, the union output the
+  ///     slot space — validating each window's function/frame against the union
+  ///     scope and lowering the outer projection and query `ORDER BY` against
+  ///     the widened window slots;
+  ///   - stacks `materialise` → `Plan.window` → `.shaped`, so the query-level
+  ///     DISTINCT / `ORDER BY` / OFFSET·FETCH cap layers `Project(Limit(Sort))`
+  ///     over the window, as the plain window path does.
+  ///
+  /// The schema-derive twin (`columns(windowed:sets:_:)`) lowers the same outer
+  /// window layer over the union-output schema, and the executor descends a
+  /// `.window` carrier over the setop leaf, so run ≡ validate.
+  internal borrowing func windowed(sets select: Select,
+                                   _ sets: Array<Array<Expression>>,
+                                   _ context: Context)
+      throws(SQLError) -> Plan {
+    let routines = context.routines
+    let parts = try decompose(windowed: select, sets: sets, routines)
+    // The outer window layer reads only `*gwN` union columns and window slots,
+    // so it nests no subquery — the `Lift` pushed a subquery-bearing
+    // window-free operand into an arm — and resolves with no subquery surface.
+    let none = Resolution.unsupported
+    // Compile the window-free arm union in the enclosing context and derive its
+    // output columns — the `*gwN`-named, type-unified result columns the window
+    // layer reads. The union plan's output sits at slots `0 ..< arity` (a
+    // `setop`'s output is its arm-0 projection), so the window resolves and
+    // stacks in that identity space, exactly as the `ordered` carrier does over
+    // a set operation.
+    let plan = try compile(parts.union, context)
+    let cols = try columns(unifying: parts.union, context)
+    let arity = cols.count
+    let schema = Schema(from: cols, names: cols.map(\.name), extent: arity,
+                        virtuals: [])
+    // The union-output scope is keyed by the empty alias, so a bare `*gwN`
+    // resolves unqualified over `schema`; its inner query is inspected nowhere,
+    // so the union's arm-0 `SELECT` stands in for the derived relation.
+    let scope = Scope([(Relation(derived: parts.union.arm, as: ""), schema)])
+
+    // The distinct windows the outer layer computes, gathered from the lifted
+    // projection and `ORDER BY`. An unsupported function or frame faults the
+    // feature diagnostic in parity with the schema type derive, exactly as the
+    // plain window path gates them.
+    var expressions = Array<Expression>()
+    for item in parts.projection {
+      item.expression.collect(windows: &expressions)
+    }
+    for key in parts.order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(windows: &expressions)
+      }
+    }
+    for expression in expressions {
+      guard case let .window(function, spec) = expression else {
+        throw .state("XX000", "expected a window function")
+      }
+      guard function.supported else {
+        throw .state("0A000", "\(function.keyword) is not yet supported")
+      }
+      try function.require(order: spec)
+      if let frame = spec.frame {
+        let ordering = try frame.measured
+            ? scope.ordering(spec, routines, subquery: none)
+            : nil
+        try frame.reject(for: function, order: ordering)
+      }
+    }
+
+    // The union output is the window's slot space, so the slot map is the
+    // identity over `0 ..< arity`: a `*gwN` reference reads its own union slot,
+    // and each windowing appends one slot past the source width (`arity + j`).
+    let identity =
+        Dictionary(uniqueKeysWithValues: (0 ..< arity).map { ($0, $0) })
+    var windowed = Windowed(scope, identity, width: arity)
+    let projection = try windowed.terms(.expressions(parts.projection),
+                                        routines, subquery: none)
+    var order = Array<SortKey>()
+    if let clause = parts.order {
+      order = try windowed.order(clause, projection, routines,
+                                 subquery: none)
+    }
+    // Under DISTINCT every `ORDER BY` key must be a select-list value (see
+    // `distinct`); the keys and projection are in the window's output slot
+    // space, aligned with the AST keys index-for-index.
+    if select.distinct, let clause = parts.order {
+      order = try distinct(clause.keys, order, projection)
+    }
+
+    // Materialise each window ORDER BY value the projection also reports once
+    // below the window (a stateful ordinal-named value evaluated once, the
+    // ranking matching the reported column), then stack the window over the
+    // setop plan and shape the query-level DISTINCT / ORDER BY / OFFSET·FETCH —
+    // `shaped` layers `Project(Limit(Sort(_)))`, exactly as the plain window
+    // path shapes its own window node.
+    let hoisted = SQLEngine.materialise(windowed.windowings, projection,
+                                        order, width: arity, below: plan)
     let node = Plan.window(hoisted.windowings, hoisted.chain)
     return node.shaped(distinct: select.distinct,
                        projection: hoisted.projection, filter: nil,

--- a/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
+++ b/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
@@ -30,6 +30,19 @@ extension Query {
         // identically on the run and validate paths (both enter `expanded`).
         let select = try select.inlined
         if case let .sets(sets) = select.grouping {
+          // A window over a `GROUPING SETS` query sees the whole result set —
+          // the union of every set's rows (ISO 9075) — not one arm's grouped
+          // rows, so the window layer rides above the union rather than inside
+          // an arm. A windowed grouping-sets select is NOT desugared here: it
+          // is lowered directly at compile — the window node placed above the
+          // arm union's `setop` plan, over the union-output scope (`compile(_
+          // select:)`) — so no derived-table boundary drops its context. The
+          // inlined select rides through unchanged for that direct lowering
+          // (and the schema-derive/typecheck twins), while a non-windowed one
+          // desugars to its `UNION ALL` here as before.
+          if select.windows {
+            return Query(body: .select(select), carriers: carriers)
+          }
           let expanded = try expand(select, sets: sets)
           return Query(body: expanded.body,
                        carriers: expanded.carriers + carriers)
@@ -62,7 +75,11 @@ extension Query {
 /// set-operation `merge` (a NULL arm constrains nothing, deferring to the arm
 /// that groups on the column). HAVING is copied into every arm (ISO: it filters
 /// each set's own groups); arms combine with `UNION ALL`, so a duplicate set
-/// keeps its rows and the grand-total row is never deduplicated.
+/// keeps its rows and the grand-total row is never deduplicated. The `WINDOW`
+/// clause is copied into every arm too, so the arm compile validates each named
+/// definition against the grouped source — an unused definition faulting a
+/// context-free error (an undefined ORDER BY column) on both paths, as the
+/// ordinary aggregate form does, rather than being dropped unvalidated.
 ///
 /// The query-level `ORDER BY` / `OFFSET`/`FETCH` / `DISTINCT` ride the outer
 /// `Query.ordered` carrier over the union — a `setop` node carries no
@@ -186,7 +203,7 @@ internal func expand(_ select: Select,
     return .select(Select(projection: projection, from: select.from,
                           joins: select.joins, predicate: select.predicate,
                           grouping: .arm(keys: set, superset: superset),
-                          having: select.having))
+                          having: select.having, window: select.window))
   }
   // `sets` is non-empty (the parser requires at least one set), so `union` is
   // set; combine with `UNION ALL` so no arm's rows are deduplicated.
@@ -210,8 +227,8 @@ internal func expand(_ select: Select,
                           projection: select.projection, from: select.from,
                           joins: select.joins, predicate: select.predicate,
                           grouping: .arm(keys: sets[0], superset: superset),
-                          having: select.having, order: select.order,
-                          limit: select.limit))
+                          having: select.having, window: select.window,
+                          order: select.order, limit: select.limit))
   }
   guard carried else { return union }
   // The query-level row operators ride the `ordered` carrier over the union.
@@ -222,4 +239,404 @@ internal func expand(_ select: Select,
   // as `width − generated`, never by scanning output names for a `*gs` prefix.
   return .ordered(union, distinct: select.distinct, order: select.order,
                   limit: select.limit, generated: hidden.count)
+}
+
+// MARK: - Window over GROUPING SETS
+
+/// The decomposition of a windowed `GROUP BY GROUPING SETS` `select` into the
+/// two halves the direct lowering composes — the window-free arm `union` and
+/// the outer window layer's `projection` and `order` over it. It is NOT an AST
+/// rewrite to a derived table: the compile seam (`compile(_ select:)`) compiles
+/// the `union` to a `setop` plan, builds the union-output `Scope`, and drives
+/// the shared window machinery over it, placing a `window` node above the arm
+/// union with no derived-table boundary to drop context; the schema-derive and
+/// type-check twins reuse the same decomposition, so a run and a `columns(of:)`
+/// derive cannot diverge.
+internal struct WindowedSets {
+  /// The original projected items (verbatim), from which the direct lowering's
+  /// schema twin names each output — an alias, else a bare column's name, else
+  /// the positional `column N` synthesized header — and marks an unnamed one
+  /// synthesized, preserving its provenance across the boundary-free lowering.
+  internal let items: Array<Projected>
+
+  /// The outer window layer's projection — each original item with every
+  /// window-free subexpression lifted to a synthetic `*gwN` reference of the
+  /// union output, a window kept with its operands lifted. Each item carries
+  /// the original item's inferable output name as its alias (`nil` for an
+  /// unnamed one), so a query `ORDER BY` names a window alias while an unnamed
+  /// output stays a synthesized header, never the internal `*gwN` name.
+  internal let projection: Array<Projected>
+
+  /// The outer window layer's query-level `ORDER BY`, each key lifted to read
+  /// the union output — an ordinal or a bare name of a projected output left
+  /// verbatim (it orders on that output), any other key's expression lifted.
+  internal let order: Order?
+
+  /// The inner window-free `UNION ALL` of arms — the `expand` of a synthetic
+  /// grouping-sets select projecting the lifted `*gwN` operands, the rest of
+  /// the query verbatim. It carries the original `WINDOW` clause onto its arms,
+  /// so each arm validates every named definition against the grouped source.
+  internal let union: Query
+}
+
+/// Decomposes a `GROUP BY GROUPING SETS` `select` that also projects (or orders
+/// by) a window function into the window-free arm union and the outer window
+/// layer over it — the two halves the direct lowering composes, without any
+/// derived-table boundary.
+///
+/// A window over a grouping-sets query must see the whole result set: the union
+/// of every set's rows, the per-set grouped rows and the NULL-extended
+/// super-aggregate rows alike (ISO 9075). The ordinary `expand` would push a
+/// window into each arm, so it would see only that arm's grouped rows. The
+/// decomposition instead separates:
+///
+///   - the inner window-free `expand` union of arms, whose projection is
+///     exactly the operands the windows and the surviving projection reference
+///     — each maximal window-free subexpression (a group key, an aggregate, a
+///     `GROUPING(…)`, or a scalar over them) lifted to a synthetic `*gwN`
+///     column, so every arm computes those values in its own grouped scope and
+///     the union carries one row per group across every set. The original
+///     `WINDOW` clause rides onto the union arms so the arm compile validates
+///     every named definition against the grouped source before dropping it —
+///     an unused `WINDOW bad AS (ORDER BY nonesuch)` still faults its undefined
+///     column, as the ordinary and non-windowed aggregate forms do;
+///
+///   - the outer window layer: the original projection and `ORDER BY` with
+///     every lifted subexpression rewritten to its `*gwN` reference of the
+///     union output. Each window's `PARTITION BY`/`ORDER BY`/argument now reads
+///     a computed column of the union — a `SUM(x)` a window orders by is
+///     already materialised, the window reads it and does not re-aggregate — so
+///     the window computes over the full result set.
+///
+/// The lifted `*gwN` references are unqualified: the compile seam builds the
+/// union-output `Scope` keyed by the empty alias (as the `ordered` set-op
+/// carrier does), so a bare `*gwN` resolves against that scope's columns rather
+/// than a derived-table qualifier. The compile seam compiles the union in the
+/// enclosing context, so a correlated arm reference (an enclosing LATERAL
+/// `T.Id`) resolves natively — no `VALUES (1)` unit or LATERAL apply is needed.
+///
+/// A window-free subexpression is lifted to one shared `*gwN` column only when
+/// it is deterministic under `routines` (a group key, an aggregate, a scalar
+/// over such, a deterministic call) — so a `SUM(x)` a window orders by and the
+/// projection also yields is one column, read never re-aggregated. A non-
+/// deterministic one (a `tick()` in the projection and the window `ORDER BY`
+/// alike) takes a fresh column per occurrence, so each site evaluates it
+/// independently, matching the plain grouped-window path rather than collapsing
+/// the two sites onto one union column.
+///
+/// A window `FILTER` and a windowed `CASE` are the two operand shapes not
+/// lowered here — each carries a `Predicate` a `*gwN` column cannot stand in
+/// for — so each faults the feature diagnostic on both paths, in parity,
+/// rather than resolving a base column the union scope cannot see.
+internal func decompose(windowed select: Select,
+                        sets: Array<Array<Expression>>,
+                        _ routines: Routines) throws(SQLError) -> WindowedSets {
+  // `GROUPING SETS ()` has no arm to union — rejected here as in `expand`, so a
+  // directly built empty set list faults a syntax error rather than trapping.
+  guard !sets.isEmpty else {
+    throw .state("42601", "GROUPING SETS requires at least one set")
+  }
+  // A grouped `SELECT *` is ill-formed (the window then lives in `ORDER BY`);
+  // reject it with the same fault the grouped projection resolver raises, so a
+  // windowed `SELECT * … GROUP BY GROUPING SETS` faults identically to the
+  // unwrapped grouped form, on both paths.
+  if case .all = select.projection {
+    throw .state("0A000",
+                 "SELECT * is not allowed with GROUP BY or aggregates")
+  }
+
+  // The real projected items, as an explicit list — an `expressions` list
+  // verbatim, a bare-column `columns` list lifted into `Projected`s.
+  let items: Array<Projected> = switch select.projection {
+  case let .expressions(list):
+    list
+  case let .columns(columns):
+    columns.map { Projected(expression: .column($0)) }
+  case .all:
+    []
+  }
+
+  // Lift the projection and the query-level ORDER BY over the union output,
+  // gathering the window-free operands each references into `lift.leaves`. Each
+  // outer item carries the original item's inferable output name as its alias
+  // (`nil` for an unnamed one) — a bare group column stays named, an aliased
+  // value keeps its alias — so a query `ORDER BY` may name a window alias,
+  // while an unnamed output takes no `*gwN` name and stays a synthesized
+  // `column N` header (the schema twin names it from `items`).
+  var lift = Lift(routines)
+  var projection = Array<Projected>()
+  projection.reserveCapacity(items.count)
+  for index in items.indices {
+    projection.append(
+        Projected(expression: try lift.lift(items[index].expression),
+                  alias: items[index].name))
+  }
+  // The projected output names — a bare unqualified ORDER BY key naming one
+  // orders on that output (ISO output-alias precedence), so it is left to
+  // resolve against the outer projection rather than lifted to a `*gwN`
+  // reference.
+  let outputs = Set(items.compactMap { $0.name?.lowercased() })
+  let order: Order? = if let clause = select.order {
+    Order(keys: try clause.keys.map { key throws(SQLError) in
+      switch key.sort {
+      case .ordinal:
+        // A query-level ordinal names an outer projected column by position —
+        // preserved verbatim, resolved against the outer select's projection.
+        return key
+      case let .expression(expression):
+        if case let .column(column) = expression, column.qualifier == nil,
+            outputs.contains(column.name.lowercased()) {
+          return key
+        }
+        var lifted = Order.Key(sort: .expression(try lift.lift(expression)),
+                               ascending: key.ascending)
+        lifted.output = key.output
+        return lifted
+      }
+    })
+  } else {
+    nil
+  }
+
+  // Build the inner union of window-free arms — the `expand` of a synthetic
+  // grouping-sets select projecting the lifted operands (aliased `*gwN`), the
+  // rest of the query verbatim. With no query-level operators the union carries
+  // no `ordered` wrapper, so the union is a bare `UNION ALL` (or the lone
+  // grouped select of a single set). When nothing is lifted (a bare
+  // `ROW_NUMBER() OVER ()`), a constant seeds one column so each arm still
+  // yields one row per group.
+  //
+  // The original `WINDOW` clause rides onto the inner select so `expand`
+  // threads it into each arm, where the arm's `front` validates every
+  // definition against the original grouped scope before dropping it — the used
+  // windows the prelude already inlined and lifted to the outer, so a carried
+  // definition is unused and validated only. Without it a context-free error in
+  // an unused definition (`WINDOW bad AS (ORDER BY nonesuch)`) would be quietly
+  // accepted here, unlike the ordinary and non-windowed aggregate forms.
+  let leaves = lift.leaves
+  let names = (0..<max(1, leaves.count)).map { "*gw\($0)" }
+  let projected: Array<Projected> = leaves.isEmpty
+      ? [Projected(expression: .literal(.integer(1)), alias: names[0])]
+      : leaves.indices.map {
+          Projected(expression: leaves[$0], alias: names[$0])
+        }
+  let inner = Select(projection: .expressions(projected), from: select.from,
+                     joins: select.joins, predicate: select.predicate,
+                     grouping: .sets(sets), having: select.having,
+                     window: select.window)
+  let union = try expand(inner, sets: sets)
+
+  return WindowedSets(items: items, projection: projection, order: order,
+                      union: union)
+}
+
+/// The lifter that rewrites a windowed grouping-sets query's outer expressions
+/// over the arm union output, gathering the window-free operands to push into
+/// the arms.
+///
+/// Each maximal window-free subexpression (anything but a bare literal) is a
+/// value the grouped arms compute — a group key, an aggregate, a `GROUPING(…)`,
+/// a scalar over them, a whole window-free `CASE` — so it is pushed to `leaves`
+/// once (deduplicated by structural identity) and replaced with a reference to
+/// its synthetic `*gwN` union column. A bare literal needs no arm column and
+/// stays in the outer projection. A window function is kept in the outer, its
+/// `PARTITION BY`/`ORDER BY`/argument operands lifted so they read the union
+/// columns.
+private struct Lift {
+  /// The routines a lifted operand's determinism is judged against, deciding
+  /// whether two occurrences share one `*gwN` column.
+  private let routines: Routines
+
+  /// The window-free operands pushed into the arms, in first-appearance order —
+  /// arm column `*gwN` is `leaves[N]`.
+  private(set) var leaves = Array<Expression>()
+
+  /// The `leaves` position each DETERMINISTIC pushed operand occupies, so an
+  /// operand written twice (a `SUM(x)` a window orders by that the projection
+  /// also yields) is one column. A non-deterministic operand is never recorded
+  /// here, so each occurrence takes a fresh column.
+  private var index = Dictionary<Expression, Int>()
+
+  fileprivate init(_ routines: Routines) {
+    self.routines = routines
+  }
+
+  /// The `*gwN` union reference for `expression`, registering it as an arm
+  /// column on first sight. A DETERMINISTIC operand reuses its position after
+  /// (one shared column), while a non-deterministic one (`tick()`) takes a
+  /// fresh column per occurrence, so each site evaluates it independently. The
+  /// reference is unqualified — the compile seam builds the union-output scope
+  /// keyed by the empty alias, so a bare `*gwN` resolves against it by name,
+  /// with no derived-table qualifier to match.
+  private mutating func reference(_ expression: Expression) -> Expression {
+    let steady = expression.steady(routines)
+    if steady, let existing = index[expression] {
+      return .column(Column(name: "*gw\(existing)"))
+    }
+    let position = leaves.count
+    if steady { index[expression] = position }
+    leaves.append(expression)
+    return .column(Column(name: "*gw\(position)"))
+  }
+
+  /// This expression rewritten over the arm union — a window-free
+  /// subexpression pushed to an arm column, a window kept with its operands
+  /// lifted, a bare literal left as is.
+  fileprivate mutating func lift(_ expression: Expression) throws(SQLError)
+      -> Expression {
+    guard expression.windowed else {
+      // A bare literal needs no arm column and stays in the outer projection.
+      // Every other window-free subexpression — a group key, an aggregate, a
+      // `GROUPING(…)`, a scalar over them — is lifted to a `*gwN` arm column,
+      // computed in the arm's grouped scope and validated there (its reachable
+      // operands type-checked as the arm compiles), so a lifted operand faults
+      // on the run and validate paths alike. A non-deterministic operand takes
+      // a fresh column per occurrence (`reference`), so a `tick()` in the
+      // projection and the window `ORDER BY` are two evaluations, not one
+      // collapsed onto a shared arm column.
+      if case .literal = expression { return expression }
+      return reference(expression)
+    }
+    switch expression {
+    case let .window(function, spec):
+      return .window(function: try lift(function), spec: try lift(spec))
+    case let .call(name, arguments):
+      return .call(name: name, arguments: try lift(arguments))
+    case let .binary(operation, lhs, rhs):
+      return .binary(operation, try lift(lhs), try lift(rhs))
+    case let .cast(operand, type):
+      return .cast(try lift(operand), type)
+    case let .coalesce(arguments):
+      return .coalesce(try lift(arguments))
+    case let .nullif(lhs, rhs):
+      return .nullif(try lift(lhs), try lift(rhs))
+    case .case:
+      // A windowed `CASE`'s `WHEN` is a `Predicate` no derived column stands in
+      // for; defer it rather than leave a base column unresolved in the outer.
+      throw .state("0A000",
+                   "a window in a CASE with GROUPING SETS is not yet supported")
+    case .column, .literal, .aggregate, .subquery, .grouping:
+      // Window-free (the guard pushed or kept it) — unreachable here.
+      return expression
+    }
+  }
+
+  /// Each expression of `expressions` lifted, in order.
+  private mutating func lift(_ expressions: Array<Expression>)
+      throws(SQLError) -> Array<Expression> {
+    var lifted = Array<Expression>()
+    lifted.reserveCapacity(expressions.count)
+    for expression in expressions { lifted.append(try lift(expression)) }
+    return lifted
+  }
+
+  /// This window function with its operands lifted over the arm union — a
+  /// ranking function is unchanged, an aggregate window lifts its argument, and
+  /// a positional function lifts its value and default.
+  private mutating func lift(_ function: WindowFunction)
+      throws(SQLError) -> WindowFunction {
+    switch function {
+    case .number, .rank, .dense, .ntile, .percent, .cumulative:
+      return function
+    case let .aggregate(aggregate, operand, distinct, filter):
+      // A `FILTER` search condition is a `Predicate` no derived column stands
+      // in for; defer it rather than leave a base column unresolved.
+      guard filter == nil else {
+        throw .state("0A000",
+                     "a window FILTER with GROUPING SETS is not yet supported")
+      }
+      let lifted: Aggregand = switch operand {
+      case .star:
+        .star
+      case let .expression(expression):
+        .expression(try lift(expression))
+      }
+      return .aggregate(aggregate, of: lifted, distinct: distinct)
+    case let .lead(value, offset, fallback):
+      return .lead(try lift(value), offset: offset,
+                   default: try lift(fallback))
+    case let .lag(value, offset, fallback):
+      return .lag(try lift(value), offset: offset,
+                  default: try lift(fallback))
+    case let .first(value):
+      return .first(try lift(value))
+    case let .last(value):
+      return .last(try lift(value))
+    case let .nth(value, position):
+      return .nth(try lift(value), position)
+    }
+  }
+
+  /// An optional operand lifted — `nil` stays `nil` (a positional window's
+  /// absent default).
+  private mutating func lift(_ expression: Expression?)
+      throws(SQLError) -> Expression? {
+    guard let expression else { return nil }
+    return try lift(expression)
+  }
+
+  /// This window specification with its `PARTITION BY` keys and `ORDER BY`
+  /// values lifted over the arm union — an ordinal key (a `SELECT *` window
+  /// order the prelude left unbound) is preserved, a value key's expression
+  /// lifted, the frame carried through.
+  private mutating func lift(_ spec: WindowSpec)
+      throws(SQLError) -> WindowSpec {
+    let partition = try lift(spec.partition)
+    let order: Order? = if let clause = spec.order {
+      Order(keys: try clause.keys.map { key throws(SQLError) in
+        switch key.sort {
+        case .ordinal:
+          return key
+        case let .expression(expression):
+          var lifted = Order.Key(sort: .expression(try lift(expression)),
+                                 ascending: key.ascending)
+          lifted.output = key.output
+          return lifted
+        }
+      })
+    } else {
+      nil
+    }
+    return WindowSpec(base: spec.base, parenthesized: spec.parenthesized,
+                      partition: partition, order: order, frame: spec.frame)
+  }
+}
+
+extension Expression {
+  /// Whether this window-free expression yields the same value at every
+  /// occurrence, so the lifter may compute it once and share the `*gwN` column
+  /// across the sites that reference it — a bare column, literal, or GROUPING
+  /// bit-vector (a per-arm compile-time constant), an aggregate over a steady
+  /// operand with no FILTER, or an arithmetic/CAST/COALESCE/NULLIF over steady
+  /// parts, and a scalar call only when its routine is deterministic and every
+  /// argument is. A non-deterministic call (`tick()`) is not shared — each site
+  /// computes it independently, matching the plain grouped-window path — and a
+  /// `CASE`, a scalar `subquery`, or a filtered aggregate is conservatively not
+  /// shared. Mirrors `Term.deterministic`: treating an uncertain expression as
+  /// non-steady never wrongly shares two sites that must evaluate on their own,
+  /// only forgoes sharing two that could.
+  fileprivate func steady(_ routines: Routines) -> Bool {
+    switch self {
+    case .column, .literal, .grouping:
+      true
+    case let .call(name, arguments):
+      routines[name]?.deterministic == true
+          && arguments.allSatisfy { $0.steady(routines) }
+    case let .binary(_, lhs, rhs), let .nullif(lhs, rhs):
+      lhs.steady(routines) && rhs.steady(routines)
+    case let .cast(operand, _):
+      operand.steady(routines)
+    case let .coalesce(arguments):
+      arguments.allSatisfy { $0.steady(routines) }
+    case let .aggregate(_, operand, _, filter):
+      switch operand {
+      case .star:
+        filter == nil
+      case let .expression(expression):
+        filter == nil && expression.steady(routines)
+      }
+    case .case, .subquery, .window:
+      false
+    }
+  }
 }

--- a/SwiftSQL/Sources/SQLEngine/Interpreter.swift
+++ b/SwiftSQL/Sources/SQLEngine/Interpreter.swift
@@ -148,6 +148,15 @@ extension Catalog where Self: ~Escapable {
     case let .sort(keys, source):
       return try sorted(execute(source, carrying: union, context), keys,
                         context)
+    case let .window(windowings, source):
+      // A windowed `GROUP BY GROUPING SETS` result is a carrier stack over the
+      // arm union (`compile(windowed sets:)`): descend into the window's child
+      // carrying the union — so its setop leaf per-arm augments the arm-local
+      // derived aliases the query-level augment misses — then compute the
+      // windowings over those augmented records, the same as the plain window
+      // node's execution.
+      return try windowed(execute(source, carrying: union, context),
+                          windowings, context)
     case let .distinct(source):
       return deduplicated(try execute(source, carrying: union, context))
     case let .limit(count, offset, source):

--- a/SwiftSQL/Sources/SQLEngine/Schema+Derivation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Schema+Derivation.swift
@@ -335,11 +335,17 @@ extension Catalog where Self: ~Escapable {
     switch query.body {
     case let .select(select):
       // A `GROUP BY GROUPING SETS (…)` derives its schema through the same
-      // `UNION ALL` expansion the compile path uses, so the run and the derived
-      // columns cannot diverge (`run ≡ columns(of:)`): the arms' NULL-padded
-      // columns type through the set-operation `merge` exactly as the run's do.
+      // lowering the compile path uses, so the run and the derived columns
+      // cannot diverge (`run ≡ columns(of:)`). A windowed one derives the outer
+      // window layer over the arm union's schema — the schema twin of the
+      // direct compile lowering (`compile(windowed sets:)`) — while a
+      // non-windowed one derives its `UNION ALL` expansion, whose arms'
+      // NULL-padded columns type through the set-operation `merge` as the run's
+      // do.
       if case let .sets(sets) = select.grouping {
-        cols = try columns(unifying: expand(select, sets: sets), context)
+        cols = select.windows
+            ? try columns(windowed: select, sets: sets, context)
+            : try columns(unifying: expand(select, sets: sets), context)
       } else {
         cols = try arms(of: select, context)
       }
@@ -933,6 +939,21 @@ extension Catalog where Self: ~Escapable {
 
   private borrowing func typecheck(_ select: Select, _ context: Context)
       throws(SQLError) {
+    // A windowed `GROUP BY GROUPING SETS` select lowers to a window over the
+    // arm union (`compile(windowed sets:)`); its outer window layer references
+    // only synthetic `*gwN` union columns, so every real operand — a group key,
+    // an aggregate, a `GROUPING(…)`, a scalar over them — lives in the arm
+    // union. Type-check (and, on the run's comparability walk, compare) it, so
+    // a reachable-operand or cross-kind-comparison fault surfaces exactly as a
+    // run does, in the mode this `context` carries. The window structure itself
+    // (its function, frame, and slot positions) is validated by `compile`, the
+    // parity gate both paths run before this.
+    if select.windows, case let .sets(sets) = select.grouping {
+      let union = try decompose(windowed: select, sets: sets,
+                                context.routines).union
+      try typecheck(union, context)
+      return
+    }
     // The run's comparability walk visits every reachable comparison surface of
     // this select for the ISO comparability rule — its WHERE, join `ON`s,
     // HAVING, projection, `GROUP BY` and `ORDER BY` keys, aggregate `FILTER`s,
@@ -1790,6 +1811,49 @@ extension Catalog where Self: ~Escapable {
     return (terms, { expression throws(SQLError) in
       try grouped.resolve(expression, routines, subquery: subquery)
     })
+  }
+
+  /// The result columns of a windowed `GROUP BY GROUPING SETS` `select` — the
+  /// schema twin of the direct compile lowering (`compile(windowed sets:)`), so
+  /// validate types exactly the shape run computes (run ≡ columns(of:)).
+  ///
+  /// It reuses the same `decompose` the compile seam does — the window-free arm
+  /// union and the outer window layer's `projection` over it — derives the arm
+  /// union's output schema (its `*gwN`-named, type-unified columns), builds the
+  /// union-output `Scope` over that schema, and types each outer projected
+  /// expression against it: a `*gwN` reference by the union column's type, a
+  /// window by its result (a ranking function `.integer`, an aggregate window
+  /// from its `*gwN` argument — `derive`), exactly the type the compiled
+  /// `Windowed` surface lowers it to.
+  ///
+  /// Each output takes its name and synthesized-header provenance from the
+  /// original projected item — an alias, else a bare column's name, else the
+  /// positional `column N` an unnamed expression takes (marked synthesized), so
+  /// an unnamed windowed output feeding an outer set-op carrier stays
+  /// ordinal-only (not name-bindable), never the internal `*gwN` name it reads.
+  borrowing func columns(windowed select: Select,
+                         sets: Array<Array<Expression>>, _ context: Context)
+      throws(SQLError) -> Array<ResolvedColumn> {
+    let routines = context.routines
+    let parts = try decompose(windowed: select, sets: sets, routines)
+    // The arm union's output schema — the same columns the compile seam builds
+    // its window-source scope from — derived through the shared `columns
+    // (unifying:)` fold, so the arms' NULL-padded columns type through the
+    // set-operation `merge` exactly as at compile.
+    let inner = try columns(unifying: parts.union, context)
+    let arity = inner.count
+    let schema = Schema(from: inner, names: inner.map(\.name), extent: arity,
+                        virtuals: [])
+    let scope = Scope([(Relation(derived: parts.union.arm, as: ""), schema)])
+    // Type each outer window-layer item over the union scope, naming it from
+    // the original item — an inferable name, else a synthesized `column N`.
+    return try parts.items.indices.map { index throws(SQLError) in
+      let name = parts.items[index].name ?? "column \(index + 1)"
+      let type = try scope.derive(parts.projection[index].expression, routines,
+                                  subquery: .unsupported)
+      return ResolvedColumn(OutputColumn(name: name, type: type),
+                            synthesized: parts.items[index].name == nil)
+    }
   }
 
   /// Whether `limit` drops the one row a `single`-row result would yield,

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -3548,18 +3548,16 @@ struct WindowOverGroupedTests {
     }
   }
 
-  @Test func `a window with GROUPING SETS is deferred`() throws {
-    // A window over a `GROUPING SETS` arm would see only that arm's grouped
-    // rows, not the union ISO prescribes, so it is deferred — faulting the
-    // feature diagnostic on both the run and validate paths.
-    let sql = "SELECT dept, SUM(sal), RANK() OVER (ORDER BY SUM(sal)) " +
-              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
-    let fault = SQLError.state(
-        "0A000", "a window function with GROUPING SETS is not yet supported")
-    try fixture().expect(sql, fails: fault)
-    #expect(throws: fault) {
-      _ = try fixture().columns(of: parse(query: sql), validate: true)
-    }
+  @Test func `a window over GROUPING SETS sees every set's rows`() throws {
+    // A window over a `GROUPING SETS` query numbers across the union of every
+    // set's rows (ISO 9075), not one arm's grouped rows — the per-dept totals
+    // (dept 1 300, dept 2 600, dept 3 500) AND the grand total (1400), ranked
+    // together by `SUM(sal)`: 300 → 1, 500 → 2, 600 → 3, 1400 → 4. The former
+    // `0A000` deferral is gone — the window rides above the union of arms.
+    try fixture().expect(
+        "SELECT dept, SUM(sal), ROW_NUMBER() OVER (ORDER BY SUM(sal)) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 300, 1], [2, 600, 3], [3, 500, 2], [nil, 1400, 4]])
   }
 
   @Test func `an aggregate in a grouped window FILTER is rejected`() throws {
@@ -3696,5 +3694,392 @@ struct WindowOverGroupedTests {
     try fixture().expect(sql, yields: [[1]])
     #expect(try fixture().columns(of: parse(query: sql), validate: true)
                 .count == 1)
+  }
+}
+
+@Suite("Window functions over GROUPING SETS / ROLLUP / CUBE output")
+struct WindowOverGroupingSetsTests {
+  // Groups: dept 1 sums 300, dept 2 sums 600, dept 3 sums 500; the grand total
+  // is 1400. A window over a grouping-sets query sees all of them — the per-set
+  // grouped rows and the NULL-extended super-aggregate rows — as one result.
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("Emp", ["dept": .integer, "sal": .integer]) {
+        Row(1, 100)
+        Row(1, 200)
+        Row(2, 300)
+        Row(2, 300)
+        Row(3, 500)
+      }
+    }
+  }
+
+  // A two-dimensional relation for the ROLLUP/CUBE and partition cases.
+  // Per-(Region, Product): East/A 15, East/B 20, West/A 7, West/B 3. Per-Region
+  // East 35, West 10; per-Product A 22, B 23; grand total 45.
+  private func sales() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("Sales", ["Region": .text, "Product": .text, "Qty": .integer]) {
+        Row("East", "A", 10)
+        Row("East", "A", 5)
+        Row("East", "B", 20)
+        Row("West", "A", 7)
+        Row("West", "B", 3)
+      }
+    }
+  }
+
+  @Test func `ROW_NUMBER numbers across every set's rows`() throws {
+    // The window orders the union of the `(dept)` rows and the `()` grand-total
+    // row by `SUM(sal)`, numbering across all four: 300 → 1, 500 → 2, 600 → 3,
+    // 1400 → 4. The output stays in union order (the per-dept arm, then the
+    // grand total), each row carrying its number.
+    try fixture().expect(
+        "SELECT dept, SUM(sal), ROW_NUMBER() OVER (ORDER BY SUM(sal)) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 300, 1], [2, 600, 3], [3, 500, 2], [nil, 1400, 4]])
+  }
+
+  @Test func `an aggregate-argument window reads the union`() throws {
+    // `SUM(SUM(sal)) OVER ()` sums the grouped totals across the whole result —
+    // the three per-dept totals and the grand total, 300 + 600 + 500 + 1400 =
+    // 2800 — over each row. The inner `SUM(sal)` is a column the union already
+    // computed; the outer window reads it and does not re-aggregate.
+    try fixture().expect(
+        "SELECT dept, SUM(SUM(sal)) OVER () " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 2800], [2, 2800], [3, 2800], [nil, 2800]])
+  }
+
+  @Test func `an ordered frame accumulates over the union`() throws {
+    // A running `ROWS UNBOUNDED PRECEDING → CURRENT ROW` frame over the union,
+    // ordered by `SUM(sal)` (300, 500, 600, 1400), runs the cumulative total;
+    // each row reports the sum up to its ordered position — dept 1 300, dept 3
+    // 800, dept 2 1400, the grand total 2800 — output in union order.
+    try fixture().expect(
+        """
+        SELECT dept, SUM(sal), SUM(SUM(sal)) OVER (ORDER BY SUM(sal)
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        FROM Emp GROUP BY GROUPING SETS ((dept), ())
+        """,
+        yields: [[1, 300, 300], [2, 600, 1400], [3, 500, 800],
+                 [nil, 1400, 2800]])
+  }
+
+  @Test func `a window partitions by a grouping-set key`() throws {
+    // `COUNT(*) OVER (PARTITION BY Region)` partitions the union by Region: the
+    // two East `(Region, Product)` rows form one partition (count 2), the two
+    // West rows another (count 2), and the NULL-extended grand-total row — its
+    // Region rolled up to NULL — its own partition (count 1). A super-aggregate
+    // NULL is an ordinary partition value, not skipped.
+    try sales().expect(
+        "SELECT Region, Product, SUM(Qty), COUNT(*) OVER (PARTITION BY Region) "
+        + "FROM Sales GROUP BY GROUPING SETS ((Region, Product), ())",
+        yields: [["East", "A", 15, 2], ["East", "B", 20, 2],
+                 ["West", "A", 7, 2], ["West", "B", 3, 2],
+                 [nil, nil, 45, 1]])
+  }
+
+  @Test func `a ROLLUP output feeds a window`() throws {
+    // `ROLLUP(Region, Product)` unions the full grouping, the per-Region level
+    // (Product a super-aggregate NULL), and the grand total. `ROW_NUMBER() OVER
+    // (ORDER BY SUM(Qty))` numbers across all seven rows by their total: 3 → 1,
+    // 7 → 2, 10 → 3, 15 → 4, 20 → 5, 35 → 6, 45 → 7, output in level order.
+    try sales().expect(
+        "SELECT Region, Product, SUM(Qty), "
+        + "ROW_NUMBER() OVER (ORDER BY SUM(Qty)) "
+        + "FROM Sales GROUP BY ROLLUP(Region, Product)",
+        yields: [["East", "A", 15, 4], ["East", "B", 20, 5],
+                 ["West", "A", 7, 2], ["West", "B", 3, 1],
+                 ["East", nil, 35, 6], ["West", nil, 10, 3],
+                 [nil, nil, 45, 7]])
+  }
+
+  @Test func `a CUBE output feeds a window`() throws {
+    // `CUBE(Region, Product)` unions all four subsets — `(Region, Product)`,
+    // `(Product)`, `(Region)`, `()` — nine rows. `ROW_NUMBER() OVER (ORDER BY
+    // SUM(Qty))` numbers across every one by its total: 3 → 1, 7 → 2, 10 → 3,
+    // 15 → 4, 20 → 5, 22 → 6, 23 → 7, 35 → 8, 45 → 9, output in subset order.
+    try sales().expect(
+        "SELECT Region, Product, SUM(Qty), "
+        + "ROW_NUMBER() OVER (ORDER BY SUM(Qty)) "
+        + "FROM Sales GROUP BY CUBE(Region, Product)",
+        yields: [["East", "A", 15, 4], ["East", "B", 20, 5],
+                 ["West", "A", 7, 2], ["West", "B", 3, 1],
+                 [nil, "A", 22, 6], [nil, "B", 23, 7],
+                 ["East", nil, 35, 8], ["West", nil, 10, 3],
+                 [nil, nil, 45, 9]])
+  }
+
+  @Test func `the query ORDER BY sorts on the window output`() throws {
+    // The query orders by the window number descending (aliased `n`), so the
+    // union rows come out grand total (4), dept 2 (3), dept 3 (2), dept 1 (1).
+    try fixture().expect(
+        "SELECT dept, SUM(sal), ROW_NUMBER() OVER (ORDER BY SUM(sal)) AS n " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ()) ORDER BY n DESC",
+        yields: [[nil, 1400, 4], [2, 600, 3], [3, 500, 2], [1, 300, 1]])
+  }
+
+  @Test func `run and validate agree on a windowed GROUPING SETS`() throws {
+    // Both paths enter `Query.expanded`, so they drive the one rewrite over the
+    // union: the schema path types the same three-column shape the run
+    // produces, no grouping-sets deferral surviving on either.
+    let sql = "SELECT dept, SUM(sal), ROW_NUMBER() OVER (ORDER BY SUM(sal)) " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 3)
+    try fixture().expect(sql,
+                         yields: [[1, 300, 1], [2, 600, 3], [3, 500, 2],
+                                  [nil, 1400, 4]])
+  }
+
+  @Test func `an unaliased windowed aggregate keeps its positional header`()
+      throws {
+    // The outer projection surfaces the same ISO output headers the unwrapped
+    // grouped form does — a bare group column its name, an unnamed aggregate
+    // its positional `column N` — never the internal `*gwN` name the lowering
+    // gives the derived union it reads. The window's own unnamed output takes
+    // the next positional header.
+    let windowed = "SELECT dept, SUM(sal), " +
+                   "ROW_NUMBER() OVER (ORDER BY SUM(sal)) FROM Emp " +
+                   "GROUP BY GROUPING SETS ((dept), ())"
+    let grouped = "SELECT dept, SUM(sal) FROM Emp " +
+                  "GROUP BY GROUPING SETS ((dept), ())"
+    let headers = try fixture().columns(of: parse(query: windowed),
+                                        validate: true).map(\.name)
+    let plain = try fixture().columns(of: parse(query: grouped),
+                                      validate: true).map(\.name)
+    // The first two headers match the non-windowed grouped form exactly.
+    #expect(Array(headers.prefix(2)) == plain)
+    #expect(headers == ["dept", "column 2", "column 3"])
+  }
+
+  @Test func `an aliased windowed aggregate keeps its alias header`() throws {
+    // An explicit `AS` on a projected aggregate keeps its alias, and a bare
+    // group column keeps its name — the outer projection carries the original
+    // ISO output name, not the derived `*gwN` column it reads.
+    let sql = "SELECT dept, SUM(sal) AS total, " +
+              "ROW_NUMBER() OVER (ORDER BY SUM(sal)) AS n FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept), ())"
+    let headers = try fixture().columns(of: parse(query: sql),
+                                        validate: true).map(\.name)
+    #expect(headers == ["dept", "total", "n"])
+  }
+
+  @Test func `a non-grouped operand over GROUPING SETS is rejected`() throws {
+    // A window `ORDER BY` naming a column neither grouped nor aggregated has no
+    // grouped value in any arm — the standard grouping rule rejects it as it
+    // does on the plain grouped path, on both the run and validate paths.
+    let sql = "SELECT dept, RANK() OVER (ORDER BY sal) " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    try fixture().expect(sql, fails: .grouping("sal"))
+    #expect(throws: SQLError.grouping("sal")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a window FILTER over GROUPING SETS is deferred`() throws {
+    // An aggregate window's `FILTER` is a per-row `Predicate` no derived union
+    // column stands in for, so it remains deferred — faulting the feature
+    // diagnostic on both the run and validate paths, in parity.
+    let sql = "SELECT dept, SUM(sal) FILTER (WHERE sal > 0) OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    let fault = SQLError.state(
+        "0A000", "a window FILTER with GROUPING SETS is not yet supported")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  // A parent `T` and a keyed child `U`, so a correlated LATERAL body's grouping
+  // varies per outer row: Id 1 has two children (100, 101), Id 2 one (200), and
+  // Id 3 none. The child keys reach back to `T.Id`, the correlation a once-
+  // materialised derived table would sever.
+  private func correlated() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+      }
+      Relation("U", ["k": .integer, "v": .integer]) {
+        Row(1, 100)
+        Row(1, 101)
+        Row(2, 200)
+      }
+    }
+  }
+
+  @Test func `a correlated LATERAL windowed GROUPING SETS resolves the outer`()
+      throws {
+    // The windowed grouping-sets query is a correlated LATERAL body: its arms
+    // reference the enclosing `T.Id`, so the union rides a LATERAL apply that
+    // retains that correlation rather than an uncorrelated derived table. Per
+    // `T` row, `ROLLUP(T.Id)` over the children keyed on `T.Id` yields a
+    // per-group row and the grand total, and `ROW_NUMBER() OVER (ORDER BY
+    // SUM(U.v))` numbers them: Id 1 → two rows summing 201 numbered 1, 2; Id
+    // 2 → two rows summing 200 numbered 1, 2; Id 3 → its lone grand total (no
+    // children) numbered 1.
+    try correlated().expect(
+        "SELECT T.Id, d.n FROM T JOIN LATERAL (" +
+        "SELECT ROW_NUMBER() OVER (ORDER BY SUM(U.v)) AS n " +
+        "FROM U WHERE U.k = T.Id GROUP BY ROLLUP(T.Id)) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.n",
+        yields: [[1, 1], [1, 2], [2, 1], [2, 2], [3, 1]])
+  }
+
+  @Test func `run and validate agree on a correlated LATERAL windowed query`()
+      throws {
+    // Both paths enter `Query.expanded` and drive the one lateral-apply
+    // rewrite, so the schema path types the same two-column shape a run
+    // produces — the correlated body resolving `T.Id` on both.
+    let sql = "SELECT T.Id, d.n FROM T JOIN LATERAL (" +
+              "SELECT ROW_NUMBER() OVER (ORDER BY SUM(U.v)) AS n " +
+              "FROM U WHERE U.k = T.Id GROUP BY ROLLUP(T.Id)) AS d ON 1 = 1"
+    #expect(try correlated().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    try correlated().expect(
+        sql + " ORDER BY T.Id, d.n",
+        yields: [[1, 1], [1, 2], [2, 1], [2, 2], [3, 1]])
+  }
+
+  @Test func `a non-windowed LATERAL GROUPING SETS returns the same grouping`()
+      throws {
+    // The parity the windowed form must match: the same correlated body without
+    // the window resolves `T.Id` identically, one row per group per outer row —
+    // Id 1 and Id 2 their per-group sum and grand total (equal here), Id 3 only
+    // its grand-total NULL. The windowed form numbers exactly these rows.
+    try correlated().expect(
+        "SELECT T.Id, d.s FROM T JOIN LATERAL (" +
+        "SELECT SUM(U.v) AS s FROM U WHERE U.k = T.Id " +
+        "GROUP BY ROLLUP(T.Id)) AS d ON 1 = 1 ORDER BY T.Id, d.s",
+        yields: [[1, 201], [1, 201], [2, 200], [2, 200], [3, nil]])
+  }
+
+  @Test func `an unused WINDOW definition faults over a windowed GROUPING SETS`()
+      throws {
+    // A used `ROW_NUMBER()` window beside an unused named window whose ORDER BY
+    // names a non-existent column. The rewrite carries the original WINDOW
+    // clause onto the arm union, so the arm's front validates every definition
+    // against the grouped source before dropping it — faulting the undefined
+    // `nonesuch` on both the run and validate paths, as the ordinary and
+    // non-windowed aggregate forms do, rather than silently accepting it.
+    let sql = "SELECT dept, ROW_NUMBER() OVER () FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept), ()) " +
+              "WINDOW bad AS (ORDER BY nonesuch)"
+    try fixture().expect(sql, fails: .column("nonesuch"))
+    #expect(throws: SQLError.column("nonesuch")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `an unused WINDOW faults over a single-set GROUPING SETS`()
+      throws {
+    // A single grouping set takes the fast path that reconstructs an ordinary
+    // grouped `Select`; that reconstruction must carry the `WINDOW` clause, or
+    // an unused definition naming a non-existent column is silently accepted
+    // where the multi-set path and the ordinary grouped query both reject it.
+    let sql = "SELECT dept, ROW_NUMBER() OVER () FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept)) " +
+              "WINDOW bad AS (ORDER BY nonesuch)"
+    try fixture().expect(sql, fails: .column("nonesuch"))
+    #expect(throws: SQLError.column("nonesuch")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a directly-built negative limit faults over GROUPING SETS`()
+      throws {
+    // The windowed grouping-sets lowering validates the row limit before its
+    // early return; else a public-AST-built negative `Limit` reaches the
+    // executor's slice and precondition-traps, where the ordinary path faults
+    // the query error. Run and validate fault identically.
+    let query = try parse(
+        query: "SELECT dept, ROW_NUMBER() OVER () FROM Emp " +
+               "GROUP BY GROUPING SETS ((dept), ())")
+    guard case let .select(base) = query.body else {
+      Issue.record("expected a single SELECT")
+      return
+    }
+    func rebuilt(_ limit: Limit) -> Select {
+      Select(distinct: base.distinct, projection: base.projection,
+             from: base.from, joins: base.joins, predicate: base.predicate,
+             grouping: base.grouping, having: base.having,
+             window: base.window, order: base.order, limit: limit)
+    }
+    let offset: Query = .select(rebuilt(Limit(count: 1, offset: -1)))
+    #expect(throws:
+        SQLError.state("2201X", "OFFSET row count must be non-negative")) {
+      try fixture().run(offset)
+    }
+    #expect(throws:
+        SQLError.state("2201X", "OFFSET row count must be non-negative")) {
+      _ = try fixture().columns(of: offset, validate: true)
+    }
+    let count: Query = .select(rebuilt(Limit(count: -1)))
+    #expect(throws:
+        SQLError.state("2201W", "FETCH row count must be non-negative")) {
+      try fixture().run(count)
+    }
+  }
+
+  @Test func `a valid unused WINDOW definition is accepted and dropped`()
+      throws {
+    // An unused named window whose ORDER BY names a real column is well-formed,
+    // so it validates and is dropped — the query runs exactly as it would with
+    // no WINDOW clause, matching the ordinary grouped path's treatment of an
+    // unused definition.
+    let sql = "SELECT dept, ROW_NUMBER() OVER (ORDER BY SUM(sal)) FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept), ()) WINDOW w AS (ORDER BY dept)"
+    try fixture().expect(sql, yields: [[1, 1], [2, 3], [3, 2], [nil, 4]])
+  }
+
+  @Test func `a stateful leaf evaluates independently at each site`() throws {
+    // A non-deterministic `tick()` in the projection and in the window `ORDER
+    // BY` is not collapsed onto one shared union column: each site takes its
+    // own arm column, so the two evaluate independently — six calls over the
+    // three groups, not three — matching the plain grouped-window path, not
+    // reading one shared value. A deterministic operand (a group key, an
+    // aggregate) still shares one column; only a stateful one is kept distinct.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    // The arm evaluates its two `tick()` columns left to right per group — the
+    // projected `*gw0` (1, 3, 5) and the window key `*gw1` (2, 4, 6) — and the
+    // window numbers by the ascending key, so the ranks are 1, 2, 3.
+    try fixture().expect(
+        "SELECT tick(), ROW_NUMBER() OVER (ORDER BY tick()) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept))",
+        yields: [[1, 1], [3, 2], [5, 3]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `an unnamed windowed output stays an ordinal-only header`()
+      throws {
+    // An originally-unnamed windowed grouping-sets output feeding an outer
+    // set-op carrier keeps its synthesized `column N` display header and stays
+    // ordinal-only: a delimited `ORDER BY "column N"` binds no output — the
+    // synthesized header is not a spellable name — so it faults `.column`, as
+    // it does over any derived union, not the outer carrier capturing it.
+    let arm = "SELECT SUM(sal), ROW_NUMBER() OVER () FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept))"
+    // The two outputs display as the positional headers, marked synthesized.
+    let headers = try fixture().columns(of: parse(query: arm), validate: true)
+        .map(\.name)
+    #expect(headers == ["column 1", "column 2"])
+    // Feeding an outer UNION, a delimited-name ORDER BY on either synthesized
+    // header faults; the ordinal still orders that output.
+    let union = "\(arm) UNION SELECT dept, dept FROM Emp"
+    try fixture().expect("\(union) ORDER BY \"column 1\"",
+                         fails: .column("column 1"))
+    try fixture().expect("\(union) ORDER BY \"column 2\"",
+                         fails: .column("column 2"))
+    #expect(throws: SQLError.column("column 1")) {
+      _ = try fixture().columns(of: parse(query:
+          "\(union) ORDER BY \"column 1\""), validate: true)
+    }
   }
 }


### PR DESCRIPTION
A window function whose query groups by GROUPING SETS, ROLLUP, or CUBE has nowhere to attach: the grouping sets compile to a UNION ALL of per-set aggregate arms, and an OVER(...) clause must see the whole union as its input relation. Lower it directly at the plan level instead of rewriting the query into a derived table, which would sit before scope resolution and drop the context the query carries.

Compile the arm union to a .setop plan and build an inert union-output scope over its slots -- name-keying only, no derived-table boundary -- then drive the existing WindowSurface/materialise/shaped machinery, the same path Grouped drives over an aggregate node, to place a window node above the union. Grouped values reach the arm columns through a uniform Lift walk that substitutes each maximal grounded atom -- a bare aggregate, a GROUPING() call, or a group-key column -- with a synthetic *gwN union column, leaving every other expression outer at its natural plan level.

Subqueries are lifted per arm in this first cut; hosting them in the outer window layer follows. The query is typed and executed by the same lowering, so a validated query is an executable one.