### PR TITLE
SQLEngine: keep synthetic lift names from colliding with aliases

### DIFF
--- a/SwiftSQL/Sources/SQLEngine/AST.swift
+++ b/SwiftSQL/Sources/SQLEngine/AST.swift
@@ -695,8 +695,10 @@ public struct Select: Hashable, Sendable {
 /// windowed grouping-sets outer layer share, so the sort-output model cannot
 /// drift. An ordinal names the `position`-th item (1-based); a bare
 /// unqualified name binds a matching output `named` before an input column (the
-/// ISO precedence); any other key keeps its own expression. An out-of-range
-/// ordinal is `compile`'s fault to raise, so it is skipped here.
+/// ISO precedence), unless it is synthetic — a `*gwN` lift key binds
+/// structurally and keeps its own expression, as `Windowed.order` does; any
+/// other key keeps its own expression. An out-of-range ordinal is `compile`'s
+/// fault to raise, so it is skipped here.
 internal func orderKeys(_ items: Array<Projected>, _ order: Order?,
                         named: KeyPath<Projected, String?>)
     -> Array<Expression> {
@@ -709,7 +711,14 @@ internal func orderKeys(_ items: Array<Projected>, _ order: Order?,
         expressions.append(items[position - 1].expression)
       }
     case let .expression(expression):
+      // A synthetic `*gwN` reference — a windowed GROUPING SETS lift key —
+      // bypasses output-alias precedence and keeps its own expression, binding
+      // structurally as the run path's `Windowed.order` resolves it; a
+      // colliding user alias spelled `*gwN` must not capture it here (its
+      // `Column` identity is distinct), or validate would type a projection the
+      // run never evaluates and raise a spurious datatype fault.
       if case let .column(column) = expression, column.qualifier == nil,
+          !column.synthetic,
           let item = items.first(where: {
             $0[keyPath: named]?.lowercased() == column.name.lowercased()
           }) {
@@ -917,9 +926,22 @@ public struct Column: Hashable, Sendable, ExpressibleByStringLiteral {
   /// The column name.
   public let name: String
 
-  public init(qualifier: String? = nil, name: String) {
+  /// Whether this is an engine-synthesized internal reference no user
+  /// identifier can mint — the lifted `*gwN` union columns a windowed
+  /// `GROUPING SETS` rewrite addresses (`GroupingSets`). It rides the
+  /// reference's identity so a quoted user alias spelled exactly `"*gw0"`
+  /// stays distinct from the internal `*gw0`: the parser only ever mints a
+  /// non-synthetic reference, and this flag participates in equality, so the
+  /// two never compare equal. The query-level `ORDER BY` binds a synthetic
+  /// reference to its union column structurally (against the arm-synthesized
+  /// union scope) rather than by output-alias precedence, so a colliding user
+  /// alias cannot capture it (`Windowed.order`).
+  public let synthetic: Bool
+
+  public init(qualifier: String? = nil, name: String, synthetic: Bool = false) {
     self.qualifier = qualifier
     self.name = name
+    self.synthetic = synthetic
   }
 
   /// Parses a reference from its dotted spelling: the text before the last dot
@@ -942,6 +964,7 @@ public struct Column: Hashable, Sendable, ExpressibleByStringLiteral {
       self.qualifier = nil
       self.name = spelling
     }
+    self.synthetic = false
   }
 
   public init(stringLiteral value: String) {

--- a/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
+++ b/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
@@ -890,9 +890,13 @@ private struct Lift {
   /// fresh column per occurrence, so each site evaluates it independently. The
   /// reference is unqualified — the compile seam builds the union-output scope
   /// keyed by the empty alias, so a bare `*gwN` resolves against it by name,
-  /// with no derived-table qualifier to match.
+  /// with no derived-table qualifier to match. It is `synthetic`, a `Column`
+  /// identity no user identifier can mint, so a quoted alias spelled `"*gwN"`
+  /// stays distinct and a query-level `ORDER BY` binds this reference to its
+  /// union column structurally rather than by output-alias precedence
+  /// (`Windowed.order`).
   private mutating func reference(_ expression: Expression) -> Expression {
-    .column(Column(name: "*gw\(allocate(expression))"))
+    .column(Column(name: "*gw\(allocate(expression))", synthetic: true))
   }
 
   /// The `*gwN` union reference for a projected `output` a window `ORDER BY`
@@ -907,11 +911,11 @@ private struct Lift {
   private mutating func reference(_ expression: Expression, output: Int)
       -> Expression {
     if let existing = linked[output] {
-      return .column(Column(name: "*gw\(existing)"))
+      return .column(Column(name: "*gw\(existing)", synthetic: true))
     }
     let position = allocate(expression)
     linked[output] = position
-    return .column(Column(name: "*gw\(position)"))
+    return .column(Column(name: "*gw\(position)", synthetic: true))
   }
 
   /// This expression lifted as the projected output a window `ORDER BY` ordinal

--- a/SwiftSQL/Sources/SQLEngine/Windowed.swift
+++ b/SwiftSQL/Sources/SQLEngine/Windowed.swift
@@ -1747,8 +1747,13 @@ internal struct Windowed {
                                 ascending: key.ascending,
                                 column: position - 1))
       case let .expression(expression):
+        // A synthetic reference — the lifted `*gwN` union column a windowed
+        // `GROUPING SETS` rewrite addresses — bypasses output-alias precedence
+        // and binds structurally against the arm-synthesized union scope
+        // (`term`), so a colliding user alias spelled `"*gwN"` in this
+        // projection cannot capture it (its `Column` identity is distinct).
         if case let .column(reference) = expression,
-            reference.qualifier == nil {
+            reference.qualifier == nil, !reference.synthetic {
           let name = reference.name.lowercased()
           if ambiguous.contains(name) { throw .ambiguous(reference.name) }
           if let alias = aliases[name] {

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -3820,6 +3820,44 @@ struct WindowOverGroupingSetsTests {
         yields: [[nil, 1400, 4], [2, 600, 3], [3, 500, 2], [1, 300, 1]])
   }
 
+  @Test func `a user alias colliding with a lifted column cannot capture it`()
+      throws {
+    // The lifted union columns a windowed `GROUPING SETS` rewrite reads are
+    // named `*gwN`. A user may quote that exact spelling as an output alias
+    // (`AS "*gw0"`), so the query-level `ORDER BY dept` — rewritten to the
+    // lifted `dept` union column — must not bind to that alias by output-alias
+    // precedence. The lifted reference is a synthetic `Column` identity the
+    // parser can never mint, so it binds structurally to its union column:
+    // `ORDER BY dept ASC` sorts on `dept`, numbering by `dept DESC` (3 → 1,
+    // 2 → 2, 1 → 3), so the rows come out `dept` 1, 2, 3 carrying 3, 2, 1.
+    try fixture().expect(
+        "SELECT ROW_NUMBER() OVER (ORDER BY dept DESC) AS \"*gw0\" " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept)) ORDER BY dept ASC",
+        yields: [[3], [2], [1]])
+  }
+
+  @Test func `a non-colliding alias yields the same lifted ordering`() throws {
+    // The oracle for the colliding case: the identical query with an ordinary
+    // alias behaves the same, since `ORDER BY dept` always names the lifted
+    // `dept` union column, never the row-number output. The two results agree.
+    try fixture().expect(
+        "SELECT ROW_NUMBER() OVER (ORDER BY dept DESC) AS x " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept)) ORDER BY dept ASC",
+        yields: [[3], [2], [1]])
+  }
+
+  @Test func `a user reference to a colliding alias still binds it`() throws {
+    // The synthetic-reference bypass is surgical: only the engine's lifted
+    // references skip output-alias precedence. A user naming their own quoted
+    // `"*gw0"` alias in the query `ORDER BY` still binds it, so ordering by the
+    // aliased row number descending (`dept` 1 → 1, 2 → 2, 3 → 3, sorted
+    // descending) yields `dept` 3, 2, 1 carrying 3, 2, 1.
+    try fixture().expect(
+        "SELECT dept, ROW_NUMBER() OVER (ORDER BY dept) AS \"*gw0\" " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept)) ORDER BY \"*gw0\" DESC",
+        yields: [[3, 3], [2, 2], [1, 1]])
+  }
+
   @Test func `run and validate agree on a windowed GROUPING SETS`() throws {
     // Both paths enter `Query.expanded`, so they drive the one rewrite over the
     // union: the schema path types the same three-column shape the run
@@ -4783,6 +4821,26 @@ struct WindowOverGroupingSetsTests {
                 "FROM Emp GROUP BY Id"
     try fixture().expect(plain,
                          yields: [[1, 1], [2, 1], [3, 1], [4, 1], [5, 1]])
+  }
+
+  @Test func `a synthetic ORDER BY key does not bind a colliding alias`()
+      throws {
+    // F6: a windowed GROUPING SETS query lifts its `ORDER BY dept` to the
+    // synthetic `*gw0` union column. The shared `orderKeys` resolver — driving
+    // both the run compile and the validate typecheck — must let that synthetic
+    // key bind structurally, as `Windowed.order` does, not capture a user
+    // projection aliased `"*gw0"`. Here that alias is `NULLIF(ROW_NUMBER() OVER
+    // (), 'x')`, an invalid integer-versus-text compare; resolving the sort key
+    // to it type-checked the `NULLIF` and raised a spurious 42804. `FETCH FIRST
+    // 0 ROWS` drops every row, so the `NULLIF` never evaluates — both the run
+    // and `columns(of: validate:)` succeed on the empty page. Before the fix
+    // both faulted 42804.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') AS \"*gw0\" " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept)) " +
+              "ORDER BY dept FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
   }
 
   @Test func `a correlated EXISTS CASE guard hosts outer over the union`()


### PR DESCRIPTION
A lifted union column is spelled *gwN, but nothing stopped a user query from writing AS "*gw0" and colliding with it. Give Column a synthetic flag that participates in its identity, set on the columns the Lift mints and never on a parsed spelling, so a lifted reference can never match a user alias. The window ORDER BY bypasses output-alias precedence only for a genuinely synthetic reference.