### PR TITLE
SQLEngine: execute the windowed union through the carrier-aware paths

### DIFF
--- a/SwiftSQL/Sources/SQLEngine/AST.swift
+++ b/SwiftSQL/Sources/SQLEngine/AST.swift
@@ -651,7 +651,6 @@ public struct Select: Hashable, Sendable {
   /// caller picks to mirror the resolver's lowering (see `orderKeys`).
   private func keys(named output: KeyPath<Projected, String?>)
       -> Array<Expression> {
-    guard let order else { return [] }
     // Only an `expressions` list carries a projection expression an ordinal or
     // an output-name key could reach; a `*` or bare-column projection names
     // plain column slots compilation already resolves.
@@ -661,32 +660,7 @@ public struct Select: Hashable, Sendable {
     } else {
       items = []
     }
-    var expressions = Array<Expression>()
-    for key in order.keys {
-      switch key.sort {
-      case let .ordinal(position):
-        // An ordinal names the `position`-th projected output (1-based); the
-        // sort recomputes that item's expression below the limit. An
-        // out-of-range ordinal is `compile`'s fault to raise, so skip it here.
-        if position >= 1, position <= items.count {
-          expressions.append(items[position - 1].expression)
-        }
-      case let .expression(expression):
-        // A bare unqualified name binds a matching projection output name
-        // before an input column (the ISO precedence), resolving to that
-        // item's expression — the output surface (`output`) mirrors the
-        // resolver's lowering for this query shape.
-        if case let .column(column) = expression, column.qualifier == nil,
-            let item = items.first(where: {
-              $0[keyPath: output]?.lowercased() == column.name.lowercased()
-            }) {
-          expressions.append(item.expression)
-        } else {
-          expressions.append(expression)
-        }
-      }
-    }
-    return expressions
+    return SQLEngine.orderKeys(items, order, named: output)
   }
 
   /// The projection and ORDER BY expressions the select evaluates, for routing
@@ -714,6 +688,38 @@ public struct Select: Hashable, Sendable {
     }
     return evaluated
   }
+}
+
+/// The `order` sort keys resolved to the value expression each sort evaluates,
+/// over the projected `items` — the one resolver a select's `orderKeys` and a
+/// windowed grouping-sets outer layer share, so the sort-output model cannot
+/// drift. An ordinal names the `position`-th item (1-based); a bare
+/// unqualified name binds a matching output `named` before an input column (the
+/// ISO precedence); any other key keeps its own expression. An out-of-range
+/// ordinal is `compile`'s fault to raise, so it is skipped here.
+internal func orderKeys(_ items: Array<Projected>, _ order: Order?,
+                        named: KeyPath<Projected, String?>)
+    -> Array<Expression> {
+  guard let order else { return [] }
+  var expressions = Array<Expression>()
+  for key in order.keys {
+    switch key.sort {
+    case let .ordinal(position):
+      if position >= 1, position <= items.count {
+        expressions.append(items[position - 1].expression)
+      }
+    case let .expression(expression):
+      if case let .column(column) = expression, column.qualifier == nil,
+          let item = items.first(where: {
+            $0[keyPath: named]?.lowercased() == column.name.lowercased()
+          }) {
+        expressions.append(item.expression)
+      } else {
+        expressions.append(expression)
+      }
+    }
+  }
+  return expressions
 }
 
 /// A relation in a `FROM` or `JOIN`: a base relation named by an identifier, or

--- a/SwiftSQL/Sources/SQLEngine/Compilation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Compilation.swift
@@ -2158,10 +2158,6 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> Plan {
     let routines = context.routines
     let parts = try decompose(windowed: select, sets: sets, routines)
-    // The outer window layer reads only `*gwN` union columns and window slots,
-    // so it nests no subquery — the `Lift` pushed a subquery-bearing
-    // window-free operand into an arm — and resolves with no subquery surface.
-    let none = Resolution.unsupported
     // Compile the window-free arm union in the enclosing context and derive its
     // output columns — the `*gwN`-named, type-unified result columns the window
     // layer reads. The union plan's output sits at slots `0 ..< arity` (a
@@ -2177,6 +2173,22 @@ extension Catalog where Self: ~Escapable {
     // resolves unqualified over `schema`; its inner query is inspected nowhere,
     // so the union's arm-0 `SELECT` stands in for the derived relation.
     let scope = Scope([(Relation(derived: parts.union.arm, as: ""), schema)])
+    // The outer layer hosts every subquery the `Lift` kept out of the arms — an
+    // uncorrelated one it did not push into a `*gwN` column — resolved against
+    // the union scope, so a `LEAD` default or a `CASE` branch nesting a
+    // subquery stays lazy above the cap. Build the same `Resolution` the schema
+    // twin builds, over the outer projection and `ORDER BY`, keyed by the
+    // enclosing select's own subquery roles.
+    var hosted = Array<Query>()
+    for item in parts.projection {
+      item.expression.collect(subqueries: &hosted)
+    }
+    for key in parts.order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(subqueries: &hosted)
+      }
+    }
+    let outer = try subquery(hosted, select, context, within: scope)
 
     // The distinct windows the outer layer computes, gathered from the lifted
     // projection and `ORDER BY`. An unsupported function or frame faults the
@@ -2201,7 +2213,7 @@ extension Catalog where Self: ~Escapable {
       try function.require(order: spec)
       if let frame = spec.frame {
         let ordering = try frame.measured
-            ? scope.ordering(spec, routines, subquery: none)
+            ? scope.ordering(spec, routines, subquery: outer)
             : nil
         try frame.reject(for: function, order: ordering)
       }
@@ -2214,11 +2226,11 @@ extension Catalog where Self: ~Escapable {
         Dictionary(uniqueKeysWithValues: (0 ..< arity).map { ($0, $0) })
     var windowed = Windowed(scope, identity, width: arity)
     let projection = try windowed.terms(.expressions(parts.projection),
-                                        routines, subquery: none)
+                                        routines, subquery: outer)
     var order = Array<SortKey>()
     if let clause = parts.order {
       order = try windowed.order(clause, projection, routines,
-                                 subquery: none)
+                                 subquery: outer)
     }
     // Under DISTINCT every `ORDER BY` key must be a select-list value (see
     // `distinct`); the keys and projection are in the window's output slot

--- a/SwiftSQL/Sources/SQLEngine/Definition.swift
+++ b/SwiftSQL/Sources/SQLEngine/Definition.swift
@@ -308,10 +308,30 @@ extension Catalog where Self: ~Escapable {
     // them as one derived layer that shadows an outer CTE or derived alias of
     // the same name in the scope this SELECT resolves its own references
     // against (projection/WHERE/JOIN-ON/GROUP/HAVING).
+    //
+    // A multi-set windowed `GROUP BY GROUPING SETS` select keeps a `.select`
+    // body but its FROM/JOIN derived tables are arm-scoped: the window rides
+    // above the arm union, and each expanded arm re-materialises the source
+    // (the carrier-aware executor per-arm augments it), matching the non-
+    // windowed grouping-sets over the same source. Bind the schema here — the
+    // optimiser needs the derived alias resolvable for its seek/nest rewrite —
+    // but not the rows: a stateful source materialised once at the query level
+    // would have every arm reuse those rows, diverging from the non-windowed
+    // form (whose `.setop` body carries no query-level derivation at all, so
+    // its arms materialise per arm). The run reveals this schema layer before
+    // the carrier-aware execute, so each arm re-materialises the rows.
+    //
+    // A single-set spelling has no arm union (`unioned` is false): one
+    // arm, so per-arm and per-query materialisation coincide. Materialise its
+    // rows here (not arm-scoped) so the ordinary per-query executor the run
+    // routes it through reads them — the `run` carrier fork keys on the same
+    // `unioned`, so the two decide the single-arm shape together.
+    let deferred = query.unioned
     var layer = Dictionary<String, RelationInstance>()
     for (alias, inner, columns) in derivations {
       layer[alias.lowercased()] =
-          try materialise(inner, scope, rows: rows, columns: columns)
+          try materialise(inner, scope, rows: rows && !deferred,
+                          columns: columns)
     }
     return context.scoping(augmented.pushing(layer))
   }

--- a/SwiftSQL/Sources/SQLEngine/Engine.swift
+++ b/SwiftSQL/Sources/SQLEngine/Engine.swift
@@ -121,6 +121,37 @@ extension Catalog where Self: ~Escapable {
     if !query.carriers.isEmpty, case .setop = query.body {
       return try execute(plan, carrying: query.core, augmented).map(\.values)
     }
+    // A multi-set windowed `GROUP BY GROUPING SETS` select lowers to a
+    // `.window` over the arm `union`'s `.setop` (`windowed(sets:)`), yet
+    // keeps a `.select` body: `expanded` does not desugar it, since the window
+    // must ride above the union, not inside each arm. So neither carrier
+    // branch above fires, and the plain `execute` below would run the buried
+    // setop under the one augmented context — every arm scanning the derived
+    // source the query-level augment bound a single time — where the non-
+    // windowed grouping-sets, a `.setop` routed carrier-aware, materialises it
+    // per arm. Recover the arm union the compile split off (`decompose`, the
+    // single source of that split) and route the plan through the same carrier-
+    // aware executor, whose `.window` descent carries the union to the setop
+    // leaf and per-arm augments it. `augment` bound this query's derived tables
+    // schema-only (`unioned`), so the query-level materialise fired no
+    // stateful source; `revealed` drops that schema layer so each arm
+    // materialises the rows itself — matching the non-windowed form. A stray
+    // plan node the `.window` descent does not carry through (a fused `top`)
+    // reads the same revealed base, whose store relations and CTEs it keeps.
+    //
+    // A single-set spelling (a non-empty `((x))` or the grand total `(())`) has
+    // no arm union — `decompose` returns a plain grouped `.select`, one arm,
+    // not a `.setop` — so there is nothing to carry per arm, no schema layer to
+    // reveal: `augment` (keyed on the same `unioned`) materialised its
+    // derived rows once already. `unioned` is false, so it skips the
+    // carrier route and falls through to the ordinary `execute` below, which
+    // reads those rows and runs the `.window` over the lone grouped arm. Both
+    // forks decide the single-arm shape by one predicate, so a future routing
+    // change cannot handle the multi-arm case yet miss the single arm.
+    if let union = try query.union(windowed: context.routines) {
+      return try execute(plan, carrying: union, augmented.revealed())
+          .map(\.values)
+    }
     // A carrier over a bare `SELECT` (a parenthesised simple query with an
     // outer tail — `(SELECT …) ORDER BY …`) has no set-operation arms to
     // augment, so its `.shaped` plan runs through the plain executor; only a

--- a/SwiftSQL/Sources/SQLEngine/Filter.swift
+++ b/SwiftSQL/Sources/SQLEngine/Filter.swift
@@ -1319,6 +1319,16 @@ extension Catalog where Self: ~Escapable {
     guard let plan = context.subqueries.plan(key, correlation) else {
       throw .named("a correlated subquery plan was not compiled")
     }
+    // A windowed `GROUP BY GROUPING SETS` subquery keeps a `.select` body over
+    // a hidden arm union, so the `.setop` check below misses it; the one shared
+    // decision recovers that union and this per-row execution routes it through
+    // the same carrier descender, over a `revealed()` context so each arm
+    // re-materialises its schema-only derived layer — the parity a top-level
+    // `run` gets. Without this a correlated windowed grouping-sets body scanned
+    // the schema-only source once, dropping the arm rows.
+    if let union = try key.query.union(windowed: context.routines) {
+      return try execute(plan, carrying: union, context.revealed())
+    }
     // A SET-operation subquery augments per ARM (arm-local derived aliases the
     // query-level augment misses); a single query augments the whole query
     // once. A carried union compiles to a `.shaped` plan (a project/sort/
@@ -1438,6 +1448,16 @@ extension Catalog where Self: ~Escapable {
       // uses, so a mixed-type arm widens identically here.
       return try combine(kind, arms(left, leftQuery, context),
                          arms(right, rightQuery, context), all, types: types)
+    }
+    // An arm that is itself a windowed `GROUP BY GROUPING SETS` select keeps a
+    // `.select` body over a hidden arm union, so the `.setop` check below
+    // misses it; the one shared decision recovers that union and this arm
+    // descends it carrier-aware over a `revealed()` context, per-arm
+    // re-materialising its schema-only derived layer — the parity a top-level
+    // `run` gets. Without this a `(windowed grouping-sets) UNION …` arm scanned
+    // the schema-only source once, dropping its per-group rows.
+    if let union = try query.union(windowed: context.routines) {
+      return try execute(plan, carrying: union, context.revealed())
     }
     // An arm that is itself a suffix-bearing parenthesised set operation
     // (`… UNION (… UNION … ORDER BY V FETCH n)`) reaches here as an

--- a/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
+++ b/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
@@ -4,6 +4,68 @@
 // MARK: - GROUPING SETS
 
 extension Query {
+  /// Whether this query is a windowed `GROUP BY GROUPING SETS` select — a
+  /// window function over a grouping-sets query. `expanded` does not desugar
+  /// such a select to its `UNION ALL` (the window must ride above the arm
+  /// union, not inside each arm), so it keeps a `.select` body while its result
+  /// is the arm union; the compile lowers it directly (`windowed(sets:)`) and
+  /// the run routes it through the carrier-aware executor over that union.
+  ///
+  /// The predicate matches the compile gate (`compile(_ select:)`), so the two
+  /// recognise the same shape. A multi-set spelling's FROM/JOIN derived tables
+  /// are arm-scoped, not query-scoped: `augment` binds their schema but not
+  /// their rows (a stateful source must not fire once at the query level and be
+  /// reused by both arms), the arms materialising the rows per arm — as a
+  /// `.setop` body's arms already do. A single-set spelling has no such arm
+  /// union (see `unioned`), so it is not arm-scoped: it materialises and
+  /// runs through the ordinary per-query path.
+  internal var windowing: Bool {
+    guard case let .select(select) = body, select.windows,
+        case .sets = select.grouping else { return false }
+    return true
+  }
+
+  /// Whether a `windowing` select's arm union is a genuine set operation —
+  /// two or more grouping sets, so `expand` (which `decompose` drives) reduces
+  /// it to a `.setop`. A single set — a non-empty `((x))` or the grand total
+  /// `(())` — reduces to one plain grouped `.select`, not a `.setop`: there is
+  /// no union, one arm.
+  ///
+  /// The per-arm carrier path assumes that setop — its `.window` descent
+  /// carries the union to the setop leaf and per-arm augments each arm's
+  /// derived layer, which the schema-only `augment` deferred. A single arm has
+  /// nothing to carry and no per-arm augment, so it runs the ordinary per-query
+  /// path: `augment` materialises its derived rows once (one arm, so per-arm
+  /// and per-query coincide) and the ordinary executor reads them. Both the
+  /// `augment` schema-only bind and the `run` carrier routing fork on this one
+  /// predicate, so the single-arm shape is decided at the same point as the
+  /// multi-arm and a future routing change cannot silently miss it. The
+  /// predicate agrees with the decomposed union's body: `sets.count > 1` iff
+  /// `decompose(windowed:sets:).union` is a `.setop` (both driven by `expand`).
+  internal var unioned: Bool {
+    guard windowing, case let .select(select) = body,
+        case let .sets(sets) = select.grouping else { return false }
+    return sets.count > 1
+  }
+
+  /// The hidden arm union a windowed `GROUP BY GROUPING SETS` select must
+  /// execute carrier-aware over — the `.setop` `decompose` splits off the
+  /// `.select` body — or `nil` when this query carries no such union and runs
+  /// through the ordinary per-query executor. A `unioned` select keeps a
+  /// `.select` body while its result is the arm union, so a `.setop`-only union
+  /// check misses it; every executor entry point (`run`, the view `derive`, the
+  /// correlated `executed`) instead consults this one decision, routing a
+  /// non-`nil` result through `execute(_:carrying:)` over a `revealed()`
+  /// context — the schema-only `augment` deferred each arm's derived layer, and
+  /// `revealed` drops that layer so each arm re-materialises it. Sharing the
+  /// decision keeps a future entry point from open-coding a `.setop`-only
+  /// recognition that silently scans the schema-only source once.
+  internal func union(windowed routines: Routines) throws(SQLError) -> Query? {
+    guard unioned, case let .select(select) = body,
+        case let .sets(sets) = select.grouping else { return nil }
+    return try decompose(windowed: select, sets: sets, routines).union
+  }
+
   /// This query with each top-level `GROUP BY GROUPING SETS` select replaced by
   /// its `UNION ALL` expansion — applied once at every pipeline entry (`run`,
   /// `compile`, `columns(of:)`), so the whole downstream (materialise, augment,
@@ -33,7 +95,7 @@ extension Query {
           // A window over a `GROUPING SETS` query sees the whole result set —
           // the union of every set's rows (ISO 9075) — not one arm's grouped
           // rows, so the window layer rides above the union rather than inside
-          // an arm. A windowed grouping-sets select is NOT desugared here: it
+          // an arm. A windowed grouping-sets select is not desugared here: it
           // is lowered directly at compile — the window node placed above the
           // arm union's `setop` plan, over the union-output scope (`compile(_
           // select:)`) — so no derived-table boundary drops its context. The
@@ -221,7 +283,12 @@ internal func expand(_ select: Select,
   // would hide a FROM-clause derived table from the query-level derived-table
   // collection and per-arm execution, faulting `.relation` at run. Re-attach
   // the query-level clauses to the single grouped arm and return it plain, so
-  // the ordinary `SELECT` path materialises its derived tables.
+  // the ordinary `SELECT` path materialises its derived tables. The `WINDOW`
+  // clause rides onto the arm as it does for the multi-set union, so the arm
+  // compile validates every named definition against the grouped source — an
+  // unused `WINDOW bad AS (ORDER BY nonesuch)` still faults its undefined
+  // column, as the multi-set and ordinary grouped forms do, rather than being
+  // dropped unvalidated on a single-set query.
   if sets.count == 1 {
     return .select(Select(distinct: select.distinct,
                           projection: select.projection, from: select.from,
@@ -245,7 +312,7 @@ internal func expand(_ select: Select,
 
 /// The decomposition of a windowed `GROUP BY GROUPING SETS` `select` into the
 /// two halves the direct lowering composes — the window-free arm `union` and
-/// the outer window layer's `projection` and `order` over it. It is NOT an AST
+/// the outer window layer's `projection` and `order` over it. It is not an AST
 /// rewrite to a derived table: the compile seam (`compile(_ select:)`) compiles
 /// the `union` to a `setop` plan, builds the union-output `Scope`, and drives
 /// the shared window machinery over it, placing a `window` node above the arm
@@ -260,11 +327,12 @@ internal struct WindowedSets {
   internal let items: Array<Projected>
 
   /// The outer window layer's projection — each original item with every
-  /// window-free subexpression lifted to a synthetic `*gwN` reference of the
-  /// union output, a window kept with its operands lifted. Each item carries
-  /// the original item's inferable output name as its alias (`nil` for an
-  /// unnamed one), so a query `ORDER BY` names a window alias while an unnamed
-  /// output stays a synthesized header, never the internal `*gwN` name.
+  /// group-dependent subexpression lifted to a synthetic `*gwN` reference of
+  /// the union output, each group-independent scalar (`tick()`, `1 / 0`) kept
+  /// outer, a window kept with its operands lifted. Each item carries the
+  /// original item's inferable output name as its alias (`nil` for an unnamed
+  /// one), so a query `ORDER BY` names a window alias while an unnamed output
+  /// stays a synthesized header, never the internal `*gwN` name.
   internal let projection: Array<Projected>
 
   /// The outer window layer's query-level `ORDER BY`, each key lifted to read
@@ -302,11 +370,16 @@ internal struct WindowedSets {
 ///     column, as the ordinary and non-windowed aggregate forms do;
 ///
 ///   - the outer window layer: the original projection and `ORDER BY` with
-///     every lifted subexpression rewritten to its `*gwN` reference of the
-///     union output. Each window's `PARTITION BY`/`ORDER BY`/argument now reads
-///     a computed column of the union — a `SUM(x)` a window orders by is
-///     already materialised, the window reads it and does not re-aggregate — so
-///     the window computes over the full result set.
+///     every group-dependent subexpression rewritten to its `*gwN` reference of
+///     the union output and every group-independent scalar (`tick()`, `1 / 0`)
+///     kept outer. Each window's `PARTITION BY`/`ORDER BY`/argument now reads a
+///     computed column of the union — a `SUM(x)` a window orders by is already
+///     materialised, the window reads it and does not re-aggregate — so the
+///     window computes over the full result set. A projection-only group-
+///     independent scalar stays above the window and the query-level cap,
+///     evaluated after the window as the ordinary grouped-window path evaluates
+///     its projection, so the single-set spelling observes the same values the
+///     ordinary `GROUP BY` form does (#137).
 ///
 /// The lifted `*gwN` references are unqualified: the compile seam builds the
 /// union-output `Scope` keyed by the empty alias (as the `ordered` set-op
@@ -315,14 +388,31 @@ internal struct WindowedSets {
 /// enclosing context, so a correlated arm reference (an enclosing LATERAL
 /// `T.Id`) resolves natively — no `VALUES (1)` unit or LATERAL apply is needed.
 ///
-/// A window-free subexpression is lifted to one shared `*gwN` column only when
-/// it is deterministic under `routines` (a group key, an aggregate, a scalar
-/// over such, a deterministic call) — so a `SUM(x)` a window orders by and the
-/// projection also yields is one column, read never re-aggregated. A non-
-/// deterministic one (a `tick()` in the projection and the window `ORDER BY`
-/// alike) takes a fresh column per occurrence, so each site evaluates it
-/// independently, matching the plain grouped-window path rather than collapsing
-/// the two sites onto one union column.
+/// The rewrite is one uniform substitution walk (`Lift.substitute`): each
+/// maximal grounded atom the union scope cannot compute — a bare `.aggregate`,
+/// a `.grouping(…)`, or a group column — lifts to a `*gwN` arm column, while
+/// every other node (a literal, a group-independent scalar, an arithmetic/
+/// `CAST`/`COALESCE`/`NULLIF`, a `CASE`'s structure, a window function's
+/// operands) stays outer with its operands recursed. The residual then flows to
+/// the same `Windowed`/`materialise`/`shaped` machinery the plain window path
+/// drives, so its placement is inherited, not re-implemented: a projection-only
+/// scalar and a grounded `CASE`'s structure sit above the query-level cap
+/// (`Project(Limit(Sort))`), so a dropped page never evaluates them (#137); a
+/// `LEAD`/`LAG` default stays a lazily evaluated operand; and a window reads
+/// its `*gwN` arm slots as the plain path reads its materialised source cells.
+/// A lifted atom is shared to one `*gwN` column only when deterministic under
+/// `routines` (a group key, an aggregate over steady parts), so a `SUM(x)` a
+/// window orders by and the projection also yields is one column; a non-
+/// deterministic one (`SUM(tick())`) takes a fresh column per occurrence. The
+/// exception is a projected output a window ordinal links to (`ORDER BY 1`):
+/// the ordinal ties the key to that output, so the output lifts to the arm
+/// whole, shared with the key — one evaluation, the window ordering by the
+/// reported column.
+///
+/// A scalar subquery uncorrelated to this query is hosted in the outer layer
+/// through the union-scope `Resolution` (kept verbatim so a `LEAD` default or a
+/// `CASE` branch nesting it stays lazy), while one correlated to a group key
+/// stays arm-lifted, where the arm's grouped scope binds the correlation.
 ///
 /// A window `FILTER` and a windowed `CASE` are the two operand shapes not
 /// lowered here — each carries a `Predicate` a `*gwN` column cannot stand in
@@ -356,20 +446,51 @@ internal func decompose(windowed select: Select,
     []
   }
 
+  // The projected outputs a window `ORDER BY` ordinal links to (`Order.Key
+  // .output`, stamped by the prelude's `resolving(ordinals:)`). Such an output
+  // and every window key naming it must read one `*gwN` leaf — the operand
+  // evaluated once, the window ordering by the reported value — even when it is
+  // non-deterministic, mirroring how `materialise` shares an ordinal value
+  // on the ordinary path. A window `ORDER BY` names only a window-free output
+  // (`resolving(ordinals:)` rejects a window output), so a linked output lifts
+  // to a single leaf the key can share.
+  let targets = ordinals(of: items, select.order)
+  // The bare names of the group-key columns — the columns a correlated subquery
+  // may reference (ISO restricts a grouped correlation to a grouping column).
+  // The lifter reads them to route a subquery: one naming a group key is
+  // correlated to this query and stays arm-lifted, resolved in the arm's
+  // grouped scope; one naming none is uncorrelated and hosted in the outer
+  // layer through the union-scope `Resolution`.
+  var keys = Set<String>()
+  for set in sets {
+    for key in set { key.collect(columns: &keys) }
+  }
   // Lift the projection and the query-level ORDER BY over the union output,
-  // gathering the window-free operands each references into `lift.leaves`. Each
-  // outer item carries the original item's inferable output name as its alias
-  // (`nil` for an unnamed one) — a bare group column stays named, an aliased
-  // value keeps its alias — so a query `ORDER BY` may name a window alias,
-  // while an unnamed output takes no `*gwN` name and stays a synthesized
-  // `column N` header (the schema twin names it from `items`).
-  var lift = Lift(routines)
+  // gathering the operands each references into `lift.leaves`. Each outer item
+  // carries the original item's inferable output name as its alias (`nil` for
+  // an unnamed one) — a bare group column stays named, an aliased value keeps
+  // its alias — so a query `ORDER BY` may name a window alias, while an unnamed
+  // output takes no `*gwN` name and stays a synthesized `column N` header (the
+  // schema twin names it from `items`).
+  var lift = Lift(routines, keys: keys)
   var projection = Array<Projected>()
   projection.reserveCapacity(items.count)
   for index in items.indices {
-    projection.append(
-        Projected(expression: try lift.lift(items[index].expression),
-                  alias: items[index].name))
+    // An output a window `ORDER BY` ordinal links to lifts through the ordinal
+    // channel keyed by its index, so the window key naming it (earlier or
+    // later in the list) shares the same leaf — one evaluation, the window
+    // ordering by the reported value; that output is a window operand via the
+    // link, so it lifts to the arm whole even when group-independent. Every
+    // other output takes the uniform substitution walk (`substitute`): each
+    // grounded atom it references lifts to a `*gwN` arm column, its literals
+    // and group-independent scalars kept outer, evaluated after the window.
+    let lifted: Expression
+    if targets.contains(index) {
+      lifted = lift.lift(items[index].expression, output: index)
+    } else {
+      lifted = try lift.substitute(items[index].expression)
+    }
+    projection.append(Projected(expression: lifted, alias: items[index].name))
   }
   // The projected output names — a bare unqualified ORDER BY key naming one
   // orders on that output (ISO output-alias precedence), so it is left to
@@ -377,7 +498,7 @@ internal func decompose(windowed select: Select,
   // reference.
   let outputs = Set(items.compactMap { $0.name?.lowercased() })
   let order: Order? = if let clause = select.order {
-    Order(keys: try clause.keys.map { key throws(SQLError) in
+    try Order(keys: clause.keys.map { key throws(SQLError) in
       switch key.sort {
       case .ordinal:
         // A query-level ordinal names an outer projected column by position —
@@ -388,8 +509,9 @@ internal func decompose(windowed select: Select,
             outputs.contains(column.name.lowercased()) {
           return key
         }
-        var lifted = Order.Key(sort: .expression(try lift.lift(expression)),
-                               ascending: key.ascending)
+        var lifted =
+            try Order.Key(sort: .expression(lift.substitute(expression)),
+                          ascending: key.ascending)
         lifted.output = key.output
         return lifted
       }
@@ -430,110 +552,348 @@ internal func decompose(windowed select: Select,
                       union: union)
 }
 
-/// The lifter that rewrites a windowed grouping-sets query's outer expressions
-/// over the arm union output, gathering the window-free operands to push into
-/// the arms.
+/// The 0-based outputs a window `ORDER BY` ordinal links to across the `items`
+/// projection and the query-level `order` — the provenance the prelude
+/// (`WindowSpec.resolving(ordinals:)`) stamped on each window sort key it
+/// substituted for an output ordinal. A window naming an output pins its rank
+/// to that output's value, so the lifter shares one `*gwN` leaf between the
+/// output and every key that names it. A window `ORDER BY` names only a window-
+/// free output, so a linked output is always a single-leaf value.
+private func ordinals(of items: Array<Projected>, _ order: Order?) -> Set<Int> {
+  var windows = Array<Expression>()
+  for item in items { item.expression.collect(windows: &windows) }
+  for key in order?.keys ?? [] {
+    if case let .expression(expression) = key.sort {
+      expression.collect(windows: &windows)
+    }
+  }
+  var outputs = Set<Int>()
+  for expression in windows {
+    guard case let .window(_, spec) = expression, let order = spec.order
+    else { continue }
+    for key in order.keys {
+      if let output = key.output { outputs.insert(output) }
+    }
+  }
+  return outputs
+}
+
+/// The substitution walk that rewrites a windowed grouping-sets query's outer
+/// expressions over the arm union output, gathering the grounded atoms to push
+/// into the arms.
 ///
-/// Each maximal window-free subexpression (anything but a bare literal) is a
-/// value the grouped arms compute — a group key, an aggregate, a `GROUPING(…)`,
-/// a scalar over them, a whole window-free `CASE` — so it is pushed to `leaves`
-/// once (deduplicated by structural identity) and replaced with a reference to
-/// its synthetic `*gwN` union column. A bare literal needs no arm column and
-/// stays in the outer projection. A window function is kept in the outer, its
-/// `PARTITION BY`/`ORDER BY`/argument operands lifted so they read the union
-/// columns.
+/// Every outer expression — a projected item, a query-`ORDER BY` key, a window
+/// operand — is rewritten by one uniform walk (`substitute`): each maximal
+/// grounded atom the union-output scope cannot compute — a bare `.aggregate`, a
+/// `.grouping(…)`, or a group column — is replaced by a reference to its
+/// synthetic `*gwN` union column (deduplicated by determinism), while every
+/// other node is kept in the outer with its operands recursed — a literal, a
+/// pure or stateful scalar over literals (`tick()`, `1 / 0`), an arithmetic/
+/// `CAST`/`COALESCE`/`NULLIF`, a `CASE`'s guards and branches, and a window
+/// function's operands, a `LEAD`/`LAG` default included.
+///
+/// The residual (structure-preserved, leaf-substituted) expression then flows
+/// to the same `Windowed`/`materialise`/`shaped` machinery the plain window
+/// path drives, so its placement is inherited rather than re-implemented here:
+/// a group-independent scalar and a grounded `CASE`'s structure sit in the
+/// outer projection above the query-level cap (`Project(Limit(Sort))`), so a
+/// dropped page never evaluates them (#137); a `LEAD`/`LAG` default stays a
+/// lazily evaluated operand the executor reaches only for an out-of-range
+/// target; and a window reads its `*gwN` arm slots as the plain path reads its
+/// materialised source cells.
+///
+/// `scope.term` faults a bare `.aggregate`/`.grouping` (42803) and cannot
+/// resolve a base column against the `*gwN`-only union scope, so those atoms
+/// must be pre-projected by the arms and substituted; every other node the
+/// ordinary machinery resolves against the union scope directly. A scalar
+/// `.subquery` is pushed to an arm too — the outer layer hosts it via the
+/// union-scope `Resolution` `windowed(sets:)` passes, so a `.subquery` left
+/// outer resolves against it.
+///
+/// A window `FILTER` and a windowed `CASE` are the two shapes not lowered here
+/// — each carries a `Predicate` a `*gwN` column cannot stand in for — so each
+/// faults the feature diagnostic on both paths, in parity (#136).
 private struct Lift {
   /// The routines a lifted operand's determinism is judged against, deciding
   /// whether two occurrences share one `*gwN` column.
   private let routines: Routines
 
-  /// The window-free operands pushed into the arms, in first-appearance order —
-  /// arm column `*gwN` is `leaves[N]`.
+  /// The bare names of the group-key columns — the columns a correlated
+  /// subquery may reference. A subquery naming one is correlated to this query
+  /// and arm-lifted; one naming none is uncorrelated and hosted outer.
+  private let keys: Set<String>
+
+  /// The grounded atoms pushed into the arms, in first-appearance order — arm
+  /// column `*gwN` is `leaves[N]`.
   private(set) var leaves = Array<Expression>()
 
-  /// The `leaves` position each DETERMINISTIC pushed operand occupies, so an
-  /// operand written twice (a `SUM(x)` a window orders by that the projection
-  /// also yields) is one column. A non-deterministic operand is never recorded
-  /// here, so each occurrence takes a fresh column.
+  /// The `leaves` position each deterministic pushed atom occupies, so an atom
+  /// written twice (a `SUM(x)` a window orders by that the projection also
+  /// yields) is one column. A non-deterministic atom is never recorded here, so
+  /// each occurrence takes a fresh column.
   private var index = Dictionary<Expression, Int>()
 
-  fileprivate init(_ routines: Routines) {
+  /// The `leaves` position each ordinal-linked projected output occupies, keyed
+  /// by its 0-based output. A projected output a window `ORDER BY` ordinal
+  /// names and every window key carrying that output's provenance route through
+  /// it, so both read one column even when the operand is non-deterministic —
+  /// the value evaluated once, the window ordering by the reported column — the
+  /// explicit provenance a determinism test cannot supply. Keyed by output, not
+  /// expression, so two ordinals naming distinct outputs that hold an equal
+  /// stateful value stay independent, exactly as `materialise` keys its hoist.
+  private var linked = Dictionary<Int, Int>()
+
+  fileprivate init(_ routines: Routines, keys: Set<String>) {
     self.routines = routines
+    self.keys = keys
+  }
+
+  /// Registers `expression` as a column and returns its `leaves` position —
+  /// a deterministic atom folded onto its first occurrence (one shared column),
+  /// a non-deterministic one taking a fresh position each call.
+  private mutating func allocate(_ expression: Expression) -> Int {
+    let steady = expression.steady(routines)
+    if steady, let existing = index[expression] { return existing }
+    let position = leaves.count
+    if steady { index[expression] = position }
+    leaves.append(expression)
+    return position
   }
 
   /// The `*gwN` union reference for `expression`, registering it as an arm
-  /// column on first sight. A DETERMINISTIC operand reuses its position after
-  /// (one shared column), while a non-deterministic one (`tick()`) takes a
+  /// column on first sight. A deterministic atom reuses its position after (one
+  /// shared column), while a non-deterministic one (`SUM(tick())`) takes a
   /// fresh column per occurrence, so each site evaluates it independently. The
   /// reference is unqualified — the compile seam builds the union-output scope
   /// keyed by the empty alias, so a bare `*gwN` resolves against it by name,
   /// with no derived-table qualifier to match.
   private mutating func reference(_ expression: Expression) -> Expression {
-    let steady = expression.steady(routines)
-    if steady, let existing = index[expression] {
+    .column(Column(name: "*gw\(allocate(expression))"))
+  }
+
+  /// The `*gwN` union reference for a projected `output` a window `ORDER BY`
+  /// ordinal links to, keyed by the 0-based `output`. The projected output and
+  /// every window key carrying that output's provenance route here, so all read
+  /// one leaf — the operand evaluated once, the window ordering by the reported
+  /// value — even when it is non-deterministic (a `tick()`), matching how
+  /// `materialise` shares an ordinal-named value on the ordinary path. A
+  /// deterministic operand still folds through the shared `index` memo, so an
+  /// unlinked occurrence reuses it too; a directly written key (no `output`)
+  /// never routes here and stays an independent evaluation (#135).
+  private mutating func reference(_ expression: Expression, output: Int)
+      -> Expression {
+    if let existing = linked[output] {
       return .column(Column(name: "*gw\(existing)"))
     }
-    let position = leaves.count
-    if steady { index[expression] = position }
-    leaves.append(expression)
+    let position = allocate(expression)
+    linked[output] = position
     return .column(Column(name: "*gw\(position)"))
   }
 
-  /// This expression rewritten over the arm union — a window-free
-  /// subexpression pushed to an arm column, a window kept with its operands
-  /// lifted, a bare literal left as is.
-  fileprivate mutating func lift(_ expression: Expression) throws(SQLError)
+  /// This expression lifted as the projected output a window `ORDER BY` ordinal
+  /// links to — a window-free subexpression pushed to the `*gwN` arm column
+  /// keyed by `output`, shared with every window key naming the same output. A
+  /// bare literal needs no column (a constant reads the same twice) and stays
+  /// inline. The output is window-free by construction — the prelude rejects a
+  /// window as an ordinal's target — so this never meets a window operand.
+  fileprivate mutating func lift(_ expression: Expression, output: Int)
       -> Expression {
-    guard expression.windowed else {
-      // A bare literal needs no arm column and stays in the outer projection.
-      // Every other window-free subexpression — a group key, an aggregate, a
-      // `GROUPING(…)`, a scalar over them — is lifted to a `*gwN` arm column,
-      // computed in the arm's grouped scope and validated there (its reachable
-      // operands type-checked as the arm compiles), so a lifted operand faults
-      // on the run and validate paths alike. A non-deterministic operand takes
-      // a fresh column per occurrence (`reference`), so a `tick()` in the
-      // projection and the window `ORDER BY` are two evaluations, not one
-      // collapsed onto a shared arm column.
-      if case .literal = expression { return expression }
-      return reference(expression)
-    }
+    if case .literal = expression { return expression }
+    return reference(expression, output: output)
+  }
+
+  /// This outer expression rewritten over the arm union by the uniform
+  /// substitution walk — each maximal grounded atom the union scope cannot
+  /// compute (an aggregate, a `GROUPING(…)`, a group column, or a scalar
+  /// subquery the outer layer hosts through the union-scope `Resolution`)
+  /// replaced by its `*gwN` reference, every other node kept in the outer with
+  /// its operands recursed.
+  ///
+  /// A literal and a group-independent scalar (`tick()`, `1 / 0`) stay outer
+  /// verbatim (their operands hold no grounded atom); an arithmetic, `CAST`,
+  /// `COALESCE`, `NULLIF`, or `CASE` keeps its structure and recurses its
+  /// operands and guards; a window keeps its function and specification with
+  /// their operands recursed. The residual flows to the ordinary `Windowed`
+  /// machinery, which places it exactly as the plain window path places its
+  /// own — the outer projection above the cap, a `LEAD`/`LAG` default lazily.
+  fileprivate mutating func substitute(_ expression: Expression)
+      throws(SQLError) -> Expression {
     switch expression {
-    case let .window(function, spec):
-      return .window(function: try lift(function), spec: try lift(spec))
-    case let .call(name, arguments):
-      return .call(name: name, arguments: try lift(arguments))
-    case let .binary(operation, lhs, rhs):
-      return .binary(operation, try lift(lhs), try lift(rhs))
-    case let .cast(operand, type):
-      return .cast(try lift(operand), type)
-    case let .coalesce(arguments):
-      return .coalesce(try lift(arguments))
-    case let .nullif(lhs, rhs):
-      return .nullif(try lift(lhs), try lift(rhs))
-    case .case:
-      // A windowed `CASE`'s `WHEN` is a `Predicate` no derived column stands in
-      // for; defer it rather than leave a base column unresolved in the outer.
-      throw .state("0A000",
-                   "a window in a CASE with GROUPING SETS is not yet supported")
-    case .column, .literal, .aggregate, .subquery, .grouping:
-      // Window-free (the guard pushed or kept it) — unreachable here.
+    case .aggregate, .grouping, .column:
+      // A grounded atom the union scope cannot compute — an aggregate, a
+      // GROUPING bit-vector, or a group column — becomes its deduplicated
+      // `*gwN` reference, computed in the arm's grouped scope.
+      return reference(expression)
+    case let .subquery(query):
+      // A subquery uncorrelated to this query is hosted in the outer layer
+      // through the union-scope `Resolution` — kept verbatim so a `LEAD`
+      // default or a `CASE` branch nesting it stays lazy, evaluated only when
+      // reached — while one correlated to a group key stays arm-lifted (a
+      // `*gwN` reference) where the arm's grouped scope binds the correlation.
+      // Arm-lifting is always value-correct, so over-approximating the
+      // correlation only forgoes the lazy outer host, never mis-hosts a
+      // correlated subquery.
+      var referenced = Set<String>()
+      query.collect(columns: &referenced)
+      return referenced.isDisjoint(with: keys)
+          ? expression : reference(expression)
+    case .literal:
       return expression
+    case let .call(name, arguments):
+      return try .call(name: name, arguments: substitute(arguments))
+    case let .binary(operation, lhs, rhs):
+      return try .binary(operation, substitute(lhs), substitute(rhs))
+    case let .cast(operand, type):
+      return try .cast(substitute(operand), type)
+    case let .coalesce(arguments):
+      return try .coalesce(substitute(arguments))
+    case let .nullif(lhs, rhs):
+      return try .nullif(substitute(lhs), substitute(rhs))
+    case let .case(whens, otherwise):
+      // A CASE nesting a window carries a per-row Predicate/window shape no
+      // `*gwN` column stands in for (#136), so defer it; a window-free CASE
+      // keeps its structure outer, its guards and branches recursed so only
+      // their grounded atoms lift to arm columns.
+      let windowed = whens.contains { $0.when.windowed || $0.then.windowed }
+          || (otherwise?.windowed ?? false)
+      if windowed {
+        throw .state("0A000", "a window in a CASE with GROUPING SETS is not " +
+                              "yet supported")
+      }
+      var branches = Array<When>()
+      branches.reserveCapacity(whens.count)
+      for when in whens {
+        branches.append(try When(when: substitute(when.when),
+                                 then: substitute(when.then)))
+      }
+      let fallback: Expression?
+      if let otherwise {
+        fallback = try substitute(otherwise)
+      } else {
+        fallback = nil
+      }
+      return .case(branches, else: fallback)
+    case let .window(function, spec):
+      return try .window(function: substitute(function), spec: substitute(spec))
     }
   }
 
-  /// Each expression of `expressions` lifted, in order.
-  private mutating func lift(_ expressions: Array<Expression>)
+  /// Each expression of `expressions` substituted, in order — a manual loop
+  /// rather than `map`, so the typed `SQLError` throw propagates without
+  /// widening to `any Error`.
+  private mutating func substitute(_ expressions: Array<Expression>)
       throws(SQLError) -> Array<Expression> {
     var lifted = Array<Expression>()
     lifted.reserveCapacity(expressions.count)
-    for expression in expressions { lifted.append(try lift(expression)) }
+    for expression in expressions { lifted.append(try substitute(expression)) }
     return lifted
   }
 
-  /// This window function with its operands lifted over the arm union — a
-  /// ranking function is unchanged, an aggregate window lifts its argument, and
-  /// a positional function lifts its value and default.
-  private mutating func lift(_ function: WindowFunction)
+  /// An optional operand substituted — `nil` stays `nil` (a `LEAD`/`LAG` with
+  /// no default, a positional window's absent default). A default stays in the
+  /// outer window function with only its grounded atoms lifted, so the executor
+  /// evaluates it at its natural point (an out-of-range target only), not
+  /// eagerly per row.
+  private mutating func substitute(_ expression: Expression?)
+      throws(SQLError) -> Expression? {
+    guard let expression else { return nil }
+    return try substitute(expression)
+  }
+
+  /// This `CASE` guard predicate substituted over the arm union — each operand
+  /// expression recursed through `substitute`, the predicate's structure kept
+  /// in the outer projection. A grounded value (a `dept` column, an aggregate,
+  /// a `GROUPING(…)`) becomes a `*gwN` arm reference while the predicate shape
+  /// stays outer (`dept = 1` → `*gw0 = 1`); a group-independent operand (a
+  /// literal, a `:parameter`) stays verbatim. This does not split the predicate
+  /// across arms — only its grouped value operands become arm columns — over
+  /// comparison, bound, IS NULL, IN, row comparison and membership, LIKE,
+  /// BETWEEN, IS DISTINCT FROM, the boolean test, and AND/OR/NOT.
+  ///
+  /// A subquery-bearing form (`exists`/`within`/`quantified`) rebuilds
+  /// unchanged: the union-scope `Resolution` the outer layer resolves against
+  /// hosts the guard's subquery in place, so its enclosing predicate needs no
+  /// per-arm rewrite.
+  fileprivate mutating func substitute(_ predicate: Predicate)
+      throws(SQLError) -> Predicate {
+    switch predicate {
+    case let .comparison(left, op, right):
+      return try .comparison(left: substitute(left), op: op,
+                             right: substitute(right))
+    case let .bound(left, op, parameter):
+      return try .bound(left: substitute(left), op: op, parameter: parameter)
+    case let .null(operand, negated):
+      return try .null(substitute(operand), negated: negated)
+    case let .membership(operand, values, negated):
+      return try .membership(substitute(operand), substitute(values),
+                             negated: negated)
+    case let .rows(left, op, right):
+      return try .rows(substitute(left), op, substitute(right))
+    case let .among(left, rows, negated):
+      var lifted = Array<Array<Expression>>()
+      lifted.reserveCapacity(rows.count)
+      for row in rows { lifted.append(try substitute(row)) }
+      return try .among(substitute(left), lifted, negated: negated)
+    case let .like(operand, pattern, escape, negated):
+      return try .like(substitute(operand), pattern: substitute(pattern),
+                       escape: substitute(escape), negated: negated)
+    case let .between(operand, lower, upper, negated):
+      return try .between(substitute(operand), substitute(lower),
+                          substitute(upper), negated: negated)
+    case let .distinct(left, right, negated):
+      return try .distinct(substitute(left), substitute(right),
+                           negated: negated)
+    case let .truth(inner, value, negated):
+      return try .truth(substitute(inner), value: value, negated: negated)
+    case let .and(left, right):
+      return try .and(substitute(left), substitute(right))
+    case let .or(left, right):
+      return try .or(substitute(left), substitute(right))
+    case let .not(inner):
+      return try .not(substitute(inner))
+    case .exists, .within, .quantified:
+      // A subquery-bearing guard is hosted whole by the outer layer's union-
+      // scope `Resolution`, so rebuild it unchanged.
+      return predicate
+    }
+  }
+
+  /// A `LIKE`/`BETWEEN` operand substituted over the arm union — an expression
+  /// recursed through `substitute`, a `:parameter` (one value for the whole
+  /// execution, identical across every group, so group-independent) left
+  /// verbatim.
+  fileprivate mutating func substitute(_ operand: Predicate.Operand)
+      throws(SQLError) -> Predicate.Operand {
+    switch operand {
+    case let .expression(expression):
+      return try .expression(substitute(expression))
+    case .parameter:
+      return operand
+    }
+  }
+
+  /// An optional `LIKE` escape operand substituted — `nil` stays `nil`.
+  fileprivate mutating func substitute(_ operand: Predicate.Operand?)
+      throws(SQLError) -> Predicate.Operand? {
+    guard let operand else { return nil }
+    return try substitute(operand)
+  }
+
+  /// This window function with its operands substituted over the arm union — a
+  /// ranking function is unchanged, an aggregate window substitutes its
+  /// argument, a positional function substitutes its read-at-a-row value, and a
+  /// `LEAD`/`LAG` default substitutes too but stays in the outer function.
+  ///
+  /// A window reads most operands at a row — the aggregate argument, the
+  /// positional value, the `PARTITION BY`/`ORDER BY` keys — so the executor
+  /// materialises each once per source row (`Window.position`/`extremum`); the
+  /// grounded atoms substitute to `*gwN` arm slots the window reads, the rest
+  /// (a scalar, an offset arithmetic) kept in the operand. A `LEAD`/`LAG`
+  /// default is the conditional one: `Window.position` evaluates it only for an
+  /// out-of-range target, so it stays in the outer function with only its
+  /// grounded atoms lifted, the executor evaluating it at its natural point —
+  /// exactly as the ordinary grouped-window path's `reconciled` default does.
+  private mutating func substitute(_ function: WindowFunction)
       throws(SQLError) -> WindowFunction {
     switch function {
     case .number, .rank, .dense, .ntile, .percent, .cumulative:
@@ -549,46 +909,48 @@ private struct Lift {
       case .star:
         .star
       case let .expression(expression):
-        .expression(try lift(expression))
+        try .expression(substitute(expression))
       }
       return .aggregate(aggregate, of: lifted, distinct: distinct)
     case let .lead(value, offset, fallback):
-      return .lead(try lift(value), offset: offset,
-                   default: try lift(fallback))
+      return try .lead(substitute(value), offset: offset,
+                       default: substitute(fallback))
     case let .lag(value, offset, fallback):
-      return .lag(try lift(value), offset: offset,
-                  default: try lift(fallback))
+      return try .lag(substitute(value), offset: offset,
+                      default: substitute(fallback))
     case let .first(value):
-      return .first(try lift(value))
+      return try .first(substitute(value))
     case let .last(value):
-      return .last(try lift(value))
+      return try .last(substitute(value))
     case let .nth(value, position):
-      return .nth(try lift(value), position)
+      return try .nth(substitute(value), position)
     }
   }
 
-  /// An optional operand lifted — `nil` stays `nil` (a positional window's
-  /// absent default).
-  private mutating func lift(_ expression: Expression?)
-      throws(SQLError) -> Expression? {
-    guard let expression else { return nil }
-    return try lift(expression)
-  }
-
   /// This window specification with its `PARTITION BY` keys and `ORDER BY`
-  /// values lifted over the arm union — an ordinal key (a `SELECT *` window
-  /// order the prelude left unbound) is preserved, a value key's expression
-  /// lifted, the frame carried through.
-  private mutating func lift(_ spec: WindowSpec)
+  /// values substituted over the arm union — an ordinal key (a `SELECT *`
+  /// window order the prelude left unbound) is preserved, a value key's
+  /// expression substituted, the frame carried through.
+  private mutating func substitute(_ spec: WindowSpec)
       throws(SQLError) -> WindowSpec {
-    let partition = try lift(spec.partition)
+    let partition = try substitute(spec.partition)
     let order: Order? = if let clause = spec.order {
-      Order(keys: try clause.keys.map { key throws(SQLError) in
+      try Order(keys: clause.keys.map { key throws(SQLError) in
         switch key.sort {
         case .ordinal:
           return key
         case let .expression(expression):
-          var lifted = Order.Key(sort: .expression(try lift(expression)),
+          // A key the prelude substituted for an output ordinal (`key.output`)
+          // shares that output's `*gwN` leaf, so a non-deterministic operand is
+          // evaluated once and the window orders by the reported value; a
+          // directly written key substitutes to an independent leaf (#135).
+          let value: Expression
+          if let output = key.output {
+            value = lift(expression, output: output)
+          } else {
+            value = try substitute(expression)
+          }
+          var lifted = Order.Key(sort: .expression(value),
                                  ascending: key.ascending)
           lifted.output = key.output
           return lifted
@@ -637,6 +999,199 @@ extension Expression {
       }
     case .case, .subquery, .window:
       false
+    }
+  }
+}
+
+extension Query {
+  /// The bare (unqualified, case-folded) names of every column this query
+  /// references anywhere — its FROM/JOIN derived bodies, predicates,
+  /// projection, grouping, HAVING, ORDER BY, window specifications, and the
+  /// body of every subquery nested within, at any depth. The lifter reads it to
+  /// decide whether a candidate subquery correlates to the enclosing grouping-
+  /// sets query: one naming a group-key column is correlated (ISO restricts a
+  /// grouped correlation to a grouping column) and stays arm-lifted, one naming
+  /// none is uncorrelated and hosted outer. Over-approximating (a subquery's
+  /// own column shadowing a group-key name) only forgoes the outer host, never
+  /// mis-hosts a correlated one, so the routing stays sound.
+  fileprivate func collect(columns names: inout Set<String>) {
+    switch body {
+    case let .select(select):
+      select.collect(columns: &names)
+    case let .setop(_, left, right, _):
+      left.collect(columns: &names)
+      right.collect(columns: &names)
+    case let .values(rows):
+      for row in rows {
+        for expression in row { expression.collect(columns: &names) }
+      }
+    }
+  }
+}
+
+extension Select {
+  /// The bare names of every column this select references — its FROM/JOIN
+  /// derived bodies and `ON`s, predicate, projection, grouping keys, HAVING,
+  /// ORDER BY, and named-window specifications.
+  fileprivate func collect(columns names: inout Set<String>) {
+    from.collect(columns: &names)
+    for join in joins {
+      join.relation.collect(columns: &names)
+      join.on.collect(columns: &names)
+    }
+    predicate?.collect(columns: &names)
+    switch projection {
+    case .all:
+      break
+    case let .columns(columns):
+      for column in columns { names.insert(column.name.lowercased()) }
+    case let .expressions(items):
+      for item in items { item.expression.collect(columns: &names) }
+    }
+    for key in grouping.collected { key.collect(columns: &names) }
+    having?.collect(columns: &names)
+    for key in order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(columns: &names)
+      }
+    }
+    for definition in window {
+      for expression in definition.spec.expressions {
+        expression.collect(columns: &names)
+      }
+    }
+  }
+}
+
+extension Relation {
+  /// The bare names a relation references — a `.derived` one by recursing into
+  /// its inner query, a `.named` one none (its columns are named at resolution,
+  /// not in the AST).
+  fileprivate func collect(columns names: inout Set<String>) {
+    if case let .derived(query) = source { query.collect(columns: &names) }
+  }
+}
+
+extension Expression {
+  /// The bare (case-folded) names of every column this expression references,
+  /// descending into a scalar `subquery`'s body and a window's operands so a
+  /// correlation nested at any depth is seen.
+  fileprivate func collect(columns names: inout Set<String>) {
+    switch self {
+    case let .column(column):
+      names.insert(column.name.lowercased())
+    case .literal:
+      break
+    case let .call(_, arguments), let .coalesce(arguments),
+         let .grouping(arguments):
+      for argument in arguments { argument.collect(columns: &names) }
+    case let .binary(_, lhs, rhs), let .nullif(lhs, rhs):
+      lhs.collect(columns: &names)
+      rhs.collect(columns: &names)
+    case let .cast(operand, _):
+      operand.collect(columns: &names)
+    case let .aggregate(_, operand, _, filter):
+      if case let .expression(argument) = operand {
+        argument.collect(columns: &names)
+      }
+      filter?.collect(columns: &names)
+    case let .case(whens, otherwise):
+      for when in whens {
+        when.when.collect(columns: &names)
+        when.then.collect(columns: &names)
+      }
+      otherwise?.collect(columns: &names)
+    case let .subquery(query):
+      query.collect(columns: &names)
+    case let .window(function, spec):
+      for expression in spec.expressions { expression.collect(columns: &names) }
+      function.collect(columns: &names)
+    }
+  }
+}
+
+extension WindowFunction {
+  /// The bare names of every column this window function's operands reference —
+  /// an aggregate's argument and FILTER, a positional value and default, a
+  /// FIRST/LAST/NTH value.
+  fileprivate func collect(columns names: inout Set<String>) {
+    switch self {
+    case .number, .rank, .dense, .ntile, .percent, .cumulative:
+      break
+    case let .aggregate(_, operand, _, filter):
+      if case let .expression(argument) = operand {
+        argument.collect(columns: &names)
+      }
+      filter?.collect(columns: &names)
+    case let .lead(value, _, fallback), let .lag(value, _, fallback):
+      value.collect(columns: &names)
+      fallback?.collect(columns: &names)
+    case let .first(value), let .last(value), let .nth(value, _):
+      value.collect(columns: &names)
+    }
+  }
+}
+
+extension Predicate {
+  /// The bare names of every column this predicate references — its operand
+  /// expressions, nested predicates, and the body of any `EXISTS`/`IN`/
+  /// quantified subquery.
+  fileprivate func collect(columns names: inout Set<String>) {
+    switch self {
+    case let .exists(query, _):
+      query.collect(columns: &names)
+    case let .within(lhs, query, _):
+      for expression in lhs { expression.collect(columns: &names) }
+      query.collect(columns: &names)
+    case let .quantified(lhs, _, _, query):
+      for expression in lhs { expression.collect(columns: &names) }
+      query.collect(columns: &names)
+    case let .comparison(left, _, right):
+      left.collect(columns: &names)
+      right.collect(columns: &names)
+    case let .bound(left, _, _):
+      left.collect(columns: &names)
+    case let .null(operand, _):
+      operand.collect(columns: &names)
+    case let .membership(operand, values, _):
+      operand.collect(columns: &names)
+      for value in values { value.collect(columns: &names) }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs { expression.collect(columns: &names) }
+      for expression in rhs { expression.collect(columns: &names) }
+    case let .among(lhs, rows, _):
+      for expression in lhs { expression.collect(columns: &names) }
+      for row in rows {
+        for expression in row { expression.collect(columns: &names) }
+      }
+    case let .like(operand, pattern, escape, _):
+      operand.collect(columns: &names)
+      pattern.collect(columns: &names)
+      escape?.collect(columns: &names)
+    case let .between(operand, lower, upper, _):
+      operand.collect(columns: &names)
+      lower.collect(columns: &names)
+      upper.collect(columns: &names)
+    case let .distinct(lhs, rhs, _):
+      lhs.collect(columns: &names)
+      rhs.collect(columns: &names)
+    case let .truth(inner, _, _):
+      inner.collect(columns: &names)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.collect(columns: &names)
+      rhs.collect(columns: &names)
+    case let .not(operand):
+      operand.collect(columns: &names)
+    }
+  }
+}
+
+extension Predicate.Operand {
+  /// The bare names a `LIKE`/`BETWEEN` operand references — an expression's
+  /// columns, a `:parameter` none.
+  fileprivate func collect(columns names: inout Set<String>) {
+    if case let .expression(expression) = self {
+      expression.collect(columns: &names)
     }
   }
 }

--- a/SwiftSQL/Sources/SQLEngine/Interpreter.swift
+++ b/SwiftSQL/Sources/SQLEngine/Interpreter.swift
@@ -162,6 +162,18 @@ extension Catalog where Self: ~Escapable {
     case let .limit(count, offset, source):
       return limited(try execute(source, carrying: union, context), count,
                      offset)
+    case let .top(keys, offset, count, source):
+      // The windowed grouping-sets plan is optimised through the generic
+      // optimiser (its query body is a `.select`, not a `.setop`), which fuses
+      // a bounded `limit` directly over a `sort` into a `top` — so a windowed
+      // grouping-sets under a query `ORDER BY … FETCH n` stacks a `top` above
+      // the window, where the carried set-operation carrier's own plan (a
+      // setop-aware optimise that never fuses) never does. Descend it carrying
+      // the union like the `sort`/`limit` pair it fuses — so the setop leaf
+      // still per-arm augments the arm-local derived aliases — then take the
+      // sorted head, matching the plain `.top` node's execution.
+      return try topmost(execute(source, carrying: union, context), keys,
+                         offset, count, context)
     case let .select(filter, source):
       return try admitted(execute(source, carrying: union, context), filter,
                           context)
@@ -1027,8 +1039,17 @@ extension Catalog where Self: ~Escapable {
     }
     let rows: Array<Record>
     let view = resolve(view: name)
-    if let view, view.query.carriers.isEmpty, case .setop = view.query.body,
-        case .setop = plan {
+    if let view, let union = try view.query.union(windowed: context.routines) {
+      // A windowed `GROUP BY GROUPING SETS` view body keeps a `.select` body
+      // over a hidden arm union, so neither `.setop` branch below sees it; the
+      // one shared decision recovers that union and the body runs through the
+      // same carrier descender the top-level `run` uses, over the `overlay`
+      // revealed so each arm re-materialises its schema-only derived layer.
+      // Without this the body scanned the schema-only source `augment` bound
+      // once (`unioned`), dropping the arm rows.
+      rows = try execute(plan, carrying: union, overlay.revealed())
+    } else if let view, view.query.carriers.isEmpty,
+        case .setop = view.query.body, case .setop = plan {
       // A SET-operation view body executes each ARM's sub-plan under an overlay
       // augmented with that arm's own derived aliases. A `setop` collects no
       // derived aliases at the query level (arms are SELECT-scoped), so the
@@ -1109,6 +1130,16 @@ extension Catalog where Self: ~Escapable {
     // leaves a bare setop or a leaf select unchanged, so a non-carried body is
     // untouched.
     let query = query.core
+    // An arm that is itself a windowed `GROUP BY GROUPING SETS` select keeps a
+    // `.select` body over a hidden arm union, so neither `.setop` branch below
+    // sees it; the one shared decision recovers that union and this arm
+    // descends it carrier-aware over the `overlay` revealed, per-arm
+    // re-materialising its schema-only derived layer. Without this a view body
+    // `(windowed grouping-sets) UNION …` scanned the schema-only source once,
+    // dropping its per-group rows.
+    if let union = try query.union(windowed: overlay.routines) {
+      return try execute(plan, carrying: union, overlay.revealed())
+    }
     if case let .setop(kind, left, right, all, types, _) = plan,
         case let .setop(_, leftQuery, rightQuery, _) = query.body {
       // This node's arm queries are in hand, so the unified column `types` the

--- a/SwiftSQL/Sources/SQLEngine/Schema+Derivation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Schema+Derivation.swift
@@ -940,18 +940,25 @@ extension Catalog where Self: ~Escapable {
   private borrowing func typecheck(_ select: Select, _ context: Context)
       throws(SQLError) {
     // A windowed `GROUP BY GROUPING SETS` select lowers to a window over the
-    // arm union (`compile(windowed sets:)`); its outer window layer references
-    // only synthetic `*gwN` union columns, so every real operand — a group key,
-    // an aggregate, a `GROUPING(…)`, a scalar over them — lives in the arm
-    // union. Type-check (and, on the run's comparability walk, compare) it, so
-    // a reachable-operand or cross-kind-comparison fault surfaces exactly as a
-    // run does, in the mode this `context` carries. The window structure itself
-    // (its function, frame, and slot positions) is validated by `compile`, the
-    // parity gate both paths run before this.
+    // arm union (`compile(windowed sets:)`): every window-free operand — a
+    // group key, an aggregate, a `GROUPING(…)`, a scalar over them — lives in
+    // the arm union, while the outer window layer keeps the windows and the
+    // scalars wrapping them (`NULLIF(ROW_NUMBER() OVER (), 'x')`, a
+    // comparison, a `CASE`), reading the arm columns as `*gwN` union
+    // references. Type-check (and, on the run's comparability walk, compare)
+    // the arm union so a reachable-operand or cross-kind-comparison fault
+    // inside a lifted operand surfaces exactly as a run does, then the lifted
+    // outer projection and `ORDER BY` over the union-output scope so a
+    // wrapper's operand incomparability faults `42804` here rather than only
+    // at execution (`matches`) — both in the mode this `context` carries,
+    // keeping run ≡ validate. The window structure itself (its function,
+    // frame, and slot positions) is validated by `compile`, the parity gate
+    // both paths run before this.
     if select.windows, case let .sets(sets) = select.grouping {
-      let union = try decompose(windowed: select, sets: sets,
-                                context.routines).union
-      try typecheck(union, context)
+      let parts = try decompose(windowed: select, sets: sets,
+                                context.routines)
+      try typecheck(parts.union, context)
+      try typecheck(outer: parts, select, context)
       return
     }
     // The run's comparability walk visits every reachable comparison surface of
@@ -1049,6 +1056,148 @@ extension Catalog where Self: ~Escapable {
       for reach in on.visited {
         try typecheck(shape(of: reach), revealed.with(outer: scope))
       }
+    }
+  }
+
+  /// Type-checks the outer window layer of a windowed `GROUP BY GROUPING SETS`
+  /// select — its lifted projection and query `ORDER BY` — against the arm
+  /// union's output scope, so a scalar wrapping a window
+  /// (`NULLIF(ROW_NUMBER() OVER (), 'x')`, a comparison, a `CASE`) whose
+  /// operands are incomparable faults exactly as the ordinary grouped-window
+  /// path faults it, on both the run's comparability walk and the strict
+  /// validate path.
+  ///
+  /// The direct lowering (`decompose`) keeps the window functions in the outer
+  /// layer, their window-free operands lifted to `*gwN` references of the union
+  /// output. The arm union (type-checked by the caller) validates those
+  /// operands in their grouped scope, but the outer wrappers that combine the
+  /// windows resolve only over the union output — a hole through which a
+  /// wrapper's operand-comparability mismatch reaches `matches` at execution
+  /// (`42804`) while `columns(of:validate:)` accepts it. Resolving each lifted
+  /// outer expression over the same union-output scope the compile seam builds
+  /// (`windowed(sets:)`) closes it, in the mode this `context` carries — the
+  /// run's comparability finder (`comparisons`, only a `42804` escaping) or the
+  /// strict validate type-check (`validate`) — the same two surfaces `walk` and
+  /// `comparability(of:)` drive over an ordinary select's projection and sort.
+  private borrowing func typecheck(outer parts: WindowedSets,
+                                   _ select: Select, _ context: Context)
+      throws(SQLError) {
+    // The union-output scope keyed by the empty alias — the `*gwN`-named,
+    // type-unified arm columns the outer layer reads — built exactly as the
+    // compile seam and the schema derive build it, so a lifted outer
+    // expression resolves its window operands (`*gwN`) as the run lowers them.
+    let inner = try columns(unifying: parts.union, context)
+    let schema = Schema(from: inner, names: inner.map(\.name),
+                        extent: inner.count, virtuals: [])
+    let scope = Scope([(Relation(derived: parts.union.arm, as: ""), schema)])
+    // The outer layer hosts every subquery the `Lift` kept out of the arms,
+    // resolved against the union scope. Build the `SubqueryCheck` twin of the
+    // run's `Resolution` — each hosted subquery's cursor-free width and single-
+    // column type derived once (ahead of the walk), a scalar occurrence's
+    // operand check deferred to the walk — so validate types a hosted subquery
+    // exactly as the run lowers it, keeping run ≡ validate. A subquery
+    // correlates against the union scope stacked past this query's own outer,
+    // as the run's `subquery(_:_:_:within:)` correlates it.
+    let revealed = context.revealed()
+    let nested = (context.outer ?? Outer()).nested(under: scope)
+    var widths = Dictionary<Query, Int>()
+    var types = Dictionary<Query, ValueType>()
+    let scalar = select.scalar
+    var hosted = Array<Query>()
+    for item in parts.projection {
+      item.expression.collect(subqueries: &hosted)
+    }
+    for key in parts.order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(subqueries: &hosted)
+      }
+    }
+    for query in hosted {
+      try width(query, scalar, revealed, nested, &widths, &types)
+    }
+    let check = SubqueryCheck(widths, types, deferred: scalar,
+                              outer: context.outer)
+    // The projection sits above the query-level cap (`Project(Limit(Sort))`),
+    // so a zero `FETCH` that drops every output row leaves it unreachable;
+    // validate it only when reachable, as the ordinary walk does, while a
+    // DISTINCT evaluates it before the cap. The layer is a window over the arm
+    // union — cardinality-preserving — so its row count is the union's, and the
+    // union is statically single-row iff it reduces to one arm with no group
+    // keys: the grand-total single set `GROUPING SETS (())` (`.sets([[]])`),
+    // which yields exactly one whole-result row. A multi-arm union
+    // (`sets.count > 1`, e.g. `((), ())`) is ≥2 rows; a non-empty single set
+    // groups by its keys. So a positive `OFFSET` elides the projection only for
+    // that grand total, exactly as an ordinary whole-result aggregate
+    // (`aggregates && no keys`) is skipped by a positive `OFFSET`. Derive that
+    // single-row flag from the decomposition rather than hard-coding `false`.
+    // (`||` with a `borrowing self` autoclosure needs the two-statement form.)
+    let single: Bool
+    if case let .sets(sets) = select.grouping {
+      single = sets.count == 1 && sets[0].isEmpty
+    } else {
+      single = false
+    }
+    var reachable = select.distinct
+    if !reachable { reachable = !drops(select.limit, single: single) }
+    if reachable {
+      for item in parts.projection {
+        try validate(outer: item.expression, scope, context, subquery: check)
+      }
+    }
+    // The sort sits below the cap (`Sort` under `Limit`), so every ORDER BY key
+    // runs over the union before the cap pages the rows. Resolve each key
+    // to the value the sort evaluates through the one `orderKeys` resolver the
+    // ordinary path uses (`Select.orderKeys`): an ordinal or an output name —
+    // bound over the output surface the run's `windowed.order` records, an
+    // alias else a bare column's name (`\.name`) — names a projected expression
+    // the sort recomputes below the cap, so an output-referencing sort pulls
+    // that projection into reach and validates it even where the projection
+    // block above is skipped under a row-dropping cap (`FETCH FIRST 0` with
+    // `ORDER BY 1`), the hole the bespoke ordinal/column skip left. A directly
+    // written wrapper (a `NULLIF` over a window) keeps its expression and is
+    // validated too; a bare `*gwN` reference resolves cleanly against the union
+    // scope. Inheriting the resolver, not re-implementing it, keeps the sort-
+    // output model from drifting from the run's.
+    for expression in orderKeys(parts.projection, parts.order, named: \.name) {
+      try validate(outer: expression, scope, context, subquery: check)
+    }
+    // Validate the body of each hosted subquery the walk reached — a scalar or
+    // an `IN`/`EXISTS`/quantified one — in its own reached role's run shape (an
+    // `existential` reach the cardinality probe, a `scalar`/`valued` reach the
+    // original), so a reached throwing body faults exactly as the run
+    // evaluates it while an unreached one (a dropped page, a lazy `LEAD`
+    // default the walk never records) does not. A subquery's own FROM sees the
+    // revealed base, its correlation the union scope stacked past this query's
+    // outer — the same context the run re-executes it under.
+    let recursion =
+        revealed.with(outer: (context.outer ?? Outer()).nested(under: scope))
+    for reach in check.visited {
+      try typecheck(shape(of: reach), recursion)
+      // Re-fold a reached set-operation subquery's operand compatibility (the
+      // width pre-pass deferred it through `shaping()`), so a reached scalar or
+      // `IN` with irreconcilable arm types faults `SQLError.operand`; an
+      // `EXISTS`/`lateral` reach doesn't read the unified arm type, so skip it.
+      switch reach.role {
+      case .scalar, .valued:
+        _ = try columns(unifying: reach.query, recursion)
+      case .existential, .lateral:
+        break
+      }
+    }
+  }
+
+  /// Validates one lifted outer window-layer `expression` over the union
+  /// `scope` in the mode `context` carries — the run's comparability finder
+  /// (only a `42804` escaping) or the strict validate type-check — resolving a
+  /// hosted subquery through the union-scope `subquery` check.
+  private borrowing func validate(outer expression: Expression, _ scope: Scope,
+                                  _ context: Context,
+                                  subquery: SubqueryCheck) throws(SQLError) {
+    if context.comparability {
+      try scope.comparisons(in: expression, context.routines,
+                            subquery: subquery)
+    } else {
+      _ = try scope.validate(expression, context.routines, subquery: subquery)
     }
   }
 
@@ -1820,14 +1969,21 @@ extension Catalog where Self: ~Escapable {
   /// It reuses the same `decompose` the compile seam does — the window-free arm
   /// union and the outer window layer's `projection` over it — derives the arm
   /// union's output schema (its `*gwN`-named, type-unified columns), builds the
-  /// union-output `Scope` over that schema, and types each outer projected
-  /// expression against it: a `*gwN` reference by the union column's type, a
-  /// window by its result (a ranking function `.integer`, an aggregate window
-  /// from its `*gwN` argument — `derive`), exactly the type the compiled
-  /// `Windowed` surface lowers it to.
+  /// union-output `Scope` over that schema, and resolves each lifted outer item
+  /// against it through the ordinary projection-output logic (`output(_:at:)`),
+  /// so each output carries the complete `ResolvedColumn` — type AND
+  /// `unconstrained` mask — that an ordinary grouped-window select yields as a
+  /// set-op arm: a `*gwN` reference by the union column's type and mask (a
+  /// passed-through constant-NULL source column stays unconstrained), a
+  /// constant NULL kept outer unconstrained, a window by its constrained result
+  /// (a ranking function `.integer`, an aggregate window from its `*gwN`
+  /// argument), the shape the compiled `Windowed` surface lowers it to. Keeping
+  /// only the type (hand-stamped constrained) would mis-type a constant-NULL
+  /// output as a constrained integer, so an outer set-op merge would reject the
+  /// integer/text pair (`42804`) the ordinary companion accepts.
   ///
-  /// Each output takes its name and synthesized-header provenance from the
-  /// original projected item — an alias, else a bare column's name, else the
+  /// Each output then re-takes its name and synthesized-header provenance from
+  /// the original projected item — an alias, else a bare column's name, else a
   /// positional `column N` an unnamed expression takes (marked synthesized), so
   /// an unnamed windowed output feeding an outer set-op carrier stays
   /// ordinal-only (not name-bindable), never the internal `*gwN` name it reads.
@@ -1845,13 +2001,32 @@ extension Catalog where Self: ~Escapable {
     let schema = Schema(from: inner, names: inner.map(\.name), extent: arity,
                         virtuals: [])
     let scope = Scope([(Relation(derived: parts.union.arm, as: ""), schema)])
-    // Type each outer window-layer item over the union scope, naming it from
-    // the original item — an inferable name, else a synthesized `column N`.
+    // The outer layer hosts every subquery the `Lift` kept out of the arms,
+    // resolved against the union scope — the same `Resolution` the compile seam
+    // builds, so a hosted subquery derives its output column exactly as the run
+    // lowers it.
+    var hosted = Array<Query>()
+    for item in parts.projection {
+      item.expression.collect(subqueries: &hosted)
+    }
+    for key in parts.order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(subqueries: &hosted)
+      }
+    }
+    let outer = try subquery(hosted, select, context, within: scope)
+    // Resolve each outer window-layer item over the union scope through the
+    // ordinary projection-output logic, so its `unconstrained` mask comes from
+    // the same resolution as its type (a constant NULL unconstrained, a window
+    // constrained, a passed-through `*gwN` column by its source mask), then
+    // re-stamp the name and synthesized-header provenance from the original
+    // item — an inferable name, else a synthesized `column N`.
     return try parts.items.indices.map { index throws(SQLError) in
       let name = parts.items[index].name ?? "column \(index + 1)"
-      let type = try scope.derive(parts.projection[index].expression, routines,
-                                  subquery: .unsupported)
-      return ResolvedColumn(OutputColumn(name: name, type: type),
+      let resolved = try scope.output(parts.projection[index], at: index,
+                                      routines, subquery: outer)
+      return ResolvedColumn(OutputColumn(name: name, type: resolved.type),
+                            unconstrained: resolved.unconstrained,
                             synthesized: parts.items[index].name == nil)
     }
   }

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -3892,6 +3892,111 @@ struct WindowOverGroupingSetsTests {
     }
   }
 
+  @Test func `an incomparable outer wrapper over GROUPING SETS faults`()
+      throws {
+    // A scalar wrapping a window — `NULLIF(ROW_NUMBER() OVER (), 'x')` — lives
+    // in the outer window layer, its window operand lifted to a `*gwN` union
+    // column. The wrapper's implicit `window = 'x'` compares an integer to
+    // text, incomparable (42804). The direct lowering type-checks the arm
+    // union but once skipped the outer layer, so the run reached `matches` and
+    // faulted while `columns(of:validate:)` accepted it. Both paths now fault
+    // over the union scope, matching the ordinary grouped-window form.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `an incomparable ORDER BY wrapper over GROUPING SETS faults`()
+      throws {
+    // The same mismatch in a query `ORDER BY` wrapper — the lowering lifts the
+    // sort key over the union too, so its comparability is validated over the
+    // union scope exactly as the projection's is, faulting 42804 on both paths.
+    let sql = "SELECT dept FROM Emp GROUP BY GROUPING SETS ((dept), ()) " +
+              "ORDER BY NULLIF(ROW_NUMBER() OVER (), 'x')"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a comparable outer wrapper over GROUPING SETS is accepted`()
+      throws {
+    // The outer validation must not over-reject a well-typed wrapper: comparing
+    // the integer window to an integer is comparable, so `NULLIF(ROW_NUMBER()
+    // OVER (), 5)` runs — numbering the four union rows 1…4 (none equal 5, so
+    // each stays), accepted by both paths.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 5) " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
+    try fixture().expect(sql, yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `an outer wrapper faults the same over sets and plain grouping`()
+      throws {
+    // Parity: the ordinary (non-grouping-sets) grouped-window form of the same
+    // incomparable wrapper faults identically, so the direct sets lowering does
+    // not diverge from the grouped path it mirrors.
+    let sets = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    let plain = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+                "FROM Emp GROUP BY dept"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sets, fails: fault)
+    try fixture().expect(plain, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sets), validate: true)
+    }
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: plain), validate: true)
+    }
+  }
+
+  @Test func `a capped output-referencing sort validates the projection`()
+      throws {
+    // A row-dropping cap leaves the projection above it unreachable — but an
+    // `ORDER BY 1` names that output, pulling its projection below the sort
+    // (below the cap), where the run still evaluates it. The incomparable
+    // `NULLIF(ROW_NUMBER() OVER (), 'x')` (integer versus text) faults
+    // 42804 on the run under `FETCH FIRST 0`, and validate must fault
+    // identically: the outer layer inherits the ordinary path's sort-output
+    // resolution, so the ordinal key resolves to the projection expression the
+    // sort recomputes and validates it even where the projection block is
+    // skipped. A bespoke skip of the ordinal key accepted the query — the
+    // run ≠ validate hole this closes.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept), ()) ORDER BY 1 " +
+              "FETCH FIRST 0 ROWS ONLY"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a capped unreferenced projection stays unreachable`() throws {
+    // The companion guarding against over-rejection: the same incomparable
+    // wrapper under `FETCH FIRST 0` but with no output-referencing sort. The
+    // projection sits above the cap and no sort names it, so it stays
+    // unreachable — the run drops every row without evaluating it, yielding the
+    // empty page, and validate accepts its one column rather than faulting a
+    // wrapper the run never reaches.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept), ()) FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
+  }
+
   // A parent `T` and a keyed child `U`, so a correlated LATERAL body's grouping
   // varies per outer row: Id 1 has two children (100, 101), Id 2 one (200), and
   // Id 3 none. The child keys reach back to `T.Id`, the correlation a once-
@@ -3957,7 +4062,7 @@ struct WindowOverGroupingSetsTests {
         yields: [[1, 201], [1, 201], [2, 200], [2, 200], [3, nil]])
   }
 
-  @Test func `an unused WINDOW definition faults over a windowed GROUPING SETS`()
+  @Test func `an unused WINDOW faults over a windowed GROUPING SETS query`()
       throws {
     // A used `ROW_NUMBER()` window beside an unused named window whose ORDER BY
     // names a non-existent column. The rewrite carries the original WINDOW
@@ -4037,24 +4142,87 @@ struct WindowOverGroupingSetsTests {
 
   @Test func `a stateful leaf evaluates independently at each site`() throws {
     // A non-deterministic `tick()` in the projection and in the window `ORDER
-    // BY` is not collapsed onto one shared union column: each site takes its
-    // own arm column, so the two evaluate independently — six calls over the
-    // three groups, not three — matching the plain grouped-window path, not
-    // reading one shared value. A deterministic operand (a group key, an
-    // aggregate) still shares one column; only a stateful one is kept distinct.
+    // BY` is not collapsed onto one shared union column: each site evaluates
+    // independently — six calls over the three groups, not three — matching the
+    // plain grouped-window path, not reading one shared value. Under grounded-
+    // outer the projection `tick()` is group-independent, so it stays in the
+    // outer projection and evaluates after the window; only the window key
+    // `tick()` lifts to an arm column (`*gw0`) and evaluates before it. The arm
+    // evaluates its lone key per group (1, 2, 3), the window numbers by that
+    // ascending key (ranks 1, 2, 3), and the outer projection then evaluates
+    // its own `tick()` per output row (4, 5, 6) — the same values, and the same
+    // six calls, the ordinary `GROUP BY dept` companion below reports.
     let counter = Counter()
     let routines = try Routines.standard
         .registering("tick", returns: .integer, deterministic: false) { _ in
           .integer(counter.next())
         }
-    // The arm evaluates its two `tick()` columns left to right per group — the
-    // projected `*gw0` (1, 3, 5) and the window key `*gw1` (2, 4, 6) — and the
-    // window numbers by the ascending key, so the ranks are 1, 2, 3.
     try fixture().expect(
         "SELECT tick(), ROW_NUMBER() OVER (ORDER BY tick()) " +
         "FROM Emp GROUP BY GROUPING SETS ((dept))",
-        yields: [[1, 1], [3, 2], [5, 3]], routines: routines)
+        yields: [[4, 1], [5, 2], [6, 3]], routines: routines)
     #expect(counter.count == 6)
+  }
+
+  @Test func `the single set matches the ordinary grouped-window path`()
+      throws {
+    // The grounded-outer oracle: the single-set `GROUPING SETS ((dept))`
+    // spelling of the query above must observe exactly what the ordinary `GROUP
+    // BY dept` windowed query does — the window key `tick()` evaluated first as
+    // the ranking input (1, 2, 3), the projection `tick()` evaluated after the
+    // window (4, 5, 6), six calls in all. This is the reference the grouping-
+    // sets form is pinned to; before grounded-outer the grouping-sets form
+    // reported 1, 3, 5 (both `tick()`s in the arm), diverging from it.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT tick(), ROW_NUMBER() OVER (ORDER BY tick()) " +
+        "FROM Emp GROUP BY dept",
+        yields: [[4, 1], [5, 2], [6, 3]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `a capped projection-only fault drops with the page`() throws {
+    // #137: a projection-only pure scalar that would fault (`1 / 0`) is group-
+    // independent, so grounded-outer keeps it in the outer projection above the
+    // `Project(Limit(Sort))` cap rather than in an arm below it. A zero `FETCH`
+    // drops every row before the projection runs, so the division never
+    // happens and the query returns the empty page — matching the ordinary
+    // grouped-window path. Before grounded-outer the `1 / 0` lifted into the
+    // arm, dividing per group and faulting `.divide` even though no row
+    // survived. `columns(of: validate:)` agrees — the outer projection sits
+    // above the cap, so a dropped page leaves it unreachable and validate types
+    // its two columns rather than faulting a division the run never reaches.
+    let sql = "SELECT 1 / 0, ROW_NUMBER() OVER () FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept)) FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+  }
+
+  @Test func `an ordinal-linked window key shares the reported leaf`() throws {
+    // The window `ORDER BY 1` names column 1 — the `tick()` value — so
+    // the ordinal links the key to that output: both must read one evaluation.
+    // The lifter shares its `*gwN` leaf across the projection and the ordinal-
+    // linked key, so `tick()` is evaluated once per group (1, 2, 3), the window
+    // orders on those, and the row numbered k reports `tick()` k — the ranking
+    // matching the reported column, three calls. Sharing only by determinism
+    // would give the ordinal its own leaf, evaluating `tick()` twice per group,
+    // ordering on 2, 4, 6 yet reporting 1, 3, 5 over six calls — the reported
+    // value diverging from the ranking, as the directly written key above does.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT tick(), ROW_NUMBER() OVER (ORDER BY 1) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept))",
+        yields: [[1, 1], [2, 2], [3, 3]], routines: routines)
+    #expect(counter.count == 3)
   }
 
   @Test func `an unnamed windowed output stays an ordinal-only header`()
@@ -4081,5 +4249,968 @@ struct WindowOverGroupingSetsTests {
       _ = try fixture().columns(of: parse(query:
           "\(union) ORDER BY \"column 1\""), validate: true)
     }
+  }
+
+  @Test func `an unused WINDOW faults over a single-set windowed query`()
+      throws {
+    // A single grouping set takes `expand`'s fast path, which reconstructs a
+    // plain grouped select rather than a union. It carries the WINDOW clause
+    // onto that select as the multi-set arms do, so the arm compile validates
+    // every definition against the grouped source — the undefined `nonesuch`
+    // faulting on both the run and validate paths, as the multi-set and
+    // ordinary grouped forms do, not silently accepted on a one-set query.
+    let sql = "SELECT dept, ROW_NUMBER() OVER () FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept)) " +
+              "WINDOW bad AS (ORDER BY nonesuch)"
+    try fixture().expect(sql, fails: .column("nonesuch"))
+    #expect(throws: SQLError.column("nonesuch")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a valid unused WINDOW is accepted over a single-set query`()
+      throws {
+    // The companion: a single-set windowed grouping-sets query with a well-
+    // formed unused named window validates and drops it, running exactly as it
+    // would with no WINDOW clause. The fast path carries the definition through
+    // validation, not around it — so a valid one is accepted, not rejected.
+    let sql = "SELECT dept, ROW_NUMBER() OVER (ORDER BY SUM(sal)) FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept)) WINDOW w AS (ORDER BY dept)"
+    try fixture().expect(sql, yields: [[1, 1], [2, 3], [3, 2]])
+  }
+
+  @Test func `an unused WINDOW faults over a non-windowed single set`()
+      throws {
+    // The single-set fast path is shared by the non-windowed grouping-sets
+    // form, so an ordinary single-set grouping-sets query with a bad unused
+    // WINDOW definition validates it too — faulting `nonesuch` on both paths,
+    // as the multi-set and ordinary grouped forms do, rather than dropping the
+    // clause unvalidated because there is only one set.
+    let sql = "SELECT dept FROM Emp GROUP BY GROUPING SETS ((dept)) " +
+              "WINDOW bad AS (ORDER BY nonesuch)"
+    try fixture().expect(sql, fails: .column("nonesuch"))
+    #expect(throws: SQLError.column("nonesuch")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a negative OFFSET over a windowed GROUPING SETS faults`() throws {
+    // The parser cannot spell a negative count, but a directly built `Limit`
+    // can. The windowed grouping-sets lowering used to take its early return
+    // before the row-limit guard, passing the negative offset to `limited`,
+    // where the negative slice precondition-traps; the guard now runs ahead of
+    // that return, so the query faults 2201X on both the run and validate
+    // paths, as an ordinary select does, rather than crashing the process.
+    let base = try parse(select:
+        "SELECT dept, ROW_NUMBER() OVER (ORDER BY SUM(sal)) FROM Emp " +
+        "GROUP BY GROUPING SETS ((dept), ())")
+    let select = Select(projection: base.projection, from: base.from,
+                        grouping: base.grouping,
+                        limit: Limit(count: 1, offset: -1))
+    let query = Query.select(select)
+    let catalog = try fixture()
+    let fault = SQLError.state("2201X", "OFFSET row count must be non-negative")
+    let ran: SQLError?
+    do {
+      _ = try catalog.run(query)
+      ran = nil
+    } catch let raised {
+      ran = raised
+    }
+    #expect(ran == fault)
+    let derived: SQLError?
+    do {
+      _ = try catalog.columns(of: query, validate: true)
+      derived = nil
+    } catch let raised {
+      derived = raised
+    }
+    #expect(derived == fault)
+  }
+
+  @Test func `a negative FETCH over a windowed GROUPING SETS faults`() throws {
+    // The same guard covers a negative FETCH count: a directly built `Limit`
+    // with a negative count reaches the windowed grouping-sets lowering and
+    // used to trap in `limited`'s prefix; it now faults 2201W ahead of the
+    // early return, on both the run and validate paths, as an ordinary select
+    // does.
+    let base = try parse(select:
+        "SELECT dept, ROW_NUMBER() OVER (ORDER BY SUM(sal)) FROM Emp " +
+        "GROUP BY GROUPING SETS ((dept), ())")
+    let select = Select(projection: base.projection, from: base.from,
+                        grouping: base.grouping, limit: Limit(count: -1))
+    let query = Query.select(select)
+    let catalog = try fixture()
+    let fault = SQLError.state("2201W", "FETCH row count must be non-negative")
+    let ran: SQLError?
+    do {
+      _ = try catalog.run(query)
+      ran = nil
+    } catch let raised {
+      ran = raised
+    }
+    #expect(ran == fault)
+    let derived: SQLError?
+    do {
+      _ = try catalog.columns(of: query, validate: true)
+      derived = nil
+    } catch let raised {
+      derived = raised
+    }
+    #expect(derived == fault)
+  }
+
+  @Test func `a capped projection CASE fault drops with the page`() throws {
+    // #137, the `CASE` shape: a projection-only `CASE` whose result would fault
+    // (`CASE WHEN 1 = 1 THEN 1 / 0 END`) is group-independent — its `WHEN`
+    // guard and `THEN` result name no grouped data — so grounded-outer keeps it
+    // in the outer projection above the `Project(Limit(Sort))` cap, not an arm
+    // below it. A zero `FETCH` drops every row before the projection runs, so
+    // the division never happens and the query returns the empty page, matching
+    // the ordinary `GROUP BY dept` companion. Before this the `CASE` was hard-
+    // coded grounded and lifted into the arm, dividing per group and faulting
+    // even though no row survived. `columns(of: validate:)` agrees over the
+    // union scope, typing its two columns rather than faulting a division no
+    // run reaches.
+    let sql = "SELECT CASE WHEN 1 = 1 THEN 1 / 0 END, ROW_NUMBER() OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept)) FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    let plain = "SELECT CASE WHEN 1 = 1 THEN 1 / 0 END, ROW_NUMBER() OVER () " +
+                "FROM Emp GROUP BY dept FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(plain)
+  }
+
+  @Test func `a projection-only CASE evaluates in the outer projection`()
+      throws {
+    // A stateful `CASE WHEN 1 = 1 THEN tick() END` in the projection is group-
+    // independent, so it stays in the outer projection and evaluates after the
+    // window — its `tick()` per output row — while the window `ORDER BY tick()`
+    // lifts to an arm column evaluated per group before it. Six calls over the
+    // three groups: the arm key 1, 2, 3 (the ranking input), then the
+    // projection 4, 5, 6, matching the ordinary `GROUP BY dept` companion.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT CASE WHEN 1 = 1 THEN tick() END, " +
+        "ROW_NUMBER() OVER (ORDER BY tick()) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept))",
+        yields: [[4, 1], [5, 2], [6, 3]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `the single-set CASE matches the ordinary grouped-window path`()
+      throws {
+    // The oracle for the `CASE` above: the ordinary `GROUP BY dept` windowed
+    // form observes exactly the same values — the arm key `tick()` 1, 2, 3, the
+    // projection `CASE`'s `tick()` 4, 5, 6, six calls — the reference the
+    // grouping-sets form is pinned to.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT CASE WHEN 1 = 1 THEN tick() END, " +
+        "ROW_NUMBER() OVER (ORDER BY tick()) FROM Emp GROUP BY dept",
+        yields: [[4, 1], [5, 2], [6, 3]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `a grounded CASE keeps its structure in the outer projection`()
+      throws {
+    // A grounded window-free `CASE` — `CASE WHEN dept = 1 THEN SUM(sal) ELSE 0
+    // END` — keeps its `CASE` structure in the outer projection and lifts only
+    // the grouped values its guard and branches reference: the `dept` guard
+    // column and the `SUM(sal)` branch each become a `*gwN` arm column, the
+    // `CASE` itself evaluated outer above the window. Over the single set dept
+    // 1 yields SUM 300, dept 2 and 3 the `ELSE` 0 (their guard false), each
+    // numbered, matching the ordinary `GROUP BY dept` form. Before this fix the
+    // whole `CASE` lifted into the arm; the values are the same here, but the
+    // capped finding below shows why keeping the structure outer matters.
+    let sets = "SELECT CASE WHEN dept = 1 THEN SUM(sal) ELSE 0 END, " +
+               "ROW_NUMBER() OVER () FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[300, 1], [0, 2], [0, 3]])
+    let plain = "SELECT CASE WHEN dept = 1 THEN SUM(sal) ELSE 0 END, " +
+                "ROW_NUMBER() OVER () FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[300, 1], [0, 2], [0, 3]])
+  }
+
+  @Test func `a grounded CASE above a zero FETCH drops with the page`() throws {
+    // The finding: a grounded `CASE` whose branch would fault — `CASE WHEN dept
+    // = 1 THEN 1 / 0 END` — keeps its structure in the outer projection above
+    // the `Project(Limit(Sort))` cap, only its `dept` guard column lifted to a
+    // `*gwN` arm. A zero `FETCH` drops every row before the outer `CASE` runs,
+    // so the division never happens and the query returns the empty page,
+    // matching the ordinary `GROUP BY dept` companion. Before this fix the
+    // whole grounded `CASE` lifted into the arm below the cap, dividing per
+    // group and faulting `.divide` though no row survived. `columns(of:
+    // validate:)` agrees over the union scope — the outer `CASE` sits above the
+    // cap, so a dropped page leaves it unreachable and validate types its two
+    // columns rather than faulting a division the run never reaches.
+    let sql =
+        "SELECT CASE WHEN dept = 1 THEN 1 / 0 END, ROW_NUMBER() OVER () " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept)) FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    let plain =
+        "SELECT CASE WHEN dept = 1 THEN 1 / 0 END, ROW_NUMBER() OVER () " +
+        "FROM Emp GROUP BY dept FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(plain)
+  }
+
+  @Test func `a grounded CASE's stateful branch evaluates in the outer`()
+      throws {
+    // A grounded `CASE` with a grouped guard and a stateful branch — `CASE WHEN
+    // dept = 1 THEN tick() ELSE 0 END` — lifts only the `dept` guard column to
+    // an arm while the `tick()` branch stays outer, evaluated after the window
+    // per output row. The window `ORDER BY tick()` lifts its own `tick()` to a
+    // separate arm column evaluated per group before the window. So the arm
+    // ticks 1, 2, 3 (the ranking input, ranks 1, 2, 3) and the outer `CASE`'s
+    // branch ticks once for the dept-1 row (4) — four calls, matching the
+    // ordinary `GROUP BY dept` companion. Before this fix the whole `CASE`
+    // lifted into the arm, so its branch `tick()` evaluated before the window,
+    // reporting 1 rather than the outer 4.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT CASE WHEN dept = 1 THEN tick() ELSE 0 END, " +
+        "ROW_NUMBER() OVER (ORDER BY tick()) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept))",
+        yields: [[4, 1], [0, 2], [0, 3]], routines: routines)
+    #expect(counter.count == 4)
+    let other = Counter()
+    let plain = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(other.next())
+        }
+    try fixture().expect(
+        "SELECT CASE WHEN dept = 1 THEN tick() ELSE 0 END, " +
+        "ROW_NUMBER() OVER (ORDER BY tick()) FROM Emp GROUP BY dept",
+        yields: [[4, 1], [0, 2], [0, 3]], routines: plain)
+    #expect(other.count == 4)
+  }
+
+  @Test func `a windowed CASE over GROUPING SETS is deferred`() throws {
+    // Preserving #136: a `CASE` nesting a window — `CASE WHEN dept = 1 THEN
+    // ROW_NUMBER() OVER () END` — is a per-row `Predicate`/window shape no
+    // `*gwN` column stands in for, so it still faults the feature diagnostic on
+    // both the run and validate paths, unchanged by the window-free `CASE`
+    // recursion this fix adds.
+    let sql = "SELECT CASE WHEN dept = 1 THEN ROW_NUMBER() OVER () END " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    let fault = SQLError.state(
+        "0A000", "a window in a CASE with GROUPING SETS is not yet supported")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a CASE nesting an uncorrelated subquery recurses`() throws {
+    // A window-free `CASE` whose branch nests an uncorrelated scalar subquery —
+    // `CASE WHEN T.Id = 1 THEN (SELECT SUM(U.v) FROM U) END` — recurses: the
+    // `T.Id` guard lifts to a `*gwN` arm column while the subquery stays outer,
+    // hosted by the union-scope `Resolution`, so the whole `CASE` sits in the
+    // outer projection above the cap rather than lifting whole to an arm. Over
+    // the single set `T.Id` 1 yields the subquery's 401, `T.Id` 2 and 3 the
+    // `ELSE` NULL (guard false), each numbered, matching the ordinary `GROUP BY
+    // T.Id` form.
+    let sets = "SELECT CASE WHEN T.Id = 1 THEN (SELECT SUM(U.v) FROM U) END, " +
+               "ROW_NUMBER() OVER () FROM T GROUP BY GROUPING SETS ((T.Id))"
+    try correlated().expect(sets, yields: [[401, 1], [nil, 2], [nil, 3]])
+    let plain =
+        "SELECT CASE WHEN T.Id = 1 THEN (SELECT SUM(U.v) FROM U) END, " +
+        "ROW_NUMBER() OVER () FROM T GROUP BY T.Id"
+    try correlated().expect(plain, yields: [[401, 1], [nil, 2], [nil, 3]])
+  }
+
+  @Test func `an uncorrelated scalar subquery hosts in the outer layer`()
+      throws {
+    // An uncorrelated scalar subquery in the projection is hosted in the outer
+    // window layer through the union-scope `Resolution`, not lifted to an arm,
+    // so it resolves against the union output and evaluates once per output
+    // row. `(SELECT SUM(U.v) FROM U)` sums every child, the same 401 for all
+    // groups, each numbered, matching the ordinary `GROUP BY T.Id` form.
+    let sets = "SELECT T.Id, (SELECT SUM(U.v) FROM U), ROW_NUMBER() OVER () " +
+               "FROM T GROUP BY GROUPING SETS ((T.Id))"
+    try correlated().expect(sets, yields: [[1, 401, 1], [2, 401, 2],
+                                           [3, 401, 3]])
+    // The validate twin resolves the hosted subquery over the union scope too,
+    // so `columns(of: validate:)` types its three columns rather than faulting
+    // a subquery it cannot host — run ≡ validate over the outer layer.
+    #expect(try correlated().columns(of: parse(query: sets), validate: true)
+                .count == 3)
+    let plain = "SELECT T.Id, (SELECT SUM(U.v) FROM U), ROW_NUMBER() OVER () " +
+                "FROM T GROUP BY T.Id"
+    try correlated().expect(plain, yields: [[1, 401, 1], [2, 401, 2],
+                                            [3, 401, 3]])
+  }
+
+  @Test func `an uncorrelated subquery hosts over multiple sets`() throws {
+    // The multi-set companion: with two grouping sets the arm union is a real
+    // `UNION ALL`, and the uncorrelated `(SELECT SUM(U.v) FROM U)` is hosted in
+    // the outer layer over that union — evaluated once per output row, the same
+    // 401 for every per-set row and the NULL-extended grand-total row alike.
+    // `SUM(T.Id)` groups to each `T.Id` per set and to 6 for the grand total,
+    // the window numbering across all four union rows.
+    let sets = "SELECT SUM(T.Id), (SELECT SUM(U.v) FROM U), " +
+               "ROW_NUMBER() OVER () FROM T GROUP BY GROUPING SETS ((T.Id), ())"
+    try correlated().expect(sets, yields: [[1, 401, 1], [2, 401, 2],
+                                           [3, 401, 3], [6, 401, 4]])
+  }
+
+  @Test func `a correlated subquery still resolves in the arm`() throws {
+    // Approach (B): a scalar subquery correlated to a group key —
+    // `(SELECT SUM(U.v) FROM U WHERE U.k = T.Id)` — names the enclosing `T.Id`,
+    // a group key, so the lifter keeps it arm-lifted (a `*gwN` column) rather
+    // than hosting it outer, resolving `T.Id` in the arm's grouped scope; a
+    // correlated outer host awaits a follow-up (the union scope would have to
+    // expose the group key for the subquery to correlate against). Over the
+    // single set `T.Id` 1 sums its children 201, `T.Id` 2 sums 200, `T.Id` 3
+    // has none (NULL), each numbered, matching the ordinary `GROUP BY T.Id`
+    // form.
+    let sets = "SELECT T.Id, (SELECT SUM(U.v) FROM U WHERE U.k = T.Id), " +
+               "ROW_NUMBER() OVER () FROM T GROUP BY GROUPING SETS ((T.Id))"
+    try correlated().expect(sets, yields: [[1, 201, 1], [2, 200, 2],
+                                           [3, nil, 3]])
+    let plain = "SELECT T.Id, (SELECT SUM(U.v) FROM U WHERE U.k = T.Id), " +
+                "ROW_NUMBER() OVER () FROM T GROUP BY T.Id"
+    try correlated().expect(plain, yields: [[1, 201, 1], [2, 200, 2],
+                                            [3, nil, 3]])
+  }
+
+  @Test func `a stateful derived source materialises per arm`() throws {
+    // The finding: a windowed grouping-sets over a stateful derived table must
+    // materialise that source per arm — as the non-windowed grouping-sets over
+    // the same source does — not once for both arms. The window layer rides
+    // above the arm union, so the query keeps a `.select` body and once took
+    // the ordinary executor, which materialises the derived `d` a single time
+    // and scans those rows in every arm. Routed through the carrier-aware
+    // executor, the `.window` descent carries the union to the setop leaf,
+    // where each arm augments its own `d` — so `tick()` runs afresh per arm.
+    //
+    // The `(x)` arm ticks 1..5, each its own group summing to itself; the `()`
+    // arm ticks a fresh 6..10 summing to 40. Ten calls, the grand total 40 —
+    // where a single materialisation reused 1..5 and summed the grand total to
+    // 15 over five calls. The `tick()` count matches the non-windowed
+    // companion below, proving the `.window` carrier descent (dead before) is
+    // now reached.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT tick() AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x), ())",
+        yields: [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [40, 6]],
+        routines: routines)
+    #expect(counter.count == 10)
+  }
+
+  @Test func `the non-windowed form is the per-arm reference`() throws {
+    // The reference the windowed form is pinned to: the equivalent non-windowed
+    // grouping-sets over the same stateful derived source. It expands to a
+    // `UNION ALL` whose arms run per arm, so `tick()` runs afresh in each — the
+    // `(x)` arm 1..5, the `()` arm a fresh 6..10 summing to 40, ten calls. The
+    // windowed form above reports the same aggregate column and the same ten
+    // calls; the second column is the constant `0` here, `ROW_NUMBER()` there.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT SUM(x), 0 FROM (SELECT tick() AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x), ())",
+        yields: [[1, 0], [2, 0], [3, 0], [4, 0], [5, 0], [40, 0]],
+        routines: routines)
+    #expect(counter.count == 10)
+  }
+
+  @Test func `a deterministic derived source is unchanged by the routing`()
+      throws {
+    // The no-regression guard: routing a windowed grouping-sets through the
+    // carrier-aware executor must not alter a deterministic source's rows.
+    // Materialising `sal` once or per arm yields the identical values, so the
+    // grouped sums and the row numbers are the same either way — the `(x)`
+    // groups 100, 200, 600 (the two 300s), 500 and the grand total 1400.
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x), ())",
+        yields: [[100, 1], [200, 2], [600, 3], [500, 4], [1400, 5]])
+  }
+
+  @Test func `a derived source under a capped sort executes per arm`() throws {
+    // A query `ORDER BY … FETCH n` over a windowed grouping-sets fuses into a
+    // `top` above the window: the generic optimiser a `.select`-bodied plan
+    // takes fuses a bounded limit over a sort, where the set-operation
+    // carrier's own optimise never does. The carrier-aware descent must carry
+    // the union through that `top` to the setop leaf — else the leaf scans a
+    // derived `d` the revealed context no longer binds and faults `.relation`,
+    // breaking run ≡ validate. Over a derived source ordered by the aggregate
+    // and paged to three rows, the head is 100, 200, 500 — the arms
+    // materialising `sal` per arm (the same deterministic values either way).
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER (ORDER BY SUM(x)) " +
+        "FROM (SELECT sal AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x), ()) ORDER BY 1 FETCH FIRST 3 ROWS ONLY",
+        yields: [[100, 1], [200, 2], [500, 3]])
+  }
+
+  @Test func `a single-set derived source materialises for the lone arm`()
+      throws {
+    // The finding: a single-set `GROUPING SETS ((x))` reduces to one grouped
+    // arm — `decompose` returns a plain `.select`, not a `.setop` — so its arm
+    // union is not carrier-routed. The per-arm carrier path assumes a setop and
+    // never materialises the lone arm's derived `d`, and the schema-only bind
+    // it pairs with drops `d`'s rows, so the query faulted an unknown relation.
+    // A single arm augments and runs through the ordinary per-query path
+    // instead: `d` materialises once (one arm, so per-arm and per-query
+    // coincide) and the grouped window reads it. The `(x)` groups are 100, 200,
+    // 600 (the two 300s), 500, numbered 1..4 — exactly the ordinary `GROUP BY
+    // x` companion below.
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x))",
+        yields: [[100, 1], [200, 2], [600, 3], [500, 4]])
+  }
+
+  @Test func `the ordinary derived companion is the single-set reference`()
+      throws {
+    // The reference the single-set form is pinned to: the ordinary `GROUP BY x`
+    // windowed query over the same derived source, which the mature grouped-
+    // window path has always handled. Its grouped sums and row numbers are the
+    // single-set spelling's, proving the single arm reaches this path.
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d GROUP BY x",
+        yields: [[100, 1], [200, 2], [600, 3], [500, 4]])
+  }
+
+  @Test func `a stateful single-set derived source matches the ordinary form`()
+      throws {
+    // A single set has one arm, so per-arm and per-query materialisation
+    // coincide: the ordinary per-query path materialises the stateful `d` once
+    // and its lone arm reads those rows, the same as an arm materialising its
+    // own copy. `tick()` runs once per source row (five Emp rows, five calls),
+    // each `x` distinct so each groups alone summing to itself — 1..5, numbered
+    // 1..5 — the identical `tick()` count and rows the ordinary `GROUP BY x`
+    // companion yields.
+    let sets = Counter()
+    let plain = Counter()
+    func routines(_ counter: Counter) throws -> Routines {
+      try Routines.standard
+          .registering("tick", returns: .integer, deterministic: false) { _ in
+            .integer(counter.next())
+          }
+    }
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT tick() AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x))",
+        yields: [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5]],
+        routines: try routines(sets))
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT tick() AS x FROM Emp) d GROUP BY x",
+        yields: [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5]],
+        routines: try routines(plain))
+    #expect(sets.count == 5)
+    #expect(plain.count == sets.count)
+  }
+
+  @Test func `a grand-total single set matches the implicit-group window`()
+      throws {
+    // The other single set: `GROUPING SETS (())`, the grand total. It too is
+    // one arm — `expand` returns the lone grouped `.select` — so it runs the
+    // ordinary per-query path over the derived source. The whole result is one
+    // group summing 1400, `ROW_NUMBER()` numbering the single row 1 — matching
+    // the `GROUP BY ()` implicit-group window companion below.
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS (())",
+        yields: [[1400, 1]])
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d GROUP BY ()",
+        yields: [[1400, 1]])
+  }
+
+  @Test func `a single-set GROUPING is zero over the derived source`() throws {
+    // In a single set every argument is a grouping key of the lone set, so
+    // `GROUPING(x)` is 0 for every group — the standard result when no column
+    // is rolled up, identical to the ordinary `GROUP BY x` companion. A window
+    // makes this the windowed single-arm shape, so it confirms the single arm
+    // reaching the ordinary path preserves `GROUPING`.
+    try fixture().expect(
+        "SELECT SUM(x), GROUPING(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x))",
+        yields: [[100, 0, 1], [200, 0, 2], [600, 0, 3], [500, 0, 4]])
+    try fixture().expect(
+        "SELECT SUM(x), GROUPING(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d GROUP BY x",
+        yields: [[100, 0, 1], [200, 0, 2], [600, 0, 3], [500, 0, 4]])
+  }
+
+  @Test func `a grand-total set with an offset drops the unreachable wrapper`()
+      throws {
+    // The finding: the grand-total single set `GROUPING SETS (())` produces one
+    // whole-result row, so a positive `OFFSET` skips it and the outer
+    // projection never runs. `NULLIF(ROW_NUMBER() OVER (), 'x')` (integer
+    // versus text) would fault 42804 if reachable, but the cap discards the
+    // sole row first — the run returns the empty page and `columns(of:
+    // validate:)` accepts its one column. Deriving the outer layer's single-row
+    // flag from the decomposition (one arm, no keys) makes both paths treat the
+    // grand total as single-row, as the ordinary whole-result aggregate oracle
+    // below does. Before this the flag was hard-coded multi-row, so the offset
+    // left the projection reachable and the comparability preflight faulted
+    // 42804 though the run dropped the row before `NULLIF` could run.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+              "FROM Emp GROUP BY GROUPING SETS (()) OFFSET 1 ROW"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
+    // The ordinary single-row oracle: a whole-result aggregate makes the row
+    // count one, so the same offset skips the sole row and elides its
+    // projection alike, on both paths.
+    let plain = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x'), SUM(sal) " +
+                "FROM Emp OFFSET 1 ROW"
+    try fixture().empty(plain)
+    #expect(try fixture().columns(of: parse(query: plain), validate: true)
+                .count == 2)
+  }
+
+  @Test func `a grand-total set without an offset still faults its wrapper`()
+      throws {
+    // The regression guard against over-sparing: the one grand-total row is
+    // produced with no cap, so the outer projection is reachable and the
+    // incomparable `NULLIF(ROW_NUMBER() OVER (), 'x')` faults 42804 on both
+    // paths — unchanged by the derivation, which spares the projection only
+    // when a row-dropping cap makes it unreachable.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+              "FROM Emp GROUP BY GROUPING SETS (())"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a non-empty single set stays multi-row under an offset`()
+      throws {
+    // The regression guard against under-sparing: `GROUPING SETS ((dept))`
+    // groups by `dept` — three groups, so `OFFSET 1` leaves rows and the outer
+    // projection is reachable. The single-row flag is false for a non-empty
+    // single set (one arm, but keys present), so the incomparable wrapper still
+    // faults 42804 on both paths, unchanged.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept)) OFFSET 1 ROW"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a valid grand-total window with an offset returns the page`()
+      throws {
+    // The derivation must not over-reject a well-typed grand total: `SUM(sal)`
+    // over the one whole-result group is 1400, `ROW_NUMBER() OVER ()` numbers
+    // it 1, and `OFFSET 1` skips that sole row — the empty page, on both paths,
+    // matching the ordinary whole-result aggregate window oracle below.
+    let sql = "SELECT SUM(sal), ROW_NUMBER() OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS (()) OFFSET 1 ROW"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    let plain = "SELECT SUM(sal), ROW_NUMBER() OVER () FROM Emp OFFSET 1 ROW"
+    try fixture().empty(plain)
+  }
+
+  @Test func `a windowed GROUPING SETS NULL arm infers the union's text`()
+      throws {
+    // The finding: a constant NULL in a windowed grouping-sets arm places no
+    // type constraint on the set-op's unified column, so the text arm decides
+    // it — column 1 infers text. The schema twin now derives the complete
+    // `ResolvedColumn` (type AND `unconstrained` mask) through the ordinary
+    // projection-output logic, so it no longer hand-stamps the NULL a
+    // constrained integer the merge rejects against the text arm (42804). The
+    // text arm is a `VALUES` row — this dialect projects a computed row through
+    // `VALUES`, not a FROM-less `SELECT`.
+    let sql = "SELECT NULL, ROW_NUMBER() OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept)) " +
+              "UNION ALL VALUES ('x', 1)"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .map(\.type) == [.text, .integer])
+    try fixture().expect(sql,
+                         yields: [[nil, 1], [nil, 2], [nil, 3], ["x", 1]])
+    // The oracle: the equivalent ordinary grouped-window arm of the same shape
+    // infers the same types and rows — the windowed grouping-sets arm must
+    // resolve exactly as its `GROUP BY dept` companion does.
+    let plain = "SELECT NULL, ROW_NUMBER() OVER () " +
+                "FROM Emp GROUP BY dept UNION ALL VALUES ('x', 1)"
+    #expect(try fixture().columns(of: parse(query: plain), validate: true)
+                .map(\.type) == [.text, .integer])
+    try fixture().expect(plain,
+                         yields: [[nil, 1], [nil, 2], [nil, 3], ["x", 1]])
+  }
+
+  @Test func `a windowed GROUPING SETS arm second still infers text`()
+      throws {
+    // The windowed arm as the second operand: the leading text arm still
+    // unifies with the trailing NULL, so column 1 infers text regardless of
+    // arm order — the trailing windowed arm's NULL stays unconstrained through
+    // the merge, not a hand-stamped integer that would fault 42804.
+    let sql = "VALUES ('x', 1) UNION ALL " +
+              "SELECT NULL, ROW_NUMBER() OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .map(\.type) == [.text, .integer])
+    try fixture().expect(sql,
+                         yields: [["x", 1], [nil, 1], [nil, 2], [nil, 3]])
+  }
+
+  @Test func `a constrained windowed GROUPING SETS rejects a text union`()
+      throws {
+    // The regression guard against over-relaxing: `ROW_NUMBER() OVER ()` is a
+    // genuine constrained integer, not a constant NULL, so column 1 keeps its
+    // integer constraint and the text arm is irreconcilable — the merge faults
+    // 42804 on both paths, unchanged by the mask-preserving derivation.
+    let sql = "SELECT ROW_NUMBER() OVER (), 1 " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept)) " +
+              "UNION ALL VALUES ('x', 1)"
+    let fault = SQLError.operand("UNION arms have irreconcilable types")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `an unused LEAD default never evaluates over GROUPING SETS`()
+      throws {
+    // The finding: a `LEAD` whose offset always lands on an existing row —
+    // offset 0 reads the current row — never needs its default, so the default
+    // must not evaluate. `Window.position` evaluates a `LEAD`/`LAG` default
+    // only for an out-of-range target, so force-lifting the `1 / 0` default
+    // into a `*gwN` arm column, evaluated eagerly per group, wrongly raised
+    // division-by-zero. Kept in the outer window function — only its grouped
+    // values lifted — the default rides the executor's conditional evaluation,
+    // so offset 0 never divides and each group's `dept` is returned, matching
+    // the ordinary `GROUP BY dept` companion. Before the fix the grouping-sets
+    // form faulted `.divide` while the ordinary form did not. (The finding's
+    // bare `OVER ()` faults `0A000` first — `LEAD` requires an `ORDER BY` — so
+    // the window carries the order the offset reads along.)
+    let sets = "SELECT LEAD(dept, 0, 1 / 0) OVER (ORDER BY dept) " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[1], [2], [3]])
+    let plain = "SELECT LEAD(dept, 0, 1 / 0) OVER (ORDER BY dept) " +
+                "FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[1], [2], [3]])
+  }
+
+  @Test func `an unused LEAD default subquery never evaluates`() throws {
+    // The subquery half of the finding: a `LEAD` default nesting a scalar
+    // subquery — `LEAD(dept, 0, (SELECT SUM(sal) / 0 FROM Emp))` — is
+    // hosted in the outer window function, not force-lifted to an arm, so it
+    // rides the executor's conditional evaluation exactly as a scalar default
+    // does. Offset 0 always lands on the current row, so the default never
+    // evaluates and the subquery never divides — each group's `dept` is
+    // returned, matching the ordinary `GROUP BY dept` companion. Were the
+    // subquery arm-lifted (evaluated eagerly per group) the division would
+    // fault, as it would for a `1 / 0` default.
+    let sets =
+        "SELECT LEAD(dept, 0, (SELECT SUM(sal) / 0 FROM Emp)) " +
+        "OVER (ORDER BY dept) FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[1], [2], [3]])
+    let plain =
+        "SELECT LEAD(dept, 0, (SELECT SUM(sal) / 0 FROM Emp)) " +
+        "OVER (ORDER BY dept) FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[1], [2], [3]])
+  }
+
+  @Test func `an uncorrelated subquery under a zero FETCH is not evaluated`()
+      throws {
+    // #138: an uncorrelated scalar subquery in the projection is hosted in the
+    // outer layer above the `Project(Limit(Sort))` cap — not in an arm below it
+    // — so a zero `FETCH` that drops every row leaves it unreached and the
+    // subquery never evaluates. `(SELECT SUM(sal) / 0 FROM Emp)` never divides,
+    // the query returns the empty page, matching the ordinary `GROUP BY dept`
+    // companion. `columns(of: validate:)` agrees — the outer projection sits
+    // above the cap, so a dropped page leaves it unreachable and validate types
+    // its two columns rather than faulting a division no run reaches.
+    let sql =
+        "SELECT (SELECT SUM(sal) / 0 FROM Emp), ROW_NUMBER() OVER () " +
+        "FROM Emp " +
+        "GROUP BY GROUPING SETS ((dept)) FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    let plain =
+        "SELECT (SELECT SUM(sal) / 0 FROM Emp), ROW_NUMBER() OVER () " +
+        "FROM Emp " +
+        "GROUP BY dept FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(plain)
+  }
+
+  @Test func `a needed LEAD default still returns over GROUPING SETS`()
+      throws {
+    // The default still works when the offset genuinely runs off the partition:
+    // offset 100 lands past every row, so `Window.position` evaluates the
+    // default for each. Keeping the default in the outer window layer preserves
+    // that path — every group takes the default `99` — matching the ordinary
+    // `GROUP BY dept` companion, so the outer default is used exactly when the
+    // executor needs it. A non-faulting default also validates cleanly over
+    // the union scope, so run and validate agree, as the ordinary form does.
+    let sets = "SELECT LEAD(dept, 100, 99) OVER (ORDER BY dept) " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[99], [99], [99]])
+    #expect(try fixture().columns(of: parse(query: sets), validate: true)
+                .count == 1)
+    let plain = "SELECT LEAD(dept, 100, 99) OVER (ORDER BY dept) " +
+                "FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[99], [99], [99]])
+    #expect(try fixture().columns(of: parse(query: plain), validate: true)
+                .count == 1)
+  }
+
+  @Test func `a stateful LEAD default evaluates once per out-of-range target`()
+      throws {
+    // A stateful default `tick()` must evaluate once per out-of-range target,
+    // not once per group. The window orders the three groups by `dept` (1, 2,
+    // 3); `LEAD(dept, 1, …)` reads the next group for the first two (2, 3) and
+    // runs off the end for the last, evaluating the default once — `tick()`
+    // yields 1 — so the rows are 2, 3, 1 over one call. Force-lifting the
+    // default into the arm evaluated it per group (three calls) and reported
+    // the arm's per-group tick (…, 3) rather than the single outer evaluation,
+    // diverging from the ordinary `GROUP BY dept` companion, which evaluates
+    // the default once (1). Kept outer, the two forms agree in rows and count.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT LEAD(dept, 1, tick()) OVER (ORDER BY dept) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept))",
+        yields: [[2], [3], [1]], routines: routines)
+    #expect(counter.count == 1)
+    let other = Counter()
+    let plain = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(other.next())
+        }
+    try fixture().expect(
+        "SELECT LEAD(dept, 1, tick()) OVER (ORDER BY dept) " +
+        "FROM Emp GROUP BY dept",
+        yields: [[2], [3], [1]], routines: plain)
+    #expect(other.count == 1)
+  }
+
+  @Test func `a grouped-dependent LEAD default lifts only its grouped value`()
+      throws {
+    // A default depending on a grouped value — `SUM(sal)` — lifts that value
+    // to a `*gwN` arm column while the default expression itself stays in the
+    // outer window function. Offset 100 runs off the partition, so each group
+    // takes its own `SUM(sal)` default — 300, 600, 500 — the grouped value
+    // computed in the arm and read by the conditionally evaluated outer
+    // default, matching the ordinary `GROUP BY dept` companion. The default
+    // validates cleanly over the union scope (its grouped leaf resolved in the
+    // arm), so run and validate agree, as the ordinary form does.
+    let sets = "SELECT LEAD(dept, 100, SUM(sal)) OVER (ORDER BY dept) " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[300], [600], [500]])
+    #expect(try fixture().columns(of: parse(query: sets), validate: true)
+                .count == 1)
+    let plain = "SELECT LEAD(dept, 100, SUM(sal)) OVER (ORDER BY dept) " +
+                "FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[300], [600], [500]])
+    #expect(try fixture().columns(of: parse(query: plain), validate: true)
+                .count == 1)
+  }
+
+  @Test func `an unused LEAD default never evaluates over multiple sets`()
+      throws {
+    // The multi-set companion of the finding: with two grouping sets the arm
+    // union is a genuine `UNION ALL`, and the outer window still holds the
+    // conditionally evaluated `1 / 0` default. Offset 0 reads each row's own
+    // `dept` — the grand-total row's rolled-up NULL included — so at run the
+    // default never evaluates and no division occurs. Before the fix the arm's
+    // eager `1 / 0` faulted `.divide`. (Validate constant-folds the `1 / 0`
+    // default and faults it identically to the ordinary grouped-window form —
+    // a pre-existing property of the validator shared by both paths — so this
+    // asserts only the run; the non-faulting defaults above cover run ≡
+    // validate over the union scope.)
+    let sql = "SELECT dept, LEAD(dept, 0, 1 / 0) OVER (ORDER BY dept) " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    try fixture().expect(sql, yields: [[1, 1], [2, 2], [3, 3], [nil, nil]])
+  }
+
+  // The finding's body: a window over two grouping sets, reading a derived
+  // source `d`. The carrier-aware routing that per-arm re-materialises `d`
+  // lived only in the top-level `run`; a view body and a correlated subquery
+  // reached their own executor entry points, which recognised a union only by
+  // a `.setop` body and so scanned the schema-only `d` once — dropping the arm
+  // rows. Every entry point now consults the one `union(windowed:)` decision.
+  private var body: String {
+    "SELECT SUM(x), ROW_NUMBER() OVER () " +
+    "FROM (SELECT sal AS x FROM Emp) d GROUP BY GROUPING SETS ((x), ())"
+  }
+
+  // The finding's body over an `Emp` beside a view `v` whose body is exactly
+  // it, so a run of the view and a run of the body share one catalog.
+  private func viewed() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("Emp", ["dept": .integer, "sal": .integer]) {
+        Row(1, 100)
+        Row(1, 200)
+        Row(2, 300)
+        Row(2, 300)
+        Row(3, 500)
+      }
+      try View("v", body, as: ["s", "n"])
+    }
+  }
+
+  @Test func `a windowed GROUPING SETS view matches the top-level result`()
+      throws {
+    // Selecting from the view returns the same groups running the body at top
+    // level does — the per-arm materialised union, not an empty schema-only
+    // `d`. Both run the same plan, so the row order coincides.
+    try viewed().expect("SELECT s, n FROM v", equals: body)
+  }
+
+  @Test func `a windowed GROUPING SETS view yields the per-set groups`()
+      throws {
+    // The concrete groups: the `(x)` arm sums each distinct salary (100, 200,
+    // 500, and the two 300s to 600) and the `()` arm the grand total 1400. The
+    // window numbers them by that ascending sum, so ordering the view output by
+    // it reads out 100, 200, 500, 600, 1400 numbered 1 through 5.
+    let ordered = "SELECT SUM(x) AS s, "
+                + "ROW_NUMBER() OVER (ORDER BY SUM(x)) AS n "
+                + "FROM (SELECT sal AS x FROM Emp) d "
+                + "GROUP BY GROUPING SETS ((x), ())"
+    let catalog = try Catalog {
+      Relation("Emp", ["dept": .integer, "sal": .integer]) {
+        Row(1, 100)
+        Row(1, 200)
+        Row(2, 300)
+        Row(2, 300)
+        Row(3, 500)
+      }
+      try View("v", ordered, as: ["s", "n"])
+    }
+    try catalog.expect(
+        "SELECT s, n FROM v ORDER BY s",
+        yields: [[100, 1], [200, 2], [500, 3], [600, 4], [1400, 5]])
+  }
+
+  @Test func `a correlated LATERAL windowed GROUPING SETS over a source`()
+      throws {
+    // The body as a correlated LATERAL over a derived source `d`: `d` reads all
+    // of `U`, and a body-level `WHERE d.k = T.Id` correlates to the enclosing
+    // row, so the apply runs through `executed` per outer row. Per `T` row the
+    // arms re-materialise `d` and filter it to that row's children: Id 1 sums
+    // 100, 101 and the total 201; Id 2 sums 200 and the equal total; Id 3 has
+    // no children, so only its grand-total NULL. Before the fix `executed`
+    // scanned the schema-only `d` and dropped the arm rows.
+    try correlated().expect(
+        "SELECT T.Id, d.s, d.n FROM T JOIN LATERAL (" +
+        "SELECT SUM(x) AS s, ROW_NUMBER() OVER (ORDER BY SUM(x)) AS n " +
+        "FROM (SELECT k, v AS x FROM U) d WHERE d.k = T.Id " +
+        "GROUP BY GROUPING SETS ((x), ())) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.n",
+        yields: [[1, 100, 1], [1, 101, 2], [1, 201, 3],
+                 [2, 200, 1], [2, 200, 2], [3, nil, 1]])
+  }
+
+  @Test func `a stateful source re-materialises per arm in a view`() throws {
+    // A counting `tick()` in the derived source over the single-row `T` fires
+    // once per arm materialisation: the two grouping sets drive two arms, so
+    // both a top-level run and a view run invoke it twice. Before the fix the
+    // view scanned the schema-only source, never materialising it — zero calls,
+    // the arm rows dropped.
+    let sql = "SELECT SUM(x), ROW_NUMBER() OVER () " +
+              "FROM (SELECT tick() AS x FROM T) d " +
+              "GROUP BY GROUPING SETS ((x), ())"
+    let top = Counter()
+    let plain = try Catalog { Relation("T", ["v": .integer]) { Row(0) } }
+    try plain.expect(sql, yields: [[1, 1], [2, 2]],
+                     routines: ticking(top))
+    #expect(top.count == 2)
+    let counter = Counter()
+    let catalog = try Catalog {
+      Relation("T", ["v": .integer]) { Row(0) }
+      try View("v", sql, as: ["s", "n"])
+    }
+    try catalog.expect("SELECT s, n FROM v", yields: [[1, 1], [2, 2]],
+                       routines: ticking(counter))
+    #expect(counter.count == 2)
+  }
+
+  // The windowed grouping-sets arm reading a derived source, its window ordered
+  // so the row number is a function of the sum.
+  private var arm: String {
+    "SELECT SUM(x) AS s, ROW_NUMBER() OVER (ORDER BY SUM(x)) AS r " +
+    "FROM (SELECT sal AS x FROM Emp) d GROUP BY GROUPING SETS ((x), ())"
+  }
+
+  @Test func `a windowed GROUPING SETS UNION arm keeps its groups`() throws {
+    // The windowed grouping-sets body as an explicit `UNION ALL` arm carried by
+    // an outer `ORDER BY`, so the arm descends through `arms` — the recursive
+    // twin of `executed`. Its per-set sums (100, 200, 500, 600 and the grand
+    // total 1400) must survive beside the plain second arm's rows, not collapse
+    // to the lone schema-only grand total the unfixed `arms` leaf produced.
+    try fixture().expect(
+        "(\(arm)) UNION ALL (SELECT dept, dept FROM Emp) ORDER BY s, r",
+        yields: [[1, 1], [1, 1], [2, 2], [2, 2], [3, 3],
+                 [100, 1], [200, 2], [500, 3], [600, 4], [1400, 5]])
+  }
+
+  @Test func `a view union with a windowed GROUPING SETS arm keeps groups`()
+      throws {
+    // The same union as a view body, so the arm descends through the view-body
+    // `setop` twin. Selecting from the view returns the per-set groups beside
+    // the plain arm, matching the top-level union.
+    let catalog = try Catalog {
+      Relation("Emp", ["dept": .integer, "sal": .integer]) {
+        Row(1, 100)
+        Row(1, 200)
+        Row(2, 300)
+        Row(2, 300)
+        Row(3, 500)
+      }
+      try View("v", "(\(arm)) UNION ALL (SELECT dept, dept FROM Emp)",
+               as: ["s", "r"])
+    }
+    try catalog.expect(
+        "SELECT s, r FROM v ORDER BY s, r",
+        yields: [[1, 1], [1, 1], [2, 2], [2, 2], [3, 3],
+                 [100, 1], [200, 2], [500, 3], [600, 4], [1400, 5]])
+  }
+
+  /// A non-deterministic routine set whose `tick()` returns `counter`'s next
+  /// value, so a run counts how many times the source it sits in materialised.
+  private func ticking(_ counter: Counter) throws -> Routines {
+    try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
   }
 }


### PR DESCRIPTION
The lowered window-over-union is a set-op carrying a window node, a shape the ordinary executor paths did not expect. Teach every execution and schema path to treat it as a first-class window input: Engine, Filter, Interpreter, and Definition route it through union(windowed:), and the schema-derivation twin mirrors the compile-time shape so a run and a validate agree on the columns.

With the union executing as a whole, a SELECT-list subquery that does not reference the grouping keys is independent of which arm produced a row. Host such a subquery once in the outer window layer through a resolution over the union output scope, rather than lifting it into every arm where it would evaluate redundantly. Correlated subqueries still lift per arm; the resolvable ones follow.