### PR TITLE
SQLEngine: lower a window function over GROUPING SETS

### DIFF
--- a/SwiftSQL/Sources/SQLEngine/AST.swift
+++ b/SwiftSQL/Sources/SQLEngine/AST.swift
@@ -651,7 +651,6 @@ public struct Select: Hashable, Sendable {
   /// caller picks to mirror the resolver's lowering (see `orderKeys`).
   private func keys(named output: KeyPath<Projected, String?>)
       -> Array<Expression> {
-    guard let order else { return [] }
     // Only an `expressions` list carries a projection expression an ordinal or
     // an output-name key could reach; a `*` or bare-column projection names
     // plain column slots compilation already resolves.
@@ -661,32 +660,7 @@ public struct Select: Hashable, Sendable {
     } else {
       items = []
     }
-    var expressions = Array<Expression>()
-    for key in order.keys {
-      switch key.sort {
-      case let .ordinal(position):
-        // An ordinal names the `position`-th projected output (1-based); the
-        // sort recomputes that item's expression below the limit. An
-        // out-of-range ordinal is `compile`'s fault to raise, so skip it here.
-        if position >= 1, position <= items.count {
-          expressions.append(items[position - 1].expression)
-        }
-      case let .expression(expression):
-        // A bare unqualified name binds a matching projection output name
-        // before an input column (the ISO precedence), resolving to that
-        // item's expression — the output surface (`output`) mirrors the
-        // resolver's lowering for this query shape.
-        if case let .column(column) = expression, column.qualifier == nil,
-            let item = items.first(where: {
-              $0[keyPath: output]?.lowercased() == column.name.lowercased()
-            }) {
-          expressions.append(item.expression)
-        } else {
-          expressions.append(expression)
-        }
-      }
-    }
-    return expressions
+    return SQLEngine.orderKeys(items, order, named: output)
   }
 
   /// The projection and ORDER BY expressions the select evaluates, for routing
@@ -714,6 +688,38 @@ public struct Select: Hashable, Sendable {
     }
     return evaluated
   }
+}
+
+/// The `order` sort keys resolved to the value expression each sort evaluates,
+/// over the projected `items` — the one resolver a select's `orderKeys` and a
+/// windowed grouping-sets outer layer share, so the sort-output model cannot
+/// drift. An ordinal names the `position`-th item (1-based); a bare
+/// unqualified name binds a matching output `named` before an input column (the
+/// ISO precedence); any other key keeps its own expression. An out-of-range
+/// ordinal is `compile`'s fault to raise, so it is skipped here.
+internal func orderKeys(_ items: Array<Projected>, _ order: Order?,
+                        named: KeyPath<Projected, String?>)
+    -> Array<Expression> {
+  guard let order else { return [] }
+  var expressions = Array<Expression>()
+  for key in order.keys {
+    switch key.sort {
+    case let .ordinal(position):
+      if position >= 1, position <= items.count {
+        expressions.append(items[position - 1].expression)
+      }
+    case let .expression(expression):
+      if case let .column(column) = expression, column.qualifier == nil,
+          let item = items.first(where: {
+            $0[keyPath: named]?.lowercased() == column.name.lowercased()
+          }) {
+        expressions.append(item.expression)
+      } else {
+        expressions.append(expression)
+      }
+    }
+  }
+  return expressions
 }
 
 /// A relation in a `FROM` or `JOIN`: a base relation named by an identifier, or

--- a/SwiftSQL/Sources/SQLEngine/Aggregation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Aggregation.swift
@@ -1275,14 +1275,10 @@ extension Catalog where Self: ~Escapable {
     }
     // A window function beside the aggregation computes over the grouped rows —
     // one output row per group, widened by the window slots — via a `window`
-    // node above the aggregate. A `GROUPING SETS` arm is deferred: its window
-    // would see only that arm's grouped rows, not the union of every set's the
-    // ISO semantics prescribe, so it faults the feature diagnostic on both the
-    // run and validate paths (this compile is the parity gate).
-    if select.windows, case .arm = select.grouping {
-      throw .state("0A000",
-                   "a window function with GROUPING SETS is not yet supported")
-    }
+    // node above the aggregate. A `GROUPING SETS` window rides above the union
+    // of arms instead (ISO: it sees every set's rows), lowered by
+    // `expand(windowed:sets:)` before an arm ever reaches here, so no windowed
+    // `.arm` select is compiled at this seam.
 
     // Lower the projection, HAVING, and ORDER BY against the grouped slot
     // space, enforcing the projection rule (every non-aggregated column must be

--- a/SwiftSQL/Sources/SQLEngine/Compilation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Compilation.swift
@@ -1647,6 +1647,31 @@ extension Catalog where Self: ~Escapable {
     // a same-named derived alias here shadows stays visible. The layered
     // overlay never overwrote the CTE, so no separate pre-augment context runs.
     let context = try augment(context, for: .select(select), rows: false)
+    // Validate the row limit ahead of any lowering — including the windowed
+    // grouping-sets early return below, which else bypasses it. The parser
+    // yields only non-negative counts (a `-` is its own token), but a direct
+    // `Limit(count:offset:)` may carry negatives the executor's skip and take
+    // would trap on, so a public-AST-built negative offset/count must fault the
+    // query error here on every path (ordinary and windowed-sets alike), rather
+    // than reach `limited` and precondition-trap on a negative slice.
+    if let limit = select.limit {
+      guard limit.offset >= 0 else {
+        throw .state("2201X", "OFFSET row count must be non-negative")
+      }
+      guard (limit.count ?? 0) >= 0 else {
+        throw .state("2201W", "FETCH row count must be non-negative")
+      }
+    }
+    // A windowed `GROUP BY GROUPING SETS` select lowers directly here — the
+    // window node above the arm union's `setop` plan, over the union-output
+    // scope — rather than through a derived-table AST rewrite. `Query.expanded`
+    // leaves it un-desugared for this seam (a non-windowed one it desugars to
+    // its `UNION ALL` before reaching here). The union compiles in this
+    // enclosing `context`, so a correlated arm reference (an enclosing LATERAL
+    // `T.Id`) resolves natively.
+    if select.windows, case let .sets(sets) = select.grouping {
+      return try windowed(sets: select, sets, context)
+    }
     let relation = select.from
     // A LATERAL first FROM item has no preceding relation to correlate against,
     // so it is meaningless (and ISO forbids it) — fault rather than resolve a
@@ -1656,19 +1681,6 @@ extension Catalog where Self: ~Escapable {
                    "a LATERAL derived table needs a preceding FROM item")
     }
     let from = try resolve(relation, context)
-
-    if let limit = select.limit {
-      // The parser yields only non-negative counts (a `-` is its own token),
-      // but a direct `Limit(count:offset:)` may carry negatives the executor's
-      // skip and take would trap on. Reject them as a query error rather than
-      // crash.
-      guard limit.offset >= 0 else {
-        throw .state("2201X", "OFFSET row count must be non-negative")
-      }
-      guard (limit.count ?? 0) >= 0 else {
-        throw .state("2201W", "FETCH row count must be non-negative")
-      }
-    }
 
     // A window function is allowed only in the SELECT list and `ORDER BY` (ISO
     // 9075); one in a WHERE, HAVING, GROUP BY, or JOIN ON has no per-row meaning
@@ -2105,6 +2117,136 @@ extension Catalog where Self: ~Escapable {
     let hoisted = SQLEngine.materialise(windowed.windowings, projection,
                                         order, width: combined.count,
                                         below: chain)
+    let node = Plan.window(hoisted.windowings, hoisted.chain)
+    return node.shaped(distinct: select.distinct,
+                       projection: hoisted.projection, filter: nil,
+                       order: hoisted.order, limit: select.limit)
+  }
+
+  /// Compiles a windowed `GROUP BY GROUPING SETS` `select` into a window over
+  /// the arm union — the window layer riding above the union of arm-aggregate
+  /// nodes rather than inside any one arm, so the window sees the whole result
+  /// set (the per-set grouped rows and the NULL-extended super-aggregate rows
+  /// alike, ISO 9075) in one compilation, with no derived-table boundary.
+  ///
+  /// `decompose` splits the query into the window-free arm `union` and the
+  /// outer window layer's `projection`/`order` over it (each window-free
+  /// operand a window or the surviving projection reads lifted to a synthetic
+  /// `*gwN` union column). This seam then:
+  ///
+  ///   - compiles the `union` to a `setop` plan in the enclosing `context`, so
+  ///     a correlated arm reference (an enclosing LATERAL `T.Id`) resolves
+  ///     natively — no `VALUES (1)` unit or LATERAL apply is needed;
+  ///   - builds the union-output `Scope` over its `0 ..< arity` slots, keyed by
+  ///     the empty alias (as the `ordered` set-op carrier does), so a bare
+  ///     `*gwN` resolves against it by name;
+  ///   - drives the same `Windowed` machinery the plain window path and the
+  ///     grouped-window path drive — an identity slot map, the union output the
+  ///     slot space — validating each window's function/frame against the union
+  ///     scope and lowering the outer projection and query `ORDER BY` against
+  ///     the widened window slots;
+  ///   - stacks `materialise` → `Plan.window` → `.shaped`, so the query-level
+  ///     DISTINCT / `ORDER BY` / OFFSET·FETCH cap layers `Project(Limit(Sort))`
+  ///     over the window, as the plain window path does.
+  ///
+  /// The schema-derive twin (`columns(windowed:sets:_:)`) lowers the same outer
+  /// window layer over the union-output schema, and the executor descends a
+  /// `.window` carrier over the setop leaf, so run ≡ validate.
+  internal borrowing func windowed(sets select: Select,
+                                   _ sets: Array<Array<Expression>>,
+                                   _ context: Context)
+      throws(SQLError) -> Plan {
+    let routines = context.routines
+    let parts = try decompose(windowed: select, sets: sets, routines)
+    // Compile the window-free arm union in the enclosing context and derive its
+    // output columns — the `*gwN`-named, type-unified result columns the window
+    // layer reads. The union plan's output sits at slots `0 ..< arity` (a
+    // `setop`'s output is its arm-0 projection), so the window resolves and
+    // stacks in that identity space, exactly as the `ordered` carrier does over
+    // a set operation.
+    let plan = try compile(parts.union, context)
+    let cols = try columns(unifying: parts.union, context)
+    let arity = cols.count
+    let schema = Schema(from: cols, names: cols.map(\.name), extent: arity,
+                        virtuals: [])
+    // The union-output scope is keyed by the empty alias, so a bare `*gwN`
+    // resolves unqualified over `schema`; its inner query is inspected nowhere,
+    // so the union's arm-0 `SELECT` stands in for the derived relation.
+    let scope = Scope([(Relation(derived: parts.union.arm, as: ""), schema)])
+    // The outer layer hosts every subquery the `Lift` kept out of the arms — an
+    // uncorrelated one it did not push into a `*gwN` column — resolved against
+    // the union scope, so a `LEAD` default or a `CASE` branch nesting a
+    // subquery stays lazy above the cap. Build the same `Resolution` the schema
+    // twin builds, over the outer projection and `ORDER BY`, keyed by the
+    // enclosing select's own subquery roles.
+    var hosted = Array<Query>()
+    for item in parts.projection {
+      item.expression.collect(subqueries: &hosted)
+    }
+    for key in parts.order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(subqueries: &hosted)
+      }
+    }
+    let outer = try subquery(hosted, select, context, within: scope)
+
+    // The distinct windows the outer layer computes, gathered from the lifted
+    // projection and `ORDER BY`. An unsupported function or frame faults the
+    // feature diagnostic in parity with the schema type derive, exactly as the
+    // plain window path gates them.
+    var expressions = Array<Expression>()
+    for item in parts.projection {
+      item.expression.collect(windows: &expressions)
+    }
+    for key in parts.order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(windows: &expressions)
+      }
+    }
+    for expression in expressions {
+      guard case let .window(function, spec) = expression else {
+        throw .state("XX000", "expected a window function")
+      }
+      guard function.supported else {
+        throw .state("0A000", "\(function.keyword) is not yet supported")
+      }
+      try function.require(order: spec)
+      if let frame = spec.frame {
+        let ordering = try frame.measured
+            ? scope.ordering(spec, routines, subquery: outer)
+            : nil
+        try frame.reject(for: function, order: ordering)
+      }
+    }
+
+    // The union output is the window's slot space, so the slot map is the
+    // identity over `0 ..< arity`: a `*gwN` reference reads its own union slot,
+    // and each windowing appends one slot past the source width (`arity + j`).
+    let identity =
+        Dictionary(uniqueKeysWithValues: (0 ..< arity).map { ($0, $0) })
+    var windowed = Windowed(scope, identity, width: arity)
+    let projection = try windowed.terms(.expressions(parts.projection),
+                                        routines, subquery: outer)
+    var order = Array<SortKey>()
+    if let clause = parts.order {
+      order = try windowed.order(clause, projection, routines,
+                                 subquery: outer)
+    }
+    // Under DISTINCT every `ORDER BY` key must be a select-list value (see
+    // `distinct`); the keys and projection are in the window's output slot
+    // space, aligned with the AST keys index-for-index.
+    if select.distinct, let clause = parts.order {
+      order = try distinct(clause.keys, order, projection)
+    }
+
+    // Materialise each window ORDER BY value the projection also reports once
+    // below the window (a stateful ordinal-named value evaluated once, the
+    // ranking matching the reported column), then stack the window over the
+    // setop plan and shape the query-level DISTINCT / ORDER BY / OFFSET·FETCH —
+    // `shaped` layers `Project(Limit(Sort(_)))`, exactly as the plain window
+    // path shapes its own window node.
+    let hoisted = SQLEngine.materialise(windowed.windowings, projection,
+                                        order, width: arity, below: plan)
     let node = Plan.window(hoisted.windowings, hoisted.chain)
     return node.shaped(distinct: select.distinct,
                        projection: hoisted.projection, filter: nil,

--- a/SwiftSQL/Sources/SQLEngine/Definition.swift
+++ b/SwiftSQL/Sources/SQLEngine/Definition.swift
@@ -308,10 +308,30 @@ extension Catalog where Self: ~Escapable {
     // them as one derived layer that shadows an outer CTE or derived alias of
     // the same name in the scope this SELECT resolves its own references
     // against (projection/WHERE/JOIN-ON/GROUP/HAVING).
+    //
+    // A multi-set windowed `GROUP BY GROUPING SETS` select keeps a `.select`
+    // body but its FROM/JOIN derived tables are arm-scoped: the window rides
+    // above the arm union, and each expanded arm re-materialises the source
+    // (the carrier-aware executor per-arm augments it), matching the non-
+    // windowed grouping-sets over the same source. Bind the schema here — the
+    // optimiser needs the derived alias resolvable for its seek/nest rewrite —
+    // but not the rows: a stateful source materialised once at the query level
+    // would have every arm reuse those rows, diverging from the non-windowed
+    // form (whose `.setop` body carries no query-level derivation at all, so
+    // its arms materialise per arm). The run reveals this schema layer before
+    // the carrier-aware execute, so each arm re-materialises the rows.
+    //
+    // A single-set spelling has no arm union (`unioned` is false): one
+    // arm, so per-arm and per-query materialisation coincide. Materialise its
+    // rows here (not arm-scoped) so the ordinary per-query executor the run
+    // routes it through reads them — the `run` carrier fork keys on the same
+    // `unioned`, so the two decide the single-arm shape together.
+    let deferred = query.unioned
     var layer = Dictionary<String, RelationInstance>()
     for (alias, inner, columns) in derivations {
       layer[alias.lowercased()] =
-          try materialise(inner, scope, rows: rows, columns: columns)
+          try materialise(inner, scope, rows: rows && !deferred,
+                          columns: columns)
     }
     return context.scoping(augmented.pushing(layer))
   }

--- a/SwiftSQL/Sources/SQLEngine/Engine.swift
+++ b/SwiftSQL/Sources/SQLEngine/Engine.swift
@@ -121,6 +121,37 @@ extension Catalog where Self: ~Escapable {
     if !query.carriers.isEmpty, case .setop = query.body {
       return try execute(plan, carrying: query.core, augmented).map(\.values)
     }
+    // A multi-set windowed `GROUP BY GROUPING SETS` select lowers to a
+    // `.window` over the arm `union`'s `.setop` (`windowed(sets:)`), yet
+    // keeps a `.select` body: `expanded` does not desugar it, since the window
+    // must ride above the union, not inside each arm. So neither carrier
+    // branch above fires, and the plain `execute` below would run the buried
+    // setop under the one augmented context — every arm scanning the derived
+    // source the query-level augment bound a single time — where the non-
+    // windowed grouping-sets, a `.setop` routed carrier-aware, materialises it
+    // per arm. Recover the arm union the compile split off (`decompose`, the
+    // single source of that split) and route the plan through the same carrier-
+    // aware executor, whose `.window` descent carries the union to the setop
+    // leaf and per-arm augments it. `augment` bound this query's derived tables
+    // schema-only (`unioned`), so the query-level materialise fired no
+    // stateful source; `revealed` drops that schema layer so each arm
+    // materialises the rows itself — matching the non-windowed form. A stray
+    // plan node the `.window` descent does not carry through (a fused `top`)
+    // reads the same revealed base, whose store relations and CTEs it keeps.
+    //
+    // A single-set spelling (a non-empty `((x))` or the grand total `(())`) has
+    // no arm union — `decompose` returns a plain grouped `.select`, one arm,
+    // not a `.setop` — so there is nothing to carry per arm, no schema layer to
+    // reveal: `augment` (keyed on the same `unioned`) materialised its
+    // derived rows once already. `unioned` is false, so it skips the
+    // carrier route and falls through to the ordinary `execute` below, which
+    // reads those rows and runs the `.window` over the lone grouped arm. Both
+    // forks decide the single-arm shape by one predicate, so a future routing
+    // change cannot handle the multi-arm case yet miss the single arm.
+    if let union = try query.union(windowed: context.routines) {
+      return try execute(plan, carrying: union, augmented.revealed())
+          .map(\.values)
+    }
     // A carrier over a bare `SELECT` (a parenthesised simple query with an
     // outer tail — `(SELECT …) ORDER BY …`) has no set-operation arms to
     // augment, so its `.shaped` plan runs through the plain executor; only a

--- a/SwiftSQL/Sources/SQLEngine/Filter.swift
+++ b/SwiftSQL/Sources/SQLEngine/Filter.swift
@@ -1319,6 +1319,16 @@ extension Catalog where Self: ~Escapable {
     guard let plan = context.subqueries.plan(key, correlation) else {
       throw .named("a correlated subquery plan was not compiled")
     }
+    // A windowed `GROUP BY GROUPING SETS` subquery keeps a `.select` body over
+    // a hidden arm union, so the `.setop` check below misses it; the one shared
+    // decision recovers that union and this per-row execution routes it through
+    // the same carrier descender, over a `revealed()` context so each arm
+    // re-materialises its schema-only derived layer — the parity a top-level
+    // `run` gets. Without this a correlated windowed grouping-sets body scanned
+    // the schema-only source once, dropping the arm rows.
+    if let union = try key.query.union(windowed: context.routines) {
+      return try execute(plan, carrying: union, context.revealed())
+    }
     // A SET-operation subquery augments per ARM (arm-local derived aliases the
     // query-level augment misses); a single query augments the whole query
     // once. A carried union compiles to a `.shaped` plan (a project/sort/
@@ -1438,6 +1448,16 @@ extension Catalog where Self: ~Escapable {
       // uses, so a mixed-type arm widens identically here.
       return try combine(kind, arms(left, leftQuery, context),
                          arms(right, rightQuery, context), all, types: types)
+    }
+    // An arm that is itself a windowed `GROUP BY GROUPING SETS` select keeps a
+    // `.select` body over a hidden arm union, so the `.setop` check below
+    // misses it; the one shared decision recovers that union and this arm
+    // descends it carrier-aware over a `revealed()` context, per-arm
+    // re-materialising its schema-only derived layer — the parity a top-level
+    // `run` gets. Without this a `(windowed grouping-sets) UNION …` arm scanned
+    // the schema-only source once, dropping its per-group rows.
+    if let union = try query.union(windowed: context.routines) {
+      return try execute(plan, carrying: union, context.revealed())
     }
     // An arm that is itself a suffix-bearing parenthesised set operation
     // (`… UNION (… UNION … ORDER BY V FETCH n)`) reaches here as an

--- a/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
+++ b/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
@@ -4,6 +4,68 @@
 // MARK: - GROUPING SETS
 
 extension Query {
+  /// Whether this query is a windowed `GROUP BY GROUPING SETS` select — a
+  /// window function over a grouping-sets query. `expanded` does not desugar
+  /// such a select to its `UNION ALL` (the window must ride above the arm
+  /// union, not inside each arm), so it keeps a `.select` body while its result
+  /// is the arm union; the compile lowers it directly (`windowed(sets:)`) and
+  /// the run routes it through the carrier-aware executor over that union.
+  ///
+  /// The predicate matches the compile gate (`compile(_ select:)`), so the two
+  /// recognise the same shape. A multi-set spelling's FROM/JOIN derived tables
+  /// are arm-scoped, not query-scoped: `augment` binds their schema but not
+  /// their rows (a stateful source must not fire once at the query level and be
+  /// reused by both arms), the arms materialising the rows per arm — as a
+  /// `.setop` body's arms already do. A single-set spelling has no such arm
+  /// union (see `unioned`), so it is not arm-scoped: it materialises and
+  /// runs through the ordinary per-query path.
+  internal var windowing: Bool {
+    guard case let .select(select) = body, select.windows,
+        case .sets = select.grouping else { return false }
+    return true
+  }
+
+  /// Whether a `windowing` select's arm union is a genuine set operation —
+  /// two or more grouping sets, so `expand` (which `decompose` drives) reduces
+  /// it to a `.setop`. A single set — a non-empty `((x))` or the grand total
+  /// `(())` — reduces to one plain grouped `.select`, not a `.setop`: there is
+  /// no union, one arm.
+  ///
+  /// The per-arm carrier path assumes that setop — its `.window` descent
+  /// carries the union to the setop leaf and per-arm augments each arm's
+  /// derived layer, which the schema-only `augment` deferred. A single arm has
+  /// nothing to carry and no per-arm augment, so it runs the ordinary per-query
+  /// path: `augment` materialises its derived rows once (one arm, so per-arm
+  /// and per-query coincide) and the ordinary executor reads them. Both the
+  /// `augment` schema-only bind and the `run` carrier routing fork on this one
+  /// predicate, so the single-arm shape is decided at the same point as the
+  /// multi-arm and a future routing change cannot silently miss it. The
+  /// predicate agrees with the decomposed union's body: `sets.count > 1` iff
+  /// `decompose(windowed:sets:).union` is a `.setop` (both driven by `expand`).
+  internal var unioned: Bool {
+    guard windowing, case let .select(select) = body,
+        case let .sets(sets) = select.grouping else { return false }
+    return sets.count > 1
+  }
+
+  /// The hidden arm union a windowed `GROUP BY GROUPING SETS` select must
+  /// execute carrier-aware over — the `.setop` `decompose` splits off the
+  /// `.select` body — or `nil` when this query carries no such union and runs
+  /// through the ordinary per-query executor. A `unioned` select keeps a
+  /// `.select` body while its result is the arm union, so a `.setop`-only union
+  /// check misses it; every executor entry point (`run`, the view `derive`, the
+  /// correlated `executed`) instead consults this one decision, routing a
+  /// non-`nil` result through `execute(_:carrying:)` over a `revealed()`
+  /// context — the schema-only `augment` deferred each arm's derived layer, and
+  /// `revealed` drops that layer so each arm re-materialises it. Sharing the
+  /// decision keeps a future entry point from open-coding a `.setop`-only
+  /// recognition that silently scans the schema-only source once.
+  internal func union(windowed routines: Routines) throws(SQLError) -> Query? {
+    guard unioned, case let .select(select) = body,
+        case let .sets(sets) = select.grouping else { return nil }
+    return try decompose(windowed: select, sets: sets, routines).union
+  }
+
   /// This query with each top-level `GROUP BY GROUPING SETS` select replaced by
   /// its `UNION ALL` expansion — applied once at every pipeline entry (`run`,
   /// `compile`, `columns(of:)`), so the whole downstream (materialise, augment,
@@ -30,6 +92,19 @@ extension Query {
         // identically on the run and validate paths (both enter `expanded`).
         let select = try select.inlined
         if case let .sets(sets) = select.grouping {
+          // A window over a `GROUPING SETS` query sees the whole result set —
+          // the union of every set's rows (ISO 9075) — not one arm's grouped
+          // rows, so the window layer rides above the union rather than inside
+          // an arm. A windowed grouping-sets select is not desugared here: it
+          // is lowered directly at compile — the window node placed above the
+          // arm union's `setop` plan, over the union-output scope (`compile(_
+          // select:)`) — so no derived-table boundary drops its context. The
+          // inlined select rides through unchanged for that direct lowering
+          // (and the schema-derive/typecheck twins), while a non-windowed one
+          // desugars to its `UNION ALL` here as before.
+          if select.windows {
+            return Query(body: .select(select), carriers: carriers)
+          }
           let expanded = try expand(select, sets: sets)
           return Query(body: expanded.body,
                        carriers: expanded.carriers + carriers)
@@ -62,7 +137,11 @@ extension Query {
 /// set-operation `merge` (a NULL arm constrains nothing, deferring to the arm
 /// that groups on the column). HAVING is copied into every arm (ISO: it filters
 /// each set's own groups); arms combine with `UNION ALL`, so a duplicate set
-/// keeps its rows and the grand-total row is never deduplicated.
+/// keeps its rows and the grand-total row is never deduplicated. The `WINDOW`
+/// clause is copied into every arm too, so the arm compile validates each named
+/// definition against the grouped source — an unused definition faulting a
+/// context-free error (an undefined ORDER BY column) on both paths, as the
+/// ordinary aggregate form does, rather than being dropped unvalidated.
 ///
 /// The query-level `ORDER BY` / `OFFSET`/`FETCH` / `DISTINCT` ride the outer
 /// `Query.ordered` carrier over the union — a `setop` node carries no
@@ -186,7 +265,7 @@ internal func expand(_ select: Select,
     return .select(Select(projection: projection, from: select.from,
                           joins: select.joins, predicate: select.predicate,
                           grouping: .arm(keys: set, superset: superset),
-                          having: select.having))
+                          having: select.having, window: select.window))
   }
   // `sets` is non-empty (the parser requires at least one set), so `union` is
   // set; combine with `UNION ALL` so no arm's rows are deduplicated.
@@ -204,14 +283,19 @@ internal func expand(_ select: Select,
   // would hide a FROM-clause derived table from the query-level derived-table
   // collection and per-arm execution, faulting `.relation` at run. Re-attach
   // the query-level clauses to the single grouped arm and return it plain, so
-  // the ordinary `SELECT` path materialises its derived tables.
+  // the ordinary `SELECT` path materialises its derived tables. The `WINDOW`
+  // clause rides onto the arm as it does for the multi-set union, so the arm
+  // compile validates every named definition against the grouped source — an
+  // unused `WINDOW bad AS (ORDER BY nonesuch)` still faults its undefined
+  // column, as the multi-set and ordinary grouped forms do, rather than being
+  // dropped unvalidated on a single-set query.
   if sets.count == 1 {
     return .select(Select(distinct: select.distinct,
                           projection: select.projection, from: select.from,
                           joins: select.joins, predicate: select.predicate,
                           grouping: .arm(keys: sets[0], superset: superset),
-                          having: select.having, order: select.order,
-                          limit: select.limit))
+                          having: select.having, window: select.window,
+                          order: select.order, limit: select.limit))
   }
   guard carried else { return union }
   // The query-level row operators ride the `ordered` carrier over the union.
@@ -222,4 +306,1063 @@ internal func expand(_ select: Select,
   // as `width − generated`, never by scanning output names for a `*gs` prefix.
   return .ordered(union, distinct: select.distinct, order: select.order,
                   limit: select.limit, generated: hidden.count)
+}
+
+// MARK: - Window over GROUPING SETS
+
+/// The decomposition of a windowed `GROUP BY GROUPING SETS` `select` into the
+/// two halves the direct lowering composes — the window-free arm `union` and
+/// the outer window layer's `projection` and `order` over it. It is not an AST
+/// rewrite to a derived table: the compile seam (`compile(_ select:)`) compiles
+/// the `union` to a `setop` plan, builds the union-output `Scope`, and drives
+/// the shared window machinery over it, placing a `window` node above the arm
+/// union with no derived-table boundary to drop context; the schema-derive and
+/// type-check twins reuse the same decomposition, so a run and a `columns(of:)`
+/// derive cannot diverge.
+internal struct WindowedSets {
+  /// The original projected items (verbatim), from which the direct lowering's
+  /// schema twin names each output — an alias, else a bare column's name, else
+  /// the positional `column N` synthesized header — and marks an unnamed one
+  /// synthesized, preserving its provenance across the boundary-free lowering.
+  internal let items: Array<Projected>
+
+  /// The outer window layer's projection — each original item with every
+  /// group-dependent subexpression lifted to a synthetic `*gwN` reference of
+  /// the union output, each group-independent scalar (`tick()`, `1 / 0`) kept
+  /// outer, a window kept with its operands lifted. Each item carries the
+  /// original item's inferable output name as its alias (`nil` for an unnamed
+  /// one), so a query `ORDER BY` names a window alias while an unnamed output
+  /// stays a synthesized header, never the internal `*gwN` name.
+  internal let projection: Array<Projected>
+
+  /// The outer window layer's query-level `ORDER BY`, each key lifted to read
+  /// the union output — an ordinal or a bare name of a projected output left
+  /// verbatim (it orders on that output), any other key's expression lifted.
+  internal let order: Order?
+
+  /// The inner window-free `UNION ALL` of arms — the `expand` of a synthetic
+  /// grouping-sets select projecting the lifted `*gwN` operands, the rest of
+  /// the query verbatim. It carries the original `WINDOW` clause onto its arms,
+  /// so each arm validates every named definition against the grouped source.
+  internal let union: Query
+}
+
+/// Decomposes a `GROUP BY GROUPING SETS` `select` that also projects (or orders
+/// by) a window function into the window-free arm union and the outer window
+/// layer over it — the two halves the direct lowering composes, without any
+/// derived-table boundary.
+///
+/// A window over a grouping-sets query must see the whole result set: the union
+/// of every set's rows, the per-set grouped rows and the NULL-extended
+/// super-aggregate rows alike (ISO 9075). The ordinary `expand` would push a
+/// window into each arm, so it would see only that arm's grouped rows. The
+/// decomposition instead separates:
+///
+///   - the inner window-free `expand` union of arms, whose projection is
+///     exactly the operands the windows and the surviving projection reference
+///     — each maximal window-free subexpression (a group key, an aggregate, a
+///     `GROUPING(…)`, or a scalar over them) lifted to a synthetic `*gwN`
+///     column, so every arm computes those values in its own grouped scope and
+///     the union carries one row per group across every set. The original
+///     `WINDOW` clause rides onto the union arms so the arm compile validates
+///     every named definition against the grouped source before dropping it —
+///     an unused `WINDOW bad AS (ORDER BY nonesuch)` still faults its undefined
+///     column, as the ordinary and non-windowed aggregate forms do;
+///
+///   - the outer window layer: the original projection and `ORDER BY` with
+///     every group-dependent subexpression rewritten to its `*gwN` reference of
+///     the union output and every group-independent scalar (`tick()`, `1 / 0`)
+///     kept outer. Each window's `PARTITION BY`/`ORDER BY`/argument now reads a
+///     computed column of the union — a `SUM(x)` a window orders by is already
+///     materialised, the window reads it and does not re-aggregate — so the
+///     window computes over the full result set. A projection-only group-
+///     independent scalar stays above the window and the query-level cap,
+///     evaluated after the window as the ordinary grouped-window path evaluates
+///     its projection, so the single-set spelling observes the same values the
+///     ordinary `GROUP BY` form does (#137).
+///
+/// The lifted `*gwN` references are unqualified: the compile seam builds the
+/// union-output `Scope` keyed by the empty alias (as the `ordered` set-op
+/// carrier does), so a bare `*gwN` resolves against that scope's columns rather
+/// than a derived-table qualifier. The compile seam compiles the union in the
+/// enclosing context, so a correlated arm reference (an enclosing LATERAL
+/// `T.Id`) resolves natively — no `VALUES (1)` unit or LATERAL apply is needed.
+///
+/// The rewrite is one uniform substitution walk (`Lift.substitute`): each
+/// maximal grounded atom the union scope cannot compute — a bare `.aggregate`,
+/// a `.grouping(…)`, or a group column — lifts to a `*gwN` arm column, while
+/// every other node (a literal, a group-independent scalar, an arithmetic/
+/// `CAST`/`COALESCE`/`NULLIF`, a `CASE`'s structure, a window function's
+/// operands) stays outer with its operands recursed. The residual then flows to
+/// the same `Windowed`/`materialise`/`shaped` machinery the plain window path
+/// drives, so its placement is inherited, not re-implemented: a projection-only
+/// scalar and a grounded `CASE`'s structure sit above the query-level cap
+/// (`Project(Limit(Sort))`), so a dropped page never evaluates them (#137); a
+/// `LEAD`/`LAG` default stays a lazily evaluated operand; and a window reads
+/// its `*gwN` arm slots as the plain path reads its materialised source cells.
+/// A lifted atom is shared to one `*gwN` column only when deterministic under
+/// `routines` (a group key, an aggregate over steady parts), so a `SUM(x)` a
+/// window orders by and the projection also yields is one column; a non-
+/// deterministic one (`SUM(tick())`) takes a fresh column per occurrence. The
+/// exception is a projected output a window ordinal links to (`ORDER BY 1`):
+/// the ordinal ties the key to that output, so the output lifts to the arm
+/// whole, shared with the key — one evaluation, the window ordering by the
+/// reported column.
+///
+/// A scalar subquery uncorrelated to this query is hosted in the outer layer
+/// through the union-scope `Resolution` (kept verbatim so a `LEAD` default or a
+/// `CASE` branch nesting it stays lazy), while one correlated to a group key
+/// stays arm-lifted, where the arm's grouped scope binds the correlation.
+///
+/// A window `FILTER` and a windowed `CASE` are the two operand shapes not
+/// lowered here — each carries a `Predicate` a `*gwN` column cannot stand in
+/// for — so each faults the feature diagnostic on both paths, in parity,
+/// rather than resolving a base column the union scope cannot see.
+internal func decompose(windowed select: Select,
+                        sets: Array<Array<Expression>>,
+                        _ routines: Routines) throws(SQLError) -> WindowedSets {
+  // `GROUPING SETS ()` has no arm to union — rejected here as in `expand`, so a
+  // directly built empty set list faults a syntax error rather than trapping.
+  guard !sets.isEmpty else {
+    throw .state("42601", "GROUPING SETS requires at least one set")
+  }
+  // A grouped `SELECT *` is ill-formed (the window then lives in `ORDER BY`);
+  // reject it with the same fault the grouped projection resolver raises, so a
+  // windowed `SELECT * … GROUP BY GROUPING SETS` faults identically to the
+  // unwrapped grouped form, on both paths.
+  if case .all = select.projection {
+    throw .state("0A000",
+                 "SELECT * is not allowed with GROUP BY or aggregates")
+  }
+
+  // The real projected items, as an explicit list — an `expressions` list
+  // verbatim, a bare-column `columns` list lifted into `Projected`s.
+  let items: Array<Projected> = switch select.projection {
+  case let .expressions(list):
+    list
+  case let .columns(columns):
+    columns.map { Projected(expression: .column($0)) }
+  case .all:
+    []
+  }
+
+  // The projected outputs a window `ORDER BY` ordinal links to (`Order.Key
+  // .output`, stamped by the prelude's `resolving(ordinals:)`). Such an output
+  // and every window key naming it must read one `*gwN` leaf — the operand
+  // evaluated once, the window ordering by the reported value — even when it is
+  // non-deterministic, mirroring how `materialise` shares an ordinal value
+  // on the ordinary path. A window `ORDER BY` names only a window-free output
+  // (`resolving(ordinals:)` rejects a window output), so a linked output lifts
+  // to a single leaf the key can share.
+  let targets = ordinals(of: items, select.order)
+  // The bare names of the group-key columns — the columns a correlated subquery
+  // may reference (ISO restricts a grouped correlation to a grouping column).
+  // The lifter reads them to route a subquery: one naming a group key is
+  // correlated to this query and stays arm-lifted, resolved in the arm's
+  // grouped scope; one naming none is uncorrelated and hosted in the outer
+  // layer through the union-scope `Resolution`.
+  var keys = Set<String>()
+  for set in sets {
+    for key in set { key.collect(columns: &keys) }
+  }
+  // The whole member expressions each grouping set names — a computed key like
+  // `A + 1` as its own expression, not decomposed to its `A` column — each by
+  // the resolved identity grouped lowering matches a key by, approximated pre-
+  // scope as its `canonical` (qualifier-stripped, case-folded). The lifter
+  // matches an outer subexpression's `canonical` against these to lift a whole
+  // grouping key to one arm column, so the arm projects the exact key it groups
+  // on rather than a bare constituent the grouped scope rejects. Canonical (not
+  // raw `Expression` equality) collapses a qualification- or case-variant
+  // spelling (`A + 1` ≡ `T.A + 1` ≡ `a + 1`) as the arm's `Grouped.term` will.
+  var members = Set<Expression>()
+  for set in sets {
+    for key in set { members.insert(key.canonical) }
+  }
+  // Lift the projection and the query-level ORDER BY over the union output,
+  // gathering the operands each references into `lift.leaves`. Each outer item
+  // carries the original item's inferable output name as its alias (`nil` for
+  // an unnamed one) — a bare group column stays named, an aliased value keeps
+  // its alias — so a query `ORDER BY` may name a window alias, while an unnamed
+  // output takes no `*gwN` name and stays a synthesized `column N` header (the
+  // schema twin names it from `items`).
+  var lift = Lift(routines, keys: keys, members: members)
+  var projection = Array<Projected>()
+  projection.reserveCapacity(items.count)
+  for index in items.indices {
+    // An output a window `ORDER BY` ordinal links to lifts through the ordinal
+    // channel keyed by its index, so the window key naming it (earlier or
+    // later in the list) shares the same leaf — one evaluation, the window
+    // ordering by the reported value; that output is a window operand via the
+    // link, so it lifts to the arm whole even when group-independent. Every
+    // other output takes the uniform substitution walk (`substitute`): each
+    // grounded atom it references lifts to a `*gwN` arm column, its literals
+    // and group-independent scalars kept outer, evaluated after the window.
+    let lifted: Expression
+    if targets.contains(index) {
+      lifted = lift.lift(items[index].expression, output: index)
+    } else {
+      lifted = try lift.substitute(items[index].expression)
+    }
+    projection.append(Projected(expression: lifted, alias: items[index].name))
+  }
+  // The projected output names — a bare unqualified ORDER BY key naming one
+  // orders on that output (ISO output-alias precedence), so it is left to
+  // resolve against the outer projection rather than lifted to a `*gwN`
+  // reference.
+  let outputs = Set(items.compactMap { $0.name?.lowercased() })
+  let order: Order? = if let clause = select.order {
+    try Order(keys: clause.keys.map { key throws(SQLError) in
+      switch key.sort {
+      case .ordinal:
+        // A query-level ordinal names an outer projected column by position —
+        // preserved verbatim, resolved against the outer select's projection.
+        return key
+      case let .expression(expression):
+        if case let .column(column) = expression, column.qualifier == nil,
+            outputs.contains(column.name.lowercased()) {
+          return key
+        }
+        var lifted =
+            try Order.Key(sort: .expression(lift.substitute(expression)),
+                          ascending: key.ascending)
+        lifted.output = key.output
+        return lifted
+      }
+    })
+  } else {
+    nil
+  }
+
+  // Build the inner union of window-free arms — the `expand` of a synthetic
+  // grouping-sets select projecting the lifted operands (aliased `*gwN`), the
+  // rest of the query verbatim. With no query-level operators the union carries
+  // no `ordered` wrapper, so the union is a bare `UNION ALL` (or the lone
+  // grouped select of a single set). When nothing is lifted (a bare
+  // `ROW_NUMBER() OVER ()`), a constant seeds one column so each arm still
+  // yields one row per group.
+  //
+  // The original `WINDOW` clause rides onto the inner select so `expand`
+  // threads it into each arm, where the arm's `front` validates every
+  // definition against the original grouped scope before dropping it — the used
+  // windows the prelude already inlined and lifted to the outer, so a carried
+  // definition is unused and validated only. Without it a context-free error in
+  // an unused definition (`WINDOW bad AS (ORDER BY nonesuch)`) would be quietly
+  // accepted here, unlike the ordinary and non-windowed aggregate forms.
+  let leaves = lift.leaves
+  let names = (0..<max(1, leaves.count)).map { "*gw\($0)" }
+  let projected: Array<Projected> = leaves.isEmpty
+      ? [Projected(expression: .literal(.integer(1)), alias: names[0])]
+      : leaves.indices.map {
+          Projected(expression: leaves[$0], alias: names[$0])
+        }
+  let inner = Select(projection: .expressions(projected), from: select.from,
+                     joins: select.joins, predicate: select.predicate,
+                     grouping: .sets(sets), having: select.having,
+                     window: select.window)
+  let union = try expand(inner, sets: sets)
+
+  return WindowedSets(items: items, projection: projection, order: order,
+                      union: union)
+}
+
+/// The 0-based outputs a window `ORDER BY` ordinal links to across the `items`
+/// projection and the query-level `order` — the provenance the prelude
+/// (`WindowSpec.resolving(ordinals:)`) stamped on each window sort key it
+/// substituted for an output ordinal. A window naming an output pins its rank
+/// to that output's value, so the lifter shares one `*gwN` leaf between the
+/// output and every key that names it. A window `ORDER BY` names only a window-
+/// free output, so a linked output is always a single-leaf value.
+private func ordinals(of items: Array<Projected>, _ order: Order?) -> Set<Int> {
+  var windows = Array<Expression>()
+  for item in items { item.expression.collect(windows: &windows) }
+  for key in order?.keys ?? [] {
+    if case let .expression(expression) = key.sort {
+      expression.collect(windows: &windows)
+    }
+  }
+  var outputs = Set<Int>()
+  for expression in windows {
+    guard case let .window(_, spec) = expression, let order = spec.order
+    else { continue }
+    for key in order.keys {
+      if let output = key.output { outputs.insert(output) }
+    }
+  }
+  return outputs
+}
+
+/// The substitution walk that rewrites a windowed grouping-sets query's outer
+/// expressions over the arm union output, gathering the grounded atoms to push
+/// into the arms.
+///
+/// Every outer expression — a projected item, a query-`ORDER BY` key, a window
+/// operand — is rewritten by one uniform walk (`substitute`): each maximal
+/// grounded atom the union-output scope cannot compute — a bare `.aggregate`, a
+/// `.grouping(…)`, or a group column — is replaced by a reference to its
+/// synthetic `*gwN` union column (deduplicated by determinism), while every
+/// other node is kept in the outer with its operands recursed — a literal, a
+/// pure or stateful scalar over literals (`tick()`, `1 / 0`), an arithmetic/
+/// `CAST`/`COALESCE`/`NULLIF`, a `CASE`'s guards and branches, and a window
+/// function's operands, a `LEAD`/`LAG` default included.
+///
+/// The residual (structure-preserved, leaf-substituted) expression then flows
+/// to the same `Windowed`/`materialise`/`shaped` machinery the plain window
+/// path drives, so its placement is inherited rather than re-implemented here:
+/// a group-independent scalar and a grounded `CASE`'s structure sit in the
+/// outer projection above the query-level cap (`Project(Limit(Sort))`), so a
+/// dropped page never evaluates them (#137); a `LEAD`/`LAG` default stays a
+/// lazily evaluated operand the executor reaches only for an out-of-range
+/// target; and a window reads its `*gwN` arm slots as the plain path reads its
+/// materialised source cells.
+///
+/// `scope.term` faults a bare `.aggregate`/`.grouping` (42803) and cannot
+/// resolve a base column against the `*gwN`-only union scope, so those atoms
+/// must be pre-projected by the arms and substituted; every other node the
+/// ordinary machinery resolves against the union scope directly. A scalar
+/// `.subquery` is pushed to an arm too — the outer layer hosts it via the
+/// union-scope `Resolution` `windowed(sets:)` passes, so a `.subquery` left
+/// outer resolves against it.
+///
+/// A window `FILTER` and a windowed `CASE` are the two shapes not lowered here
+/// — each carries a `Predicate` a `*gwN` column cannot stand in for — so each
+/// faults the feature diagnostic on both paths, in parity (#136).
+private struct Lift {
+  /// The routines a lifted operand's determinism is judged against, deciding
+  /// whether two occurrences share one `*gwN` column.
+  private let routines: Routines
+
+  /// The bare names of the group-key columns — the columns a correlated
+  /// subquery may reference. A subquery naming one is correlated to this query
+  /// and arm-lifted; one naming none is uncorrelated and hosted outer.
+  private let keys: Set<String>
+
+  /// The whole member expressions the grouping sets name — a computed key like
+  /// `A + 1` as its own expression. A subexpression equal to a member lifts
+  /// whole to one arm column, so the arm projects the exact key it groups on
+  /// rather than descending to a bare constituent the grouped scope rejects.
+  private let members: Set<Expression>
+
+  /// The grounded atoms pushed into the arms, in first-appearance order — arm
+  /// column `*gwN` is `leaves[N]`.
+  private(set) var leaves = Array<Expression>()
+
+  /// The `leaves` position each deterministic pushed atom occupies, so an atom
+  /// written twice (a `SUM(x)` a window orders by that the projection also
+  /// yields) is one column. A non-deterministic atom is never recorded here, so
+  /// each occurrence takes a fresh column.
+  private var index = Dictionary<Expression, Int>()
+
+  /// The `leaves` position each ordinal-linked projected output occupies, keyed
+  /// by its 0-based output. A projected output a window `ORDER BY` ordinal
+  /// names and every window key carrying that output's provenance route through
+  /// it, so both read one column even when the operand is non-deterministic —
+  /// the value evaluated once, the window ordering by the reported column — the
+  /// explicit provenance a determinism test cannot supply. Keyed by output, not
+  /// expression, so two ordinals naming distinct outputs that hold an equal
+  /// stateful value stay independent, exactly as `materialise` keys its hoist.
+  private var linked = Dictionary<Int, Int>()
+
+  fileprivate init(_ routines: Routines, keys: Set<String>,
+                   members: Set<Expression>) {
+    self.routines = routines
+    self.keys = keys
+    self.members = members
+  }
+
+  /// Registers `expression` as a column and returns its `leaves` position —
+  /// a deterministic atom folded onto its first occurrence (one shared column),
+  /// a non-deterministic one taking a fresh position each call.
+  private mutating func allocate(_ expression: Expression) -> Int {
+    let steady = expression.steady(routines)
+    if steady, let existing = index[expression] { return existing }
+    let position = leaves.count
+    if steady { index[expression] = position }
+    leaves.append(expression)
+    return position
+  }
+
+  /// The `*gwN` union reference for `expression`, registering it as an arm
+  /// column on first sight. A deterministic atom reuses its position after (one
+  /// shared column), while a non-deterministic one (`SUM(tick())`) takes a
+  /// fresh column per occurrence, so each site evaluates it independently. The
+  /// reference is unqualified — the compile seam builds the union-output scope
+  /// keyed by the empty alias, so a bare `*gwN` resolves against it by name,
+  /// with no derived-table qualifier to match.
+  private mutating func reference(_ expression: Expression) -> Expression {
+    .column(Column(name: "*gw\(allocate(expression))"))
+  }
+
+  /// The `*gwN` union reference for a projected `output` a window `ORDER BY`
+  /// ordinal links to, keyed by the 0-based `output`. The projected output and
+  /// every window key carrying that output's provenance route here, so all read
+  /// one leaf — the operand evaluated once, the window ordering by the reported
+  /// value — even when it is non-deterministic (a `tick()`), matching how
+  /// `materialise` shares an ordinal-named value on the ordinary path. A
+  /// deterministic operand still folds through the shared `index` memo, so an
+  /// unlinked occurrence reuses it too; a directly written key (no `output`)
+  /// never routes here and stays an independent evaluation (#135).
+  private mutating func reference(_ expression: Expression, output: Int)
+      -> Expression {
+    if let existing = linked[output] {
+      return .column(Column(name: "*gw\(existing)"))
+    }
+    let position = allocate(expression)
+    linked[output] = position
+    return .column(Column(name: "*gw\(position)"))
+  }
+
+  /// This expression lifted as the projected output a window `ORDER BY` ordinal
+  /// links to — a window-free subexpression pushed to the `*gwN` arm column
+  /// keyed by `output`, shared with every window key naming the same output. A
+  /// bare literal needs no column (a constant reads the same twice) and stays
+  /// inline. The output is window-free by construction — the prelude rejects a
+  /// window as an ordinal's target — so this never meets a window operand.
+  fileprivate mutating func lift(_ expression: Expression, output: Int)
+      -> Expression {
+    if case .literal = expression { return expression }
+    return reference(expression, output: output)
+  }
+
+  /// This outer expression rewritten over the arm union by the uniform
+  /// substitution walk — each maximal grounded atom the union scope cannot
+  /// compute (an aggregate, a `GROUPING(…)`, a group column, or a scalar
+  /// subquery the outer layer hosts through the union-scope `Resolution`)
+  /// replaced by its `*gwN` reference, every other node kept in the outer with
+  /// its operands recursed.
+  ///
+  /// A literal and a group-independent scalar (`tick()`, `1 / 0`) stay outer
+  /// verbatim (their operands hold no grounded atom); an arithmetic, `CAST`,
+  /// `COALESCE`, `NULLIF`, or `CASE` keeps its structure and recurses its
+  /// operands and guards; a window keeps its function and specification with
+  /// their operands recursed. The residual flows to the ordinary `Windowed`
+  /// machinery, which places it exactly as the plain window path places its
+  /// own — the outer projection above the cap, a `LEAD`/`LAG` default lazily.
+  fileprivate mutating func substitute(_ expression: Expression)
+      throws(SQLError) -> Expression {
+    // A whole grouping-set member — a computed key like `A + 1` — lifts whole
+    // to one arm column before the walk descends, so the arm projects the exact
+    // key it groups on rather than a bare constituent (`A`) the grouped scope
+    // rejects. Matched by `canonical` (qualifier-stripped, case-folded), so a
+    // projection spelled differently than the key (`A + 1` for a `T.A + 1` key)
+    // still lifts whole rather than descending to a bare operand. A literal
+    // member reads the same twice and stays inline. A bare column that is
+    // itself a member matches here first and still lifts whole.
+    if members.contains(expression.canonical) {
+      if case .literal = expression { return expression }
+      return reference(expression)
+    }
+    switch expression {
+    case .aggregate, .grouping, .column:
+      // A grounded atom the union scope cannot compute — an aggregate, a
+      // GROUPING bit-vector, or a group column — becomes its deduplicated
+      // `*gwN` reference, computed in the arm's grouped scope.
+      return reference(expression)
+    case let .subquery(query):
+      // A subquery uncorrelated to this query is hosted in the outer layer
+      // through the union-scope `Resolution` — kept verbatim so a `LEAD`
+      // default or a `CASE` branch nesting it stays lazy, evaluated only when
+      // reached — while one correlated to a group key stays arm-lifted (a
+      // `*gwN` reference) where the arm's grouped scope binds the correlation.
+      // Arm-lifting is always value-correct, so over-approximating the
+      // correlation only forgoes the lazy outer host, never mis-hosts a
+      // correlated subquery.
+      var referenced = Set<String>()
+      query.collect(columns: &referenced)
+      return referenced.isDisjoint(with: keys)
+          ? expression : reference(expression)
+    case .literal:
+      return expression
+    case let .call(name, arguments):
+      return try .call(name: name, arguments: substitute(arguments))
+    case let .binary(operation, lhs, rhs):
+      return try .binary(operation, substitute(lhs), substitute(rhs))
+    case let .cast(operand, type):
+      return try .cast(substitute(operand), type)
+    case let .coalesce(arguments):
+      return try .coalesce(substitute(arguments))
+    case let .nullif(lhs, rhs):
+      return try .nullif(substitute(lhs), substitute(rhs))
+    case let .case(whens, otherwise):
+      // A CASE nesting a window carries a per-row Predicate/window shape no
+      // `*gwN` column stands in for (#136), so defer it; a window-free CASE
+      // keeps its structure outer, its guards and branches recursed so only
+      // their grounded atoms lift to arm columns.
+      let windowed = whens.contains { $0.when.windowed || $0.then.windowed }
+          || (otherwise?.windowed ?? false)
+      if windowed {
+        throw .state("0A000", "a window in a CASE with GROUPING SETS is not " +
+                              "yet supported")
+      }
+      var branches = Array<When>()
+      branches.reserveCapacity(whens.count)
+      for when in whens {
+        branches.append(try When(when: substitute(when.when),
+                                 then: substitute(when.then)))
+      }
+      let fallback: Expression?
+      if let otherwise {
+        fallback = try substitute(otherwise)
+      } else {
+        fallback = nil
+      }
+      return .case(branches, else: fallback)
+    case let .window(function, spec):
+      return try .window(function: substitute(function), spec: substitute(spec))
+    }
+  }
+
+  /// Each expression of `expressions` substituted, in order — a manual loop
+  /// rather than `map`, so the typed `SQLError` throw propagates without
+  /// widening to `any Error`.
+  private mutating func substitute(_ expressions: Array<Expression>)
+      throws(SQLError) -> Array<Expression> {
+    var lifted = Array<Expression>()
+    lifted.reserveCapacity(expressions.count)
+    for expression in expressions { lifted.append(try substitute(expression)) }
+    return lifted
+  }
+
+  /// An optional operand substituted — `nil` stays `nil` (a `LEAD`/`LAG` with
+  /// no default, a positional window's absent default). A default stays in the
+  /// outer window function with only its grounded atoms lifted, so the executor
+  /// evaluates it at its natural point (an out-of-range target only), not
+  /// eagerly per row.
+  private mutating func substitute(_ expression: Expression?)
+      throws(SQLError) -> Expression? {
+    guard let expression else { return nil }
+    return try substitute(expression)
+  }
+
+  /// This `CASE` guard predicate substituted over the arm union — each operand
+  /// expression recursed through `substitute`, the predicate's structure kept
+  /// in the outer projection. A grounded value (a `dept` column, an aggregate,
+  /// a `GROUPING(…)`) becomes a `*gwN` arm reference while the predicate shape
+  /// stays outer (`dept = 1` → `*gw0 = 1`); a group-independent operand (a
+  /// literal, a `:parameter`) stays verbatim. This does not split the predicate
+  /// across arms — only its grouped value operands become arm columns — over
+  /// comparison, bound, IS NULL, IN, row comparison and membership, LIKE,
+  /// BETWEEN, IS DISTINCT FROM, the boolean test, and AND/OR/NOT.
+  ///
+  /// A subquery-bearing form keeps its nested `query` in place — the union-
+  /// scope `Resolution` the outer layer resolves against hosts the guard's
+  /// subquery — but its grounded left operands still substitute: a `within`
+  /// or `quantified` left row (a group-key atom such as `dept IN (…)`) becomes
+  /// its `*gwN` arm reference, so the guard reads the arm-projected value.
+  /// `exists` names no left operand and so rebuilds unchanged.
+  fileprivate mutating func substitute(_ predicate: Predicate)
+      throws(SQLError) -> Predicate {
+    switch predicate {
+    case let .comparison(left, op, right):
+      return try .comparison(left: substitute(left), op: op,
+                             right: substitute(right))
+    case let .bound(left, op, parameter):
+      return try .bound(left: substitute(left), op: op, parameter: parameter)
+    case let .null(operand, negated):
+      return try .null(substitute(operand), negated: negated)
+    case let .membership(operand, values, negated):
+      return try .membership(substitute(operand), substitute(values),
+                             negated: negated)
+    case let .rows(left, op, right):
+      return try .rows(substitute(left), op, substitute(right))
+    case let .among(left, rows, negated):
+      var lifted = Array<Array<Expression>>()
+      lifted.reserveCapacity(rows.count)
+      for row in rows { lifted.append(try substitute(row)) }
+      return try .among(substitute(left), lifted, negated: negated)
+    case let .like(operand, pattern, escape, negated):
+      return try .like(substitute(operand), pattern: substitute(pattern),
+                       escape: substitute(escape), negated: negated)
+    case let .between(operand, lower, upper, negated):
+      return try .between(substitute(operand), substitute(lower),
+                          substitute(upper), negated: negated)
+    case let .distinct(left, right, negated):
+      return try .distinct(substitute(left), substitute(right),
+                           negated: negated)
+    case let .truth(inner, value, negated):
+      return try .truth(substitute(inner), value: value, negated: negated)
+    case let .and(left, right):
+      return try .and(substitute(left), substitute(right))
+    case let .or(left, right):
+      return try .or(substitute(left), substitute(right))
+    case let .not(inner):
+      return try .not(substitute(inner))
+    case let .within(left, query, negated):
+      return try .within(substitute(left), query, negated: negated)
+    case let .quantified(left, op, quantifier, query):
+      return try .quantified(substitute(left), op, quantifier, query)
+    case .exists:
+      // `EXISTS (Q)` names no left operand; its subquery is hosted whole by
+      // the outer layer's union-scope `Resolution`, so rebuild it unchanged.
+      return predicate
+    }
+  }
+
+  /// A `LIKE`/`BETWEEN` operand substituted over the arm union — an expression
+  /// recursed through `substitute`, a `:parameter` (one value for the whole
+  /// execution, identical across every group, so group-independent) left
+  /// verbatim.
+  fileprivate mutating func substitute(_ operand: Predicate.Operand)
+      throws(SQLError) -> Predicate.Operand {
+    switch operand {
+    case let .expression(expression):
+      return try .expression(substitute(expression))
+    case .parameter:
+      return operand
+    }
+  }
+
+  /// An optional `LIKE` escape operand substituted — `nil` stays `nil`.
+  fileprivate mutating func substitute(_ operand: Predicate.Operand?)
+      throws(SQLError) -> Predicate.Operand? {
+    guard let operand else { return nil }
+    return try substitute(operand)
+  }
+
+  /// This window function with its operands substituted over the arm union — a
+  /// ranking function is unchanged, an aggregate window substitutes its
+  /// argument, a positional function substitutes its read-at-a-row value, and a
+  /// `LEAD`/`LAG` default substitutes too but stays in the outer function.
+  ///
+  /// A window reads most operands at a row — the aggregate argument, the
+  /// positional value, the `PARTITION BY`/`ORDER BY` keys — so the executor
+  /// materialises each once per source row (`Window.position`/`extremum`); the
+  /// grounded atoms substitute to `*gwN` arm slots the window reads, the rest
+  /// (a scalar, an offset arithmetic) kept in the operand. A `LEAD`/`LAG`
+  /// default is the conditional one: `Window.position` evaluates it only for an
+  /// out-of-range target, so it stays in the outer function with only its
+  /// grounded atoms lifted, the executor evaluating it at its natural point —
+  /// exactly as the ordinary grouped-window path's `reconciled` default does.
+  private mutating func substitute(_ function: WindowFunction)
+      throws(SQLError) -> WindowFunction {
+    switch function {
+    case .number, .rank, .dense, .ntile, .percent, .cumulative:
+      return function
+    case let .aggregate(aggregate, operand, distinct, filter):
+      // A `FILTER` search condition is a `Predicate` no derived column stands
+      // in for; defer it rather than leave a base column unresolved.
+      guard filter == nil else {
+        throw .state("0A000",
+                     "a window FILTER with GROUPING SETS is not yet supported")
+      }
+      let lifted: Aggregand = switch operand {
+      case .star:
+        .star
+      case let .expression(expression):
+        try .expression(substitute(expression))
+      }
+      return .aggregate(aggregate, of: lifted, distinct: distinct)
+    case let .lead(value, offset, fallback):
+      return try .lead(substitute(value), offset: offset,
+                       default: substitute(fallback))
+    case let .lag(value, offset, fallback):
+      return try .lag(substitute(value), offset: offset,
+                      default: substitute(fallback))
+    case let .first(value):
+      return try .first(substitute(value))
+    case let .last(value):
+      return try .last(substitute(value))
+    case let .nth(value, position):
+      return try .nth(substitute(value), position)
+    }
+  }
+
+  /// This window specification with its `PARTITION BY` keys and `ORDER BY`
+  /// values substituted over the arm union — an ordinal key (a `SELECT *`
+  /// window order the prelude left unbound) is preserved, a value key's
+  /// expression substituted, the frame carried through.
+  private mutating func substitute(_ spec: WindowSpec)
+      throws(SQLError) -> WindowSpec {
+    let partition = try substitute(spec.partition)
+    let order: Order? = if let clause = spec.order {
+      try Order(keys: clause.keys.map { key throws(SQLError) in
+        switch key.sort {
+        case .ordinal:
+          return key
+        case let .expression(expression):
+          // A key the prelude substituted for an output ordinal (`key.output`)
+          // shares that output's `*gwN` leaf, so a non-deterministic operand is
+          // evaluated once and the window orders by the reported value; a
+          // directly written key substitutes to an independent leaf (#135).
+          let value: Expression
+          if let output = key.output {
+            value = lift(expression, output: output)
+          } else {
+            value = try substitute(expression)
+          }
+          var lifted = Order.Key(sort: .expression(value),
+                                 ascending: key.ascending)
+          lifted.output = key.output
+          return lifted
+        }
+      })
+    } else {
+      nil
+    }
+    return WindowSpec(base: spec.base, parenthesized: spec.parenthesized,
+                      partition: partition, order: order, frame: spec.frame)
+  }
+}
+
+extension Expression {
+  /// Whether this window-free expression yields the same value at every
+  /// occurrence, so the lifter may compute it once and share the `*gwN` column
+  /// across the sites that reference it — a bare column, literal, or GROUPING
+  /// bit-vector (a per-arm compile-time constant), an aggregate over a steady
+  /// operand with no FILTER, or an arithmetic/CAST/COALESCE/NULLIF over steady
+  /// parts, and a scalar call only when its routine is deterministic and every
+  /// argument is. A non-deterministic call (`tick()`) is not shared — each site
+  /// computes it independently, matching the plain grouped-window path — and a
+  /// `CASE`, a scalar `subquery`, or a filtered aggregate is conservatively not
+  /// shared. Mirrors `Term.deterministic`: treating an uncertain expression as
+  /// non-steady never wrongly shares two sites that must evaluate on their own,
+  /// only forgoes sharing two that could.
+  fileprivate func steady(_ routines: Routines) -> Bool {
+    switch self {
+    case .column, .literal, .grouping:
+      true
+    case let .call(name, arguments):
+      routines[name]?.deterministic == true
+          && arguments.allSatisfy { $0.steady(routines) }
+    case let .binary(_, lhs, rhs), let .nullif(lhs, rhs):
+      lhs.steady(routines) && rhs.steady(routines)
+    case let .cast(operand, _):
+      operand.steady(routines)
+    case let .coalesce(arguments):
+      arguments.allSatisfy { $0.steady(routines) }
+    case let .aggregate(_, operand, _, filter):
+      switch operand {
+      case .star:
+        filter == nil
+      case let .expression(expression):
+        filter == nil && expression.steady(routines)
+      }
+    case .case, .subquery, .window:
+      false
+    }
+  }
+
+  /// This expression canonicalised for the grouping-key membership test — the
+  /// pre-scope approximation of the resolved identity grouped lowering matches
+  /// a key by. `Grouped.term` equates a projection/`HAVING`/`ORDER BY`
+  /// expression with a `GROUP BY` key when the two lower to the same `Term`
+  /// under `scope.term`, which resolves a column's qualifier to its ordinal (so
+  /// `T.A` and `A` collapse) and case-folds every identifier (so `A` and `a`
+  /// collapse, and a scalar-call name lowercases), then compares structurally.
+  /// With no scope here to resolve an ordinal, this mirrors those two
+  /// normalisations syntactically: each column drops its qualifier and
+  /// lowercases its name, each scalar-call name lowercases, and the rest of the
+  /// tree recurses structurally — so a computed grouping key spelled `T.A + 1`,
+  /// `A + 1`, or `a + 1` canonicalises to one form the member set matches,
+  /// exactly as the arm's real `Grouped.term` equates them once it has a scope.
+  ///
+  /// Dropping the qualifier can over-collapse two distinct relations' same-
+  /// named columns (`R.A` vs `S.A`) the resolved term keeps apart, but that
+  /// only lifts a whole non-key expression the arm's grouped resolver then
+  /// rejects with the same `.grouping` fault, never a wrong success. A `CASE`
+  /// guard `Predicate` canonicalises through `Predicate.canonical` — the same
+  /// two normalisations over its operand expressions — so a computed `CASE` key
+  /// matches a qualification- or case-variant projection of it (`CASE WHEN
+  /// T.A = 1 …` ≡ `CASE WHEN a = 1 …`), as the arm's `Grouped.term` equates the
+  /// whole `CASE` once it has a scope. A scalar `subquery` body and a `window`
+  /// specification recurse no further (neither is a legal grouping-key operand
+  /// the arm would accept), so a qualifier or case variance buried in one is a
+  /// residual matched only verbatim — a conservative under-match that forgoes
+  /// the whole-key lift and descends, as before.
+  fileprivate var canonical: Expression {
+    switch self {
+    case let .column(column):
+      return .column(Column(name: column.name.lowercased()))
+    case .literal:
+      return self
+    case let .call(name, arguments):
+      return .call(name: name.lowercased(),
+                   arguments: arguments.map { $0.canonical })
+    case let .binary(operation, lhs, rhs):
+      return .binary(operation, lhs.canonical, rhs.canonical)
+    case let .cast(operand, type):
+      return .cast(operand.canonical, type)
+    case let .coalesce(arguments):
+      return .coalesce(arguments.map { $0.canonical })
+    case let .nullif(lhs, rhs):
+      return .nullif(lhs.canonical, rhs.canonical)
+    case let .aggregate(aggregate, operand, distinct, filter):
+      let canonical: Aggregand = switch operand {
+      case .star:
+        .star
+      case let .expression(expression):
+        .expression(expression.canonical)
+      }
+      return .aggregate(aggregate, of: canonical, distinct: distinct,
+                        filter: filter)
+    case let .grouping(arguments):
+      return .grouping(arguments.map { $0.canonical })
+    case let .case(whens, otherwise):
+      let branches = whens.map {
+        When(when: $0.when.canonical, then: $0.then.canonical)
+      }
+      return .case(branches, else: otherwise?.canonical)
+    case .subquery, .window:
+      return self
+    }
+  }
+}
+
+extension Predicate {
+  /// This predicate canonicalised for the grouping-key membership test — the
+  /// pre-scope approximation of the resolved identity grouped lowering a `CASE`
+  /// key's guard matches by. It mirrors `Expression.canonical`'s two
+  /// normalisations over every operand expression the predicate carries — a
+  /// column drops its qualifier and lowercases its name, a scalar-call name
+  /// lowercases — and recurses each nested predicate, so a guard spelled
+  /// `T.A = 1` and one spelled `a = 1` canonicalise to one form, exactly as the
+  /// whole `CASE`'s `Grouped.term` equates the two keys once it has a scope.
+  ///
+  /// A nested `EXISTS`/`IN`/quantified subquery body stays structural — as
+  /// `Expression.canonical` leaves a `.subquery` body — so a qualifier or case
+  /// variance buried in one is matched only verbatim, a conservative under-
+  /// match. The operand expressions beside the subquery (the left row of an
+  /// `IN`/quantified) still canonicalise, as they do in a scalar position.
+  fileprivate var canonical: Predicate {
+    switch self {
+    case let .comparison(left, op, right):
+      return .comparison(left: left.canonical, op: op, right: right.canonical)
+    case let .bound(left, op, parameter):
+      return .bound(left: left.canonical, op: op, parameter: parameter)
+    case let .null(operand, negated):
+      return .null(operand.canonical, negated: negated)
+    case let .membership(operand, values, negated):
+      return .membership(operand.canonical, values.map { $0.canonical },
+                         negated: negated)
+    case let .rows(lhs, op, rhs):
+      return .rows(lhs.map { $0.canonical }, op, rhs.map { $0.canonical })
+    case let .among(lhs, rows, negated):
+      return .among(lhs.map { $0.canonical },
+                    rows.map { $0.map { $0.canonical } }, negated: negated)
+    case let .like(operand, pattern, escape, negated):
+      return .like(operand.canonical, pattern: pattern.canonical,
+                   escape: escape?.canonical, negated: negated)
+    case let .between(operand, lower, upper, negated):
+      return .between(operand.canonical, lower.canonical, upper.canonical,
+                      negated: negated)
+    case let .distinct(lhs, rhs, negated):
+      return .distinct(lhs.canonical, rhs.canonical, negated: negated)
+    case let .truth(inner, value, negated):
+      return .truth(inner.canonical, value: value, negated: negated)
+    case let .and(lhs, rhs):
+      return .and(lhs.canonical, rhs.canonical)
+    case let .or(lhs, rhs):
+      return .or(lhs.canonical, rhs.canonical)
+    case let .not(inner):
+      return .not(inner.canonical)
+    case let .within(lhs, query, negated):
+      return .within(lhs.map { $0.canonical }, query, negated: negated)
+    case let .quantified(lhs, op, quantifier, query):
+      return .quantified(lhs.map { $0.canonical }, op, quantifier, query)
+    case .exists:
+      return self
+    }
+  }
+}
+
+extension Predicate.Operand {
+  /// This `LIKE`/`BETWEEN` operand canonicalised — an ordinary expression
+  /// through `Expression.canonical`, a `:parameter` left verbatim (it names no
+  /// column a qualifier or case variance could reach).
+  fileprivate var canonical: Predicate.Operand {
+    guard case let .expression(expression) = self else { return self }
+    return .expression(expression.canonical)
+  }
+}
+
+extension Query {
+  /// The bare (unqualified, case-folded) names of every column this query
+  /// references anywhere — its FROM/JOIN derived bodies, predicates,
+  /// projection, grouping, HAVING, ORDER BY, window specifications, and the
+  /// body of every subquery nested within, at any depth. The lifter reads it to
+  /// decide whether a candidate subquery correlates to the enclosing grouping-
+  /// sets query: one naming a group-key column is correlated (ISO restricts a
+  /// grouped correlation to a grouping column) and stays arm-lifted, one naming
+  /// none is uncorrelated and hosted outer. Over-approximating (a subquery's
+  /// own column shadowing a group-key name) only forgoes the outer host, never
+  /// mis-hosts a correlated one, so the routing stays sound.
+  fileprivate func collect(columns names: inout Set<String>) {
+    switch body {
+    case let .select(select):
+      select.collect(columns: &names)
+    case let .setop(_, left, right, _):
+      left.collect(columns: &names)
+      right.collect(columns: &names)
+    case let .values(rows):
+      for row in rows {
+        for expression in row { expression.collect(columns: &names) }
+      }
+    }
+  }
+}
+
+extension Select {
+  /// The bare names of every column this select references — its FROM/JOIN
+  /// derived bodies and `ON`s, predicate, projection, grouping keys, HAVING,
+  /// ORDER BY, and named-window specifications.
+  fileprivate func collect(columns names: inout Set<String>) {
+    from.collect(columns: &names)
+    for join in joins {
+      join.relation.collect(columns: &names)
+      join.on.collect(columns: &names)
+    }
+    predicate?.collect(columns: &names)
+    switch projection {
+    case .all:
+      break
+    case let .columns(columns):
+      for column in columns { names.insert(column.name.lowercased()) }
+    case let .expressions(items):
+      for item in items { item.expression.collect(columns: &names) }
+    }
+    for key in grouping.collected { key.collect(columns: &names) }
+    having?.collect(columns: &names)
+    for key in order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(columns: &names)
+      }
+    }
+    for definition in window {
+      for expression in definition.spec.expressions {
+        expression.collect(columns: &names)
+      }
+    }
+  }
+}
+
+extension Relation {
+  /// The bare names a relation references — a `.derived` one by recursing into
+  /// its inner query, a `.named` one none (its columns are named at resolution,
+  /// not in the AST).
+  fileprivate func collect(columns names: inout Set<String>) {
+    if case let .derived(query) = source { query.collect(columns: &names) }
+  }
+}
+
+extension Expression {
+  /// The bare (case-folded) names of every column this expression references,
+  /// descending into a scalar `subquery`'s body and a window's operands so a
+  /// correlation nested at any depth is seen.
+  fileprivate func collect(columns names: inout Set<String>) {
+    switch self {
+    case let .column(column):
+      names.insert(column.name.lowercased())
+    case .literal:
+      break
+    case let .call(_, arguments), let .coalesce(arguments),
+         let .grouping(arguments):
+      for argument in arguments { argument.collect(columns: &names) }
+    case let .binary(_, lhs, rhs), let .nullif(lhs, rhs):
+      lhs.collect(columns: &names)
+      rhs.collect(columns: &names)
+    case let .cast(operand, _):
+      operand.collect(columns: &names)
+    case let .aggregate(_, operand, _, filter):
+      if case let .expression(argument) = operand {
+        argument.collect(columns: &names)
+      }
+      filter?.collect(columns: &names)
+    case let .case(whens, otherwise):
+      for when in whens {
+        when.when.collect(columns: &names)
+        when.then.collect(columns: &names)
+      }
+      otherwise?.collect(columns: &names)
+    case let .subquery(query):
+      query.collect(columns: &names)
+    case let .window(function, spec):
+      for expression in spec.expressions { expression.collect(columns: &names) }
+      function.collect(columns: &names)
+    }
+  }
+}
+
+extension WindowFunction {
+  /// The bare names of every column this window function's operands reference —
+  /// an aggregate's argument and FILTER, a positional value and default, a
+  /// FIRST/LAST/NTH value.
+  fileprivate func collect(columns names: inout Set<String>) {
+    switch self {
+    case .number, .rank, .dense, .ntile, .percent, .cumulative:
+      break
+    case let .aggregate(_, operand, _, filter):
+      if case let .expression(argument) = operand {
+        argument.collect(columns: &names)
+      }
+      filter?.collect(columns: &names)
+    case let .lead(value, _, fallback), let .lag(value, _, fallback):
+      value.collect(columns: &names)
+      fallback?.collect(columns: &names)
+    case let .first(value), let .last(value), let .nth(value, _):
+      value.collect(columns: &names)
+    }
+  }
+}
+
+extension Predicate {
+  /// The bare names of every column this predicate references — its operand
+  /// expressions, nested predicates, and the body of any `EXISTS`/`IN`/
+  /// quantified subquery.
+  fileprivate func collect(columns names: inout Set<String>) {
+    switch self {
+    case let .exists(query, _):
+      query.collect(columns: &names)
+    case let .within(lhs, query, _):
+      for expression in lhs { expression.collect(columns: &names) }
+      query.collect(columns: &names)
+    case let .quantified(lhs, _, _, query):
+      for expression in lhs { expression.collect(columns: &names) }
+      query.collect(columns: &names)
+    case let .comparison(left, _, right):
+      left.collect(columns: &names)
+      right.collect(columns: &names)
+    case let .bound(left, _, _):
+      left.collect(columns: &names)
+    case let .null(operand, _):
+      operand.collect(columns: &names)
+    case let .membership(operand, values, _):
+      operand.collect(columns: &names)
+      for value in values { value.collect(columns: &names) }
+    case let .rows(lhs, _, rhs):
+      for expression in lhs { expression.collect(columns: &names) }
+      for expression in rhs { expression.collect(columns: &names) }
+    case let .among(lhs, rows, _):
+      for expression in lhs { expression.collect(columns: &names) }
+      for row in rows {
+        for expression in row { expression.collect(columns: &names) }
+      }
+    case let .like(operand, pattern, escape, _):
+      operand.collect(columns: &names)
+      pattern.collect(columns: &names)
+      escape?.collect(columns: &names)
+    case let .between(operand, lower, upper, _):
+      operand.collect(columns: &names)
+      lower.collect(columns: &names)
+      upper.collect(columns: &names)
+    case let .distinct(lhs, rhs, _):
+      lhs.collect(columns: &names)
+      rhs.collect(columns: &names)
+    case let .truth(inner, _, _):
+      inner.collect(columns: &names)
+    case let .and(lhs, rhs), let .or(lhs, rhs):
+      lhs.collect(columns: &names)
+      rhs.collect(columns: &names)
+    case let .not(operand):
+      operand.collect(columns: &names)
+    }
+  }
+}
+
+extension Predicate.Operand {
+  /// The bare names a `LIKE`/`BETWEEN` operand references — an expression's
+  /// columns, a `:parameter` none.
+  fileprivate func collect(columns names: inout Set<String>) {
+    if case let .expression(expression) = self {
+      expression.collect(columns: &names)
+    }
+  }
 }

--- a/SwiftSQL/Sources/SQLEngine/Interpreter.swift
+++ b/SwiftSQL/Sources/SQLEngine/Interpreter.swift
@@ -148,11 +148,32 @@ extension Catalog where Self: ~Escapable {
     case let .sort(keys, source):
       return try sorted(execute(source, carrying: union, context), keys,
                         context)
+    case let .window(windowings, source):
+      // A windowed `GROUP BY GROUPING SETS` result is a carrier stack over the
+      // arm union (`compile(windowed sets:)`): descend into the window's child
+      // carrying the union — so its setop leaf per-arm augments the arm-local
+      // derived aliases the query-level augment misses — then compute the
+      // windowings over those augmented records, the same as the plain window
+      // node's execution.
+      return try windowed(execute(source, carrying: union, context),
+                          windowings, context)
     case let .distinct(source):
       return deduplicated(try execute(source, carrying: union, context))
     case let .limit(count, offset, source):
       return limited(try execute(source, carrying: union, context), count,
                      offset)
+    case let .top(keys, offset, count, source):
+      // The windowed grouping-sets plan is optimised through the generic
+      // optimiser (its query body is a `.select`, not a `.setop`), which fuses
+      // a bounded `limit` directly over a `sort` into a `top` — so a windowed
+      // grouping-sets under a query `ORDER BY … FETCH n` stacks a `top` above
+      // the window, where the carried set-operation carrier's own plan (a
+      // setop-aware optimise that never fuses) never does. Descend it carrying
+      // the union like the `sort`/`limit` pair it fuses — so the setop leaf
+      // still per-arm augments the arm-local derived aliases — then take the
+      // sorted head, matching the plain `.top` node's execution.
+      return try topmost(execute(source, carrying: union, context), keys,
+                         offset, count, context)
     case let .select(filter, source):
       return try admitted(execute(source, carrying: union, context), filter,
                           context)
@@ -1018,8 +1039,17 @@ extension Catalog where Self: ~Escapable {
     }
     let rows: Array<Record>
     let view = resolve(view: name)
-    if let view, view.query.carriers.isEmpty, case .setop = view.query.body,
-        case .setop = plan {
+    if let view, let union = try view.query.union(windowed: context.routines) {
+      // A windowed `GROUP BY GROUPING SETS` view body keeps a `.select` body
+      // over a hidden arm union, so neither `.setop` branch below sees it; the
+      // one shared decision recovers that union and the body runs through the
+      // same carrier descender the top-level `run` uses, over the `overlay`
+      // revealed so each arm re-materialises its schema-only derived layer.
+      // Without this the body scanned the schema-only source `augment` bound
+      // once (`unioned`), dropping the arm rows.
+      rows = try execute(plan, carrying: union, overlay.revealed())
+    } else if let view, view.query.carriers.isEmpty,
+        case .setop = view.query.body, case .setop = plan {
       // A SET-operation view body executes each ARM's sub-plan under an overlay
       // augmented with that arm's own derived aliases. A `setop` collects no
       // derived aliases at the query level (arms are SELECT-scoped), so the
@@ -1100,6 +1130,16 @@ extension Catalog where Self: ~Escapable {
     // leaves a bare setop or a leaf select unchanged, so a non-carried body is
     // untouched.
     let query = query.core
+    // An arm that is itself a windowed `GROUP BY GROUPING SETS` select keeps a
+    // `.select` body over a hidden arm union, so neither `.setop` branch below
+    // sees it; the one shared decision recovers that union and this arm
+    // descends it carrier-aware over the `overlay` revealed, per-arm
+    // re-materialising its schema-only derived layer. Without this a view body
+    // `(windowed grouping-sets) UNION …` scanned the schema-only source once,
+    // dropping its per-group rows.
+    if let union = try query.union(windowed: overlay.routines) {
+      return try execute(plan, carrying: union, overlay.revealed())
+    }
     if case let .setop(kind, left, right, all, types, _) = plan,
         case let .setop(_, leftQuery, rightQuery, _) = query.body {
       // This node's arm queries are in hand, so the unified column `types` the

--- a/SwiftSQL/Sources/SQLEngine/Schema+Derivation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Schema+Derivation.swift
@@ -335,11 +335,17 @@ extension Catalog where Self: ~Escapable {
     switch query.body {
     case let .select(select):
       // A `GROUP BY GROUPING SETS (…)` derives its schema through the same
-      // `UNION ALL` expansion the compile path uses, so the run and the derived
-      // columns cannot diverge (`run ≡ columns(of:)`): the arms' NULL-padded
-      // columns type through the set-operation `merge` exactly as the run's do.
+      // lowering the compile path uses, so the run and the derived columns
+      // cannot diverge (`run ≡ columns(of:)`). A windowed one derives the outer
+      // window layer over the arm union's schema — the schema twin of the
+      // direct compile lowering (`compile(windowed sets:)`) — while a
+      // non-windowed one derives its `UNION ALL` expansion, whose arms'
+      // NULL-padded columns type through the set-operation `merge` as the run's
+      // do.
       if case let .sets(sets) = select.grouping {
-        cols = try columns(unifying: expand(select, sets: sets), context)
+        cols = select.windows
+            ? try columns(windowed: select, sets: sets, context)
+            : try columns(unifying: expand(select, sets: sets), context)
       } else {
         cols = try arms(of: select, context)
       }
@@ -933,6 +939,28 @@ extension Catalog where Self: ~Escapable {
 
   private borrowing func typecheck(_ select: Select, _ context: Context)
       throws(SQLError) {
+    // A windowed `GROUP BY GROUPING SETS` select lowers to a window over the
+    // arm union (`compile(windowed sets:)`): every window-free operand — a
+    // group key, an aggregate, a `GROUPING(…)`, a scalar over them — lives in
+    // the arm union, while the outer window layer keeps the windows and the
+    // scalars wrapping them (`NULLIF(ROW_NUMBER() OVER (), 'x')`, a
+    // comparison, a `CASE`), reading the arm columns as `*gwN` union
+    // references. Type-check (and, on the run's comparability walk, compare)
+    // the arm union so a reachable-operand or cross-kind-comparison fault
+    // inside a lifted operand surfaces exactly as a run does, then the lifted
+    // outer projection and `ORDER BY` over the union-output scope so a
+    // wrapper's operand incomparability faults `42804` here rather than only
+    // at execution (`matches`) — both in the mode this `context` carries,
+    // keeping run ≡ validate. The window structure itself (its function,
+    // frame, and slot positions) is validated by `compile`, the parity gate
+    // both paths run before this.
+    if select.windows, case let .sets(sets) = select.grouping {
+      let parts = try decompose(windowed: select, sets: sets,
+                                context.routines)
+      try typecheck(parts.union, context)
+      try typecheck(outer: parts, select, context)
+      return
+    }
     // The run's comparability walk visits every reachable comparison surface of
     // this select for the ISO comparability rule — its WHERE, join `ON`s,
     // HAVING, projection, `GROUP BY` and `ORDER BY` keys, aggregate `FILTER`s,
@@ -1028,6 +1056,148 @@ extension Catalog where Self: ~Escapable {
       for reach in on.visited {
         try typecheck(shape(of: reach), revealed.with(outer: scope))
       }
+    }
+  }
+
+  /// Type-checks the outer window layer of a windowed `GROUP BY GROUPING SETS`
+  /// select — its lifted projection and query `ORDER BY` — against the arm
+  /// union's output scope, so a scalar wrapping a window
+  /// (`NULLIF(ROW_NUMBER() OVER (), 'x')`, a comparison, a `CASE`) whose
+  /// operands are incomparable faults exactly as the ordinary grouped-window
+  /// path faults it, on both the run's comparability walk and the strict
+  /// validate path.
+  ///
+  /// The direct lowering (`decompose`) keeps the window functions in the outer
+  /// layer, their window-free operands lifted to `*gwN` references of the union
+  /// output. The arm union (type-checked by the caller) validates those
+  /// operands in their grouped scope, but the outer wrappers that combine the
+  /// windows resolve only over the union output — a hole through which a
+  /// wrapper's operand-comparability mismatch reaches `matches` at execution
+  /// (`42804`) while `columns(of:validate:)` accepts it. Resolving each lifted
+  /// outer expression over the same union-output scope the compile seam builds
+  /// (`windowed(sets:)`) closes it, in the mode this `context` carries — the
+  /// run's comparability finder (`comparisons`, only a `42804` escaping) or the
+  /// strict validate type-check (`validate`) — the same two surfaces `walk` and
+  /// `comparability(of:)` drive over an ordinary select's projection and sort.
+  private borrowing func typecheck(outer parts: WindowedSets,
+                                   _ select: Select, _ context: Context)
+      throws(SQLError) {
+    // The union-output scope keyed by the empty alias — the `*gwN`-named,
+    // type-unified arm columns the outer layer reads — built exactly as the
+    // compile seam and the schema derive build it, so a lifted outer
+    // expression resolves its window operands (`*gwN`) as the run lowers them.
+    let inner = try columns(unifying: parts.union, context)
+    let schema = Schema(from: inner, names: inner.map(\.name),
+                        extent: inner.count, virtuals: [])
+    let scope = Scope([(Relation(derived: parts.union.arm, as: ""), schema)])
+    // The outer layer hosts every subquery the `Lift` kept out of the arms,
+    // resolved against the union scope. Build the `SubqueryCheck` twin of the
+    // run's `Resolution` — each hosted subquery's cursor-free width and single-
+    // column type derived once (ahead of the walk), a scalar occurrence's
+    // operand check deferred to the walk — so validate types a hosted subquery
+    // exactly as the run lowers it, keeping run ≡ validate. A subquery
+    // correlates against the union scope stacked past this query's own outer,
+    // as the run's `subquery(_:_:_:within:)` correlates it.
+    let revealed = context.revealed()
+    let nested = (context.outer ?? Outer()).nested(under: scope)
+    var widths = Dictionary<Query, Int>()
+    var types = Dictionary<Query, ValueType>()
+    let scalar = select.scalar
+    var hosted = Array<Query>()
+    for item in parts.projection {
+      item.expression.collect(subqueries: &hosted)
+    }
+    for key in parts.order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(subqueries: &hosted)
+      }
+    }
+    for query in hosted {
+      try width(query, scalar, revealed, nested, &widths, &types)
+    }
+    let check = SubqueryCheck(widths, types, deferred: scalar,
+                              outer: context.outer)
+    // The projection sits above the query-level cap (`Project(Limit(Sort))`),
+    // so a zero `FETCH` that drops every output row leaves it unreachable;
+    // validate it only when reachable, as the ordinary walk does, while a
+    // DISTINCT evaluates it before the cap. The layer is a window over the arm
+    // union — cardinality-preserving — so its row count is the union's, and the
+    // union is statically single-row iff it reduces to one arm with no group
+    // keys: the grand-total single set `GROUPING SETS (())` (`.sets([[]])`),
+    // which yields exactly one whole-result row. A multi-arm union
+    // (`sets.count > 1`, e.g. `((), ())`) is ≥2 rows; a non-empty single set
+    // groups by its keys. So a positive `OFFSET` elides the projection only for
+    // that grand total, exactly as an ordinary whole-result aggregate
+    // (`aggregates && no keys`) is skipped by a positive `OFFSET`. Derive that
+    // single-row flag from the decomposition rather than hard-coding `false`.
+    // (`||` with a `borrowing self` autoclosure needs the two-statement form.)
+    let single: Bool
+    if case let .sets(sets) = select.grouping {
+      single = sets.count == 1 && sets[0].isEmpty
+    } else {
+      single = false
+    }
+    var reachable = select.distinct
+    if !reachable { reachable = !drops(select.limit, single: single) }
+    if reachable {
+      for item in parts.projection {
+        try validate(outer: item.expression, scope, context, subquery: check)
+      }
+    }
+    // The sort sits below the cap (`Sort` under `Limit`), so every ORDER BY key
+    // runs over the union before the cap pages the rows. Resolve each key
+    // to the value the sort evaluates through the one `orderKeys` resolver the
+    // ordinary path uses (`Select.orderKeys`): an ordinal or an output name —
+    // bound over the output surface the run's `windowed.order` records, an
+    // alias else a bare column's name (`\.name`) — names a projected expression
+    // the sort recomputes below the cap, so an output-referencing sort pulls
+    // that projection into reach and validates it even where the projection
+    // block above is skipped under a row-dropping cap (`FETCH FIRST 0` with
+    // `ORDER BY 1`), the hole the bespoke ordinal/column skip left. A directly
+    // written wrapper (a `NULLIF` over a window) keeps its expression and is
+    // validated too; a bare `*gwN` reference resolves cleanly against the union
+    // scope. Inheriting the resolver, not re-implementing it, keeps the sort-
+    // output model from drifting from the run's.
+    for expression in orderKeys(parts.projection, parts.order, named: \.name) {
+      try validate(outer: expression, scope, context, subquery: check)
+    }
+    // Validate the body of each hosted subquery the walk reached — a scalar or
+    // an `IN`/`EXISTS`/quantified one — in its own reached role's run shape (an
+    // `existential` reach the cardinality probe, a `scalar`/`valued` reach the
+    // original), so a reached throwing body faults exactly as the run
+    // evaluates it while an unreached one (a dropped page, a lazy `LEAD`
+    // default the walk never records) does not. A subquery's own FROM sees the
+    // revealed base, its correlation the union scope stacked past this query's
+    // outer — the same context the run re-executes it under.
+    let recursion =
+        revealed.with(outer: (context.outer ?? Outer()).nested(under: scope))
+    for reach in check.visited {
+      try typecheck(shape(of: reach), recursion)
+      // Re-fold a reached set-operation subquery's operand compatibility (the
+      // width pre-pass deferred it through `shaping()`), so a reached scalar or
+      // `IN` with irreconcilable arm types faults `SQLError.operand`; an
+      // `EXISTS`/`lateral` reach doesn't read the unified arm type, so skip it.
+      switch reach.role {
+      case .scalar, .valued:
+        _ = try columns(unifying: reach.query, recursion)
+      case .existential, .lateral:
+        break
+      }
+    }
+  }
+
+  /// Validates one lifted outer window-layer `expression` over the union
+  /// `scope` in the mode `context` carries — the run's comparability finder
+  /// (only a `42804` escaping) or the strict validate type-check — resolving a
+  /// hosted subquery through the union-scope `subquery` check.
+  private borrowing func validate(outer expression: Expression, _ scope: Scope,
+                                  _ context: Context,
+                                  subquery: SubqueryCheck) throws(SQLError) {
+    if context.comparability {
+      try scope.comparisons(in: expression, context.routines,
+                            subquery: subquery)
+    } else {
+      _ = try scope.validate(expression, context.routines, subquery: subquery)
     }
   }
 
@@ -1790,6 +1960,75 @@ extension Catalog where Self: ~Escapable {
     return (terms, { expression throws(SQLError) in
       try grouped.resolve(expression, routines, subquery: subquery)
     })
+  }
+
+  /// The result columns of a windowed `GROUP BY GROUPING SETS` `select` — the
+  /// schema twin of the direct compile lowering (`compile(windowed sets:)`), so
+  /// validate types exactly the shape run computes (run ≡ columns(of:)).
+  ///
+  /// It reuses the same `decompose` the compile seam does — the window-free arm
+  /// union and the outer window layer's `projection` over it — derives the arm
+  /// union's output schema (its `*gwN`-named, type-unified columns), builds the
+  /// union-output `Scope` over that schema, and resolves each lifted outer item
+  /// against it through the ordinary projection-output logic (`output(_:at:)`),
+  /// so each output carries the complete `ResolvedColumn` — type AND
+  /// `unconstrained` mask — that an ordinary grouped-window select yields as a
+  /// set-op arm: a `*gwN` reference by the union column's type and mask (a
+  /// passed-through constant-NULL source column stays unconstrained), a
+  /// constant NULL kept outer unconstrained, a window by its constrained result
+  /// (a ranking function `.integer`, an aggregate window from its `*gwN`
+  /// argument), the shape the compiled `Windowed` surface lowers it to. Keeping
+  /// only the type (hand-stamped constrained) would mis-type a constant-NULL
+  /// output as a constrained integer, so an outer set-op merge would reject the
+  /// integer/text pair (`42804`) the ordinary companion accepts.
+  ///
+  /// Each output then re-takes its name and synthesized-header provenance from
+  /// the original projected item — an alias, else a bare column's name, else a
+  /// positional `column N` an unnamed expression takes (marked synthesized), so
+  /// an unnamed windowed output feeding an outer set-op carrier stays
+  /// ordinal-only (not name-bindable), never the internal `*gwN` name it reads.
+  borrowing func columns(windowed select: Select,
+                         sets: Array<Array<Expression>>, _ context: Context)
+      throws(SQLError) -> Array<ResolvedColumn> {
+    let routines = context.routines
+    let parts = try decompose(windowed: select, sets: sets, routines)
+    // The arm union's output schema — the same columns the compile seam builds
+    // its window-source scope from — derived through the shared `columns
+    // (unifying:)` fold, so the arms' NULL-padded columns type through the
+    // set-operation `merge` exactly as at compile.
+    let inner = try columns(unifying: parts.union, context)
+    let arity = inner.count
+    let schema = Schema(from: inner, names: inner.map(\.name), extent: arity,
+                        virtuals: [])
+    let scope = Scope([(Relation(derived: parts.union.arm, as: ""), schema)])
+    // The outer layer hosts every subquery the `Lift` kept out of the arms,
+    // resolved against the union scope — the same `Resolution` the compile seam
+    // builds, so a hosted subquery derives its output column exactly as the run
+    // lowers it.
+    var hosted = Array<Query>()
+    for item in parts.projection {
+      item.expression.collect(subqueries: &hosted)
+    }
+    for key in parts.order?.keys ?? [] {
+      if case let .expression(expression) = key.sort {
+        expression.collect(subqueries: &hosted)
+      }
+    }
+    let outer = try subquery(hosted, select, context, within: scope)
+    // Resolve each outer window-layer item over the union scope through the
+    // ordinary projection-output logic, so its `unconstrained` mask comes from
+    // the same resolution as its type (a constant NULL unconstrained, a window
+    // constrained, a passed-through `*gwN` column by its source mask), then
+    // re-stamp the name and synthesized-header provenance from the original
+    // item — an inferable name, else a synthesized `column N`.
+    return try parts.items.indices.map { index throws(SQLError) in
+      let name = parts.items[index].name ?? "column \(index + 1)"
+      let resolved = try scope.output(parts.projection[index], at: index,
+                                      routines, subquery: outer)
+      return ResolvedColumn(OutputColumn(name: name, type: resolved.type),
+                            unconstrained: resolved.unconstrained,
+                            synthesized: parts.items[index].name == nil)
+    }
   }
 
   /// Whether `limit` drops the one row a `single`-row result would yield,

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -3548,18 +3548,16 @@ struct WindowOverGroupedTests {
     }
   }
 
-  @Test func `a window with GROUPING SETS is deferred`() throws {
-    // A window over a `GROUPING SETS` arm would see only that arm's grouped
-    // rows, not the union ISO prescribes, so it is deferred — faulting the
-    // feature diagnostic on both the run and validate paths.
-    let sql = "SELECT dept, SUM(sal), RANK() OVER (ORDER BY SUM(sal)) " +
-              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
-    let fault = SQLError.state(
-        "0A000", "a window function with GROUPING SETS is not yet supported")
-    try fixture().expect(sql, fails: fault)
-    #expect(throws: fault) {
-      _ = try fixture().columns(of: parse(query: sql), validate: true)
-    }
+  @Test func `a window over GROUPING SETS sees every set's rows`() throws {
+    // A window over a `GROUPING SETS` query numbers across the union of every
+    // set's rows (ISO 9075), not one arm's grouped rows — the per-dept totals
+    // (dept 1 300, dept 2 600, dept 3 500) AND the grand total (1400), ranked
+    // together by `SUM(sal)`: 300 → 1, 500 → 2, 600 → 3, 1400 → 4. The former
+    // `0A000` deferral is gone — the window rides above the union of arms.
+    try fixture().expect(
+        "SELECT dept, SUM(sal), ROW_NUMBER() OVER (ORDER BY SUM(sal)) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 300, 1], [2, 600, 3], [3, 500, 2], [nil, 1400, 4]])
   }
 
   @Test func `an aggregate in a grouped window FILTER is rejected`() throws {
@@ -3696,5 +3694,1666 @@ struct WindowOverGroupedTests {
     try fixture().expect(sql, yields: [[1]])
     #expect(try fixture().columns(of: parse(query: sql), validate: true)
                 .count == 1)
+  }
+}
+
+@Suite("Window functions over GROUPING SETS / ROLLUP / CUBE output")
+struct WindowOverGroupingSetsTests {
+  // Groups: dept 1 sums 300, dept 2 sums 600, dept 3 sums 500; the grand total
+  // is 1400. A window over a grouping-sets query sees all of them — the per-set
+  // grouped rows and the NULL-extended super-aggregate rows — as one result.
+  private func fixture() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("Emp", ["dept": .integer, "sal": .integer]) {
+        Row(1, 100)
+        Row(1, 200)
+        Row(2, 300)
+        Row(2, 300)
+        Row(3, 500)
+      }
+    }
+  }
+
+  // A two-dimensional relation for the ROLLUP/CUBE and partition cases.
+  // Per-(Region, Product): East/A 15, East/B 20, West/A 7, West/B 3. Per-Region
+  // East 35, West 10; per-Product A 22, B 23; grand total 45.
+  private func sales() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("Sales", ["Region": .text, "Product": .text, "Qty": .integer]) {
+        Row("East", "A", 10)
+        Row("East", "A", 5)
+        Row("East", "B", 20)
+        Row("West", "A", 7)
+        Row("West", "B", 3)
+      }
+    }
+  }
+
+  @Test func `ROW_NUMBER numbers across every set's rows`() throws {
+    // The window orders the union of the `(dept)` rows and the `()` grand-total
+    // row by `SUM(sal)`, numbering across all four: 300 → 1, 500 → 2, 600 → 3,
+    // 1400 → 4. The output stays in union order (the per-dept arm, then the
+    // grand total), each row carrying its number.
+    try fixture().expect(
+        "SELECT dept, SUM(sal), ROW_NUMBER() OVER (ORDER BY SUM(sal)) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 300, 1], [2, 600, 3], [3, 500, 2], [nil, 1400, 4]])
+  }
+
+  @Test func `an aggregate-argument window reads the union`() throws {
+    // `SUM(SUM(sal)) OVER ()` sums the grouped totals across the whole result —
+    // the three per-dept totals and the grand total, 300 + 600 + 500 + 1400 =
+    // 2800 — over each row. The inner `SUM(sal)` is a column the union already
+    // computed; the outer window reads it and does not re-aggregate.
+    try fixture().expect(
+        "SELECT dept, SUM(SUM(sal)) OVER () " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 2800], [2, 2800], [3, 2800], [nil, 2800]])
+  }
+
+  @Test func `an ordered frame accumulates over the union`() throws {
+    // A running `ROWS UNBOUNDED PRECEDING → CURRENT ROW` frame over the union,
+    // ordered by `SUM(sal)` (300, 500, 600, 1400), runs the cumulative total;
+    // each row reports the sum up to its ordered position — dept 1 300, dept 3
+    // 800, dept 2 1400, the grand total 2800 — output in union order.
+    try fixture().expect(
+        """
+        SELECT dept, SUM(sal), SUM(SUM(sal)) OVER (ORDER BY SUM(sal)
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        FROM Emp GROUP BY GROUPING SETS ((dept), ())
+        """,
+        yields: [[1, 300, 300], [2, 600, 1400], [3, 500, 800],
+                 [nil, 1400, 2800]])
+  }
+
+  @Test func `a window partitions by a grouping-set key`() throws {
+    // `COUNT(*) OVER (PARTITION BY Region)` partitions the union by Region: the
+    // two East `(Region, Product)` rows form one partition (count 2), the two
+    // West rows another (count 2), and the NULL-extended grand-total row — its
+    // Region rolled up to NULL — its own partition (count 1). A super-aggregate
+    // NULL is an ordinary partition value, not skipped.
+    try sales().expect(
+        "SELECT Region, Product, SUM(Qty), COUNT(*) OVER (PARTITION BY Region) "
+        + "FROM Sales GROUP BY GROUPING SETS ((Region, Product), ())",
+        yields: [["East", "A", 15, 2], ["East", "B", 20, 2],
+                 ["West", "A", 7, 2], ["West", "B", 3, 2],
+                 [nil, nil, 45, 1]])
+  }
+
+  @Test func `a ROLLUP output feeds a window`() throws {
+    // `ROLLUP(Region, Product)` unions the full grouping, the per-Region level
+    // (Product a super-aggregate NULL), and the grand total. `ROW_NUMBER() OVER
+    // (ORDER BY SUM(Qty))` numbers across all seven rows by their total: 3 → 1,
+    // 7 → 2, 10 → 3, 15 → 4, 20 → 5, 35 → 6, 45 → 7, output in level order.
+    try sales().expect(
+        "SELECT Region, Product, SUM(Qty), "
+        + "ROW_NUMBER() OVER (ORDER BY SUM(Qty)) "
+        + "FROM Sales GROUP BY ROLLUP(Region, Product)",
+        yields: [["East", "A", 15, 4], ["East", "B", 20, 5],
+                 ["West", "A", 7, 2], ["West", "B", 3, 1],
+                 ["East", nil, 35, 6], ["West", nil, 10, 3],
+                 [nil, nil, 45, 7]])
+  }
+
+  @Test func `a CUBE output feeds a window`() throws {
+    // `CUBE(Region, Product)` unions all four subsets — `(Region, Product)`,
+    // `(Product)`, `(Region)`, `()` — nine rows. `ROW_NUMBER() OVER (ORDER BY
+    // SUM(Qty))` numbers across every one by its total: 3 → 1, 7 → 2, 10 → 3,
+    // 15 → 4, 20 → 5, 22 → 6, 23 → 7, 35 → 8, 45 → 9, output in subset order.
+    try sales().expect(
+        "SELECT Region, Product, SUM(Qty), "
+        + "ROW_NUMBER() OVER (ORDER BY SUM(Qty)) "
+        + "FROM Sales GROUP BY CUBE(Region, Product)",
+        yields: [["East", "A", 15, 4], ["East", "B", 20, 5],
+                 ["West", "A", 7, 2], ["West", "B", 3, 1],
+                 [nil, "A", 22, 6], [nil, "B", 23, 7],
+                 ["East", nil, 35, 8], ["West", nil, 10, 3],
+                 [nil, nil, 45, 9]])
+  }
+
+  @Test func `the query ORDER BY sorts on the window output`() throws {
+    // The query orders by the window number descending (aliased `n`), so the
+    // union rows come out grand total (4), dept 2 (3), dept 3 (2), dept 1 (1).
+    try fixture().expect(
+        "SELECT dept, SUM(sal), ROW_NUMBER() OVER (ORDER BY SUM(sal)) AS n " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ()) ORDER BY n DESC",
+        yields: [[nil, 1400, 4], [2, 600, 3], [3, 500, 2], [1, 300, 1]])
+  }
+
+  @Test func `run and validate agree on a windowed GROUPING SETS`() throws {
+    // Both paths enter `Query.expanded`, so they drive the one rewrite over the
+    // union: the schema path types the same three-column shape the run
+    // produces, no grouping-sets deferral surviving on either.
+    let sql = "SELECT dept, SUM(sal), ROW_NUMBER() OVER (ORDER BY SUM(sal)) " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 3)
+    try fixture().expect(sql,
+                         yields: [[1, 300, 1], [2, 600, 3], [3, 500, 2],
+                                  [nil, 1400, 4]])
+  }
+
+  @Test func `an unaliased windowed aggregate keeps its positional header`()
+      throws {
+    // The outer projection surfaces the same ISO output headers the unwrapped
+    // grouped form does — a bare group column its name, an unnamed aggregate
+    // its positional `column N` — never the internal `*gwN` name the lowering
+    // gives the derived union it reads. The window's own unnamed output takes
+    // the next positional header.
+    let windowed = "SELECT dept, SUM(sal), " +
+                   "ROW_NUMBER() OVER (ORDER BY SUM(sal)) FROM Emp " +
+                   "GROUP BY GROUPING SETS ((dept), ())"
+    let grouped = "SELECT dept, SUM(sal) FROM Emp " +
+                  "GROUP BY GROUPING SETS ((dept), ())"
+    let headers = try fixture().columns(of: parse(query: windowed),
+                                        validate: true).map(\.name)
+    let plain = try fixture().columns(of: parse(query: grouped),
+                                      validate: true).map(\.name)
+    // The first two headers match the non-windowed grouped form exactly.
+    #expect(Array(headers.prefix(2)) == plain)
+    #expect(headers == ["dept", "column 2", "column 3"])
+  }
+
+  @Test func `an aliased windowed aggregate keeps its alias header`() throws {
+    // An explicit `AS` on a projected aggregate keeps its alias, and a bare
+    // group column keeps its name — the outer projection carries the original
+    // ISO output name, not the derived `*gwN` column it reads.
+    let sql = "SELECT dept, SUM(sal) AS total, " +
+              "ROW_NUMBER() OVER (ORDER BY SUM(sal)) AS n FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept), ())"
+    let headers = try fixture().columns(of: parse(query: sql),
+                                        validate: true).map(\.name)
+    #expect(headers == ["dept", "total", "n"])
+  }
+
+  @Test func `a non-grouped operand over GROUPING SETS is rejected`() throws {
+    // A window `ORDER BY` naming a column neither grouped nor aggregated has no
+    // grouped value in any arm — the standard grouping rule rejects it as it
+    // does on the plain grouped path, on both the run and validate paths.
+    let sql = "SELECT dept, RANK() OVER (ORDER BY sal) " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    try fixture().expect(sql, fails: .grouping("sal"))
+    #expect(throws: SQLError.grouping("sal")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a window FILTER over GROUPING SETS is deferred`() throws {
+    // An aggregate window's `FILTER` is a per-row `Predicate` no derived union
+    // column stands in for, so it remains deferred — faulting the feature
+    // diagnostic on both the run and validate paths, in parity.
+    let sql = "SELECT dept, SUM(sal) FILTER (WHERE sal > 0) OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    let fault = SQLError.state(
+        "0A000", "a window FILTER with GROUPING SETS is not yet supported")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `an incomparable outer wrapper over GROUPING SETS faults`()
+      throws {
+    // A scalar wrapping a window — `NULLIF(ROW_NUMBER() OVER (), 'x')` — lives
+    // in the outer window layer, its window operand lifted to a `*gwN` union
+    // column. The wrapper's implicit `window = 'x'` compares an integer to
+    // text, incomparable (42804). The direct lowering type-checks the arm
+    // union but once skipped the outer layer, so the run reached `matches` and
+    // faulted while `columns(of:validate:)` accepted it. Both paths now fault
+    // over the union scope, matching the ordinary grouped-window form.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `an incomparable ORDER BY wrapper over GROUPING SETS faults`()
+      throws {
+    // The same mismatch in a query `ORDER BY` wrapper — the lowering lifts the
+    // sort key over the union too, so its comparability is validated over the
+    // union scope exactly as the projection's is, faulting 42804 on both paths.
+    let sql = "SELECT dept FROM Emp GROUP BY GROUPING SETS ((dept), ()) " +
+              "ORDER BY NULLIF(ROW_NUMBER() OVER (), 'x')"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a comparable outer wrapper over GROUPING SETS is accepted`()
+      throws {
+    // The outer validation must not over-reject a well-typed wrapper: comparing
+    // the integer window to an integer is comparable, so `NULLIF(ROW_NUMBER()
+    // OVER (), 5)` runs — numbering the four union rows 1…4 (none equal 5, so
+    // each stays), accepted by both paths.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 5) " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
+    try fixture().expect(sql, yields: [[1], [2], [3], [4]])
+  }
+
+  @Test func `an outer wrapper faults the same over sets and plain grouping`()
+      throws {
+    // Parity: the ordinary (non-grouping-sets) grouped-window form of the same
+    // incomparable wrapper faults identically, so the direct sets lowering does
+    // not diverge from the grouped path it mirrors.
+    let sets = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    let plain = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+                "FROM Emp GROUP BY dept"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sets, fails: fault)
+    try fixture().expect(plain, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sets), validate: true)
+    }
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: plain), validate: true)
+    }
+  }
+
+  @Test func `a capped output-referencing sort validates the projection`()
+      throws {
+    // A row-dropping cap leaves the projection above it unreachable — but an
+    // `ORDER BY 1` names that output, pulling its projection below the sort
+    // (below the cap), where the run still evaluates it. The incomparable
+    // `NULLIF(ROW_NUMBER() OVER (), 'x')` (integer versus text) faults
+    // 42804 on the run under `FETCH FIRST 0`, and validate must fault
+    // identically: the outer layer inherits the ordinary path's sort-output
+    // resolution, so the ordinal key resolves to the projection expression the
+    // sort recomputes and validates it even where the projection block is
+    // skipped. A bespoke skip of the ordinal key accepted the query — the
+    // run ≠ validate hole this closes.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept), ()) ORDER BY 1 " +
+              "FETCH FIRST 0 ROWS ONLY"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a capped unreferenced projection stays unreachable`() throws {
+    // The companion guarding against over-rejection: the same incomparable
+    // wrapper under `FETCH FIRST 0` but with no output-referencing sort. The
+    // projection sits above the cap and no sort names it, so it stays
+    // unreachable — the run drops every row without evaluating it, yielding the
+    // empty page, and validate accepts its one column rather than faulting a
+    // wrapper the run never reaches.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept), ()) FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
+  }
+
+  // A parent `T` and a keyed child `U`, so a correlated LATERAL body's grouping
+  // varies per outer row: Id 1 has two children (100, 101), Id 2 one (200), and
+  // Id 3 none. The child keys reach back to `T.Id`, the correlation a once-
+  // materialised derived table would sever.
+  private func correlated() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(1)
+        Row(2)
+        Row(3)
+      }
+      Relation("U", ["k": .integer, "v": .integer]) {
+        Row(1, 100)
+        Row(1, 101)
+        Row(2, 200)
+      }
+    }
+  }
+
+  @Test func `a correlated LATERAL windowed GROUPING SETS resolves the outer`()
+      throws {
+    // The windowed grouping-sets query is a correlated LATERAL body: its arms
+    // reference the enclosing `T.Id`, so the union rides a LATERAL apply that
+    // retains that correlation rather than an uncorrelated derived table. Per
+    // `T` row, `ROLLUP(T.Id)` over the children keyed on `T.Id` yields a
+    // per-group row and the grand total, and `ROW_NUMBER() OVER (ORDER BY
+    // SUM(U.v))` numbers them: Id 1 → two rows summing 201 numbered 1, 2; Id
+    // 2 → two rows summing 200 numbered 1, 2; Id 3 → its lone grand total (no
+    // children) numbered 1.
+    try correlated().expect(
+        "SELECT T.Id, d.n FROM T JOIN LATERAL (" +
+        "SELECT ROW_NUMBER() OVER (ORDER BY SUM(U.v)) AS n " +
+        "FROM U WHERE U.k = T.Id GROUP BY ROLLUP(T.Id)) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.n",
+        yields: [[1, 1], [1, 2], [2, 1], [2, 2], [3, 1]])
+  }
+
+  @Test func `run and validate agree on a correlated LATERAL windowed query`()
+      throws {
+    // Both paths enter `Query.expanded` and drive the one lateral-apply
+    // rewrite, so the schema path types the same two-column shape a run
+    // produces — the correlated body resolving `T.Id` on both.
+    let sql = "SELECT T.Id, d.n FROM T JOIN LATERAL (" +
+              "SELECT ROW_NUMBER() OVER (ORDER BY SUM(U.v)) AS n " +
+              "FROM U WHERE U.k = T.Id GROUP BY ROLLUP(T.Id)) AS d ON 1 = 1"
+    #expect(try correlated().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    try correlated().expect(
+        sql + " ORDER BY T.Id, d.n",
+        yields: [[1, 1], [1, 2], [2, 1], [2, 2], [3, 1]])
+  }
+
+  @Test func `a non-windowed LATERAL GROUPING SETS returns the same grouping`()
+      throws {
+    // The parity the windowed form must match: the same correlated body without
+    // the window resolves `T.Id` identically, one row per group per outer row —
+    // Id 1 and Id 2 their per-group sum and grand total (equal here), Id 3 only
+    // its grand-total NULL. The windowed form numbers exactly these rows.
+    try correlated().expect(
+        "SELECT T.Id, d.s FROM T JOIN LATERAL (" +
+        "SELECT SUM(U.v) AS s FROM U WHERE U.k = T.Id " +
+        "GROUP BY ROLLUP(T.Id)) AS d ON 1 = 1 ORDER BY T.Id, d.s",
+        yields: [[1, 201], [1, 201], [2, 200], [2, 200], [3, nil]])
+  }
+
+  @Test func `an unused WINDOW faults over a windowed GROUPING SETS query`()
+      throws {
+    // A used `ROW_NUMBER()` window beside an unused named window whose ORDER BY
+    // names a non-existent column. The rewrite carries the original WINDOW
+    // clause onto the arm union, so the arm's front validates every definition
+    // against the grouped source before dropping it — faulting the undefined
+    // `nonesuch` on both the run and validate paths, as the ordinary and
+    // non-windowed aggregate forms do, rather than silently accepting it.
+    let sql = "SELECT dept, ROW_NUMBER() OVER () FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept), ()) " +
+              "WINDOW bad AS (ORDER BY nonesuch)"
+    try fixture().expect(sql, fails: .column("nonesuch"))
+    #expect(throws: SQLError.column("nonesuch")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `an unused WINDOW faults over a single-set GROUPING SETS`()
+      throws {
+    // A single grouping set takes the fast path that reconstructs an ordinary
+    // grouped `Select`; that reconstruction must carry the `WINDOW` clause, or
+    // an unused definition naming a non-existent column is silently accepted
+    // where the multi-set path and the ordinary grouped query both reject it.
+    let sql = "SELECT dept, ROW_NUMBER() OVER () FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept)) " +
+              "WINDOW bad AS (ORDER BY nonesuch)"
+    try fixture().expect(sql, fails: .column("nonesuch"))
+    #expect(throws: SQLError.column("nonesuch")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a directly-built negative limit faults over GROUPING SETS`()
+      throws {
+    // The windowed grouping-sets lowering validates the row limit before its
+    // early return; else a public-AST-built negative `Limit` reaches the
+    // executor's slice and precondition-traps, where the ordinary path faults
+    // the query error. Run and validate fault identically.
+    let query = try parse(
+        query: "SELECT dept, ROW_NUMBER() OVER () FROM Emp " +
+               "GROUP BY GROUPING SETS ((dept), ())")
+    guard case let .select(base) = query.body else {
+      Issue.record("expected a single SELECT")
+      return
+    }
+    func rebuilt(_ limit: Limit) -> Select {
+      Select(distinct: base.distinct, projection: base.projection,
+             from: base.from, joins: base.joins, predicate: base.predicate,
+             grouping: base.grouping, having: base.having,
+             window: base.window, order: base.order, limit: limit)
+    }
+    let offset: Query = .select(rebuilt(Limit(count: 1, offset: -1)))
+    #expect(throws:
+        SQLError.state("2201X", "OFFSET row count must be non-negative")) {
+      try fixture().run(offset)
+    }
+    #expect(throws:
+        SQLError.state("2201X", "OFFSET row count must be non-negative")) {
+      _ = try fixture().columns(of: offset, validate: true)
+    }
+    let count: Query = .select(rebuilt(Limit(count: -1)))
+    #expect(throws:
+        SQLError.state("2201W", "FETCH row count must be non-negative")) {
+      try fixture().run(count)
+    }
+  }
+
+  @Test func `a valid unused WINDOW definition is accepted and dropped`()
+      throws {
+    // An unused named window whose ORDER BY names a real column is well-formed,
+    // so it validates and is dropped — the query runs exactly as it would with
+    // no WINDOW clause, matching the ordinary grouped path's treatment of an
+    // unused definition.
+    let sql = "SELECT dept, ROW_NUMBER() OVER (ORDER BY SUM(sal)) FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept), ()) WINDOW w AS (ORDER BY dept)"
+    try fixture().expect(sql, yields: [[1, 1], [2, 3], [3, 2], [nil, 4]])
+  }
+
+  @Test func `a stateful leaf evaluates independently at each site`() throws {
+    // A non-deterministic `tick()` in the projection and in the window `ORDER
+    // BY` is not collapsed onto one shared union column: each site evaluates
+    // independently — six calls over the three groups, not three — matching the
+    // plain grouped-window path, not reading one shared value. Under grounded-
+    // outer the projection `tick()` is group-independent, so it stays in the
+    // outer projection and evaluates after the window; only the window key
+    // `tick()` lifts to an arm column (`*gw0`) and evaluates before it. The arm
+    // evaluates its lone key per group (1, 2, 3), the window numbers by that
+    // ascending key (ranks 1, 2, 3), and the outer projection then evaluates
+    // its own `tick()` per output row (4, 5, 6) — the same values, and the same
+    // six calls, the ordinary `GROUP BY dept` companion below reports.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT tick(), ROW_NUMBER() OVER (ORDER BY tick()) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept))",
+        yields: [[4, 1], [5, 2], [6, 3]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `the single set matches the ordinary grouped-window path`()
+      throws {
+    // The grounded-outer oracle: the single-set `GROUPING SETS ((dept))`
+    // spelling of the query above must observe exactly what the ordinary `GROUP
+    // BY dept` windowed query does — the window key `tick()` evaluated first as
+    // the ranking input (1, 2, 3), the projection `tick()` evaluated after the
+    // window (4, 5, 6), six calls in all. This is the reference the grouping-
+    // sets form is pinned to; before grounded-outer the grouping-sets form
+    // reported 1, 3, 5 (both `tick()`s in the arm), diverging from it.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT tick(), ROW_NUMBER() OVER (ORDER BY tick()) " +
+        "FROM Emp GROUP BY dept",
+        yields: [[4, 1], [5, 2], [6, 3]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `a capped projection-only fault drops with the page`() throws {
+    // #137: a projection-only pure scalar that would fault (`1 / 0`) is group-
+    // independent, so grounded-outer keeps it in the outer projection above the
+    // `Project(Limit(Sort))` cap rather than in an arm below it. A zero `FETCH`
+    // drops every row before the projection runs, so the division never
+    // happens and the query returns the empty page — matching the ordinary
+    // grouped-window path. Before grounded-outer the `1 / 0` lifted into the
+    // arm, dividing per group and faulting `.divide` even though no row
+    // survived. `columns(of: validate:)` agrees — the outer projection sits
+    // above the cap, so a dropped page leaves it unreachable and validate types
+    // its two columns rather than faulting a division the run never reaches.
+    let sql = "SELECT 1 / 0, ROW_NUMBER() OVER () FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept)) FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+  }
+
+  @Test func `a COALESCE over a window never reaches its guarded arm`()
+      throws {
+    // A window-free `COALESCE(ROW_NUMBER() OVER (), 1 / 0)` wraps the window in
+    // the outer projection, evaluated lazily per output row over the union. The
+    // row number is never NULL, so the guarded `1 / 0` is never reached and the
+    // division never happens — the union's rows number 1, 2, 3, matching the
+    // ordinary `GROUP BY dept` form. A window-free wrapper force-lifted into an
+    // arm would evaluate the whole `COALESCE` eagerly per group and fault
+    // `.divide`; kept outer and lazy, the dead arm stays unevaluated.
+    let sets = "SELECT COALESCE(ROW_NUMBER() OVER (), 1 / 0) " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[1], [2], [3]])
+    let plain = "SELECT COALESCE(ROW_NUMBER() OVER (), 1 / 0) " +
+                "FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[1], [2], [3]])
+  }
+
+  @Test func `an ordinal-linked window key shares the reported leaf`() throws {
+    // The window `ORDER BY 1` names column 1 — the `tick()` value — so
+    // the ordinal links the key to that output: both must read one evaluation.
+    // The lifter shares its `*gwN` leaf across the projection and the ordinal-
+    // linked key, so `tick()` is evaluated once per group (1, 2, 3), the window
+    // orders on those, and the row numbered k reports `tick()` k — the ranking
+    // matching the reported column, three calls. Sharing only by determinism
+    // would give the ordinal its own leaf, evaluating `tick()` twice per group,
+    // ordering on 2, 4, 6 yet reporting 1, 3, 5 over six calls — the reported
+    // value diverging from the ranking, as the directly written key above does.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT tick(), ROW_NUMBER() OVER (ORDER BY 1) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept))",
+        yields: [[1, 1], [2, 2], [3, 3]], routines: routines)
+    #expect(counter.count == 3)
+  }
+
+  @Test func `an unnamed windowed output stays an ordinal-only header`()
+      throws {
+    // An originally-unnamed windowed grouping-sets output feeding an outer
+    // set-op carrier keeps its synthesized `column N` display header and stays
+    // ordinal-only: a delimited `ORDER BY "column N"` binds no output — the
+    // synthesized header is not a spellable name — so it faults `.column`, as
+    // it does over any derived union, not the outer carrier capturing it.
+    let arm = "SELECT SUM(sal), ROW_NUMBER() OVER () FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept))"
+    // The two outputs display as the positional headers, marked synthesized.
+    let headers = try fixture().columns(of: parse(query: arm), validate: true)
+        .map(\.name)
+    #expect(headers == ["column 1", "column 2"])
+    // Feeding an outer UNION, a delimited-name ORDER BY on either synthesized
+    // header faults; the ordinal still orders that output.
+    let union = "\(arm) UNION SELECT dept, dept FROM Emp"
+    try fixture().expect("\(union) ORDER BY \"column 1\"",
+                         fails: .column("column 1"))
+    try fixture().expect("\(union) ORDER BY \"column 2\"",
+                         fails: .column("column 2"))
+    #expect(throws: SQLError.column("column 1")) {
+      _ = try fixture().columns(of: parse(query:
+          "\(union) ORDER BY \"column 1\""), validate: true)
+    }
+  }
+
+  @Test func `an unused WINDOW faults over a single-set windowed query`()
+      throws {
+    // A single grouping set takes `expand`'s fast path, which reconstructs a
+    // plain grouped select rather than a union. It carries the WINDOW clause
+    // onto that select as the multi-set arms do, so the arm compile validates
+    // every definition against the grouped source — the undefined `nonesuch`
+    // faulting on both the run and validate paths, as the multi-set and
+    // ordinary grouped forms do, not silently accepted on a one-set query.
+    let sql = "SELECT dept, ROW_NUMBER() OVER () FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept)) " +
+              "WINDOW bad AS (ORDER BY nonesuch)"
+    try fixture().expect(sql, fails: .column("nonesuch"))
+    #expect(throws: SQLError.column("nonesuch")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a valid unused WINDOW is accepted over a single-set query`()
+      throws {
+    // The companion: a single-set windowed grouping-sets query with a well-
+    // formed unused named window validates and drops it, running exactly as it
+    // would with no WINDOW clause. The fast path carries the definition through
+    // validation, not around it — so a valid one is accepted, not rejected.
+    let sql = "SELECT dept, ROW_NUMBER() OVER (ORDER BY SUM(sal)) FROM Emp " +
+              "GROUP BY GROUPING SETS ((dept)) WINDOW w AS (ORDER BY dept)"
+    try fixture().expect(sql, yields: [[1, 1], [2, 3], [3, 2]])
+  }
+
+  @Test func `an unused WINDOW faults over a non-windowed single set`()
+      throws {
+    // The single-set fast path is shared by the non-windowed grouping-sets
+    // form, so an ordinary single-set grouping-sets query with a bad unused
+    // WINDOW definition validates it too — faulting `nonesuch` on both paths,
+    // as the multi-set and ordinary grouped forms do, rather than dropping the
+    // clause unvalidated because there is only one set.
+    let sql = "SELECT dept FROM Emp GROUP BY GROUPING SETS ((dept)) " +
+              "WINDOW bad AS (ORDER BY nonesuch)"
+    try fixture().expect(sql, fails: .column("nonesuch"))
+    #expect(throws: SQLError.column("nonesuch")) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a negative OFFSET over a windowed GROUPING SETS faults`() throws {
+    // The parser cannot spell a negative count, but a directly built `Limit`
+    // can. The windowed grouping-sets lowering used to take its early return
+    // before the row-limit guard, passing the negative offset to `limited`,
+    // where the negative slice precondition-traps; the guard now runs ahead of
+    // that return, so the query faults 2201X on both the run and validate
+    // paths, as an ordinary select does, rather than crashing the process.
+    let base = try parse(select:
+        "SELECT dept, ROW_NUMBER() OVER (ORDER BY SUM(sal)) FROM Emp " +
+        "GROUP BY GROUPING SETS ((dept), ())")
+    let select = Select(projection: base.projection, from: base.from,
+                        grouping: base.grouping,
+                        limit: Limit(count: 1, offset: -1))
+    let query = Query.select(select)
+    let catalog = try fixture()
+    let fault = SQLError.state("2201X", "OFFSET row count must be non-negative")
+    let ran: SQLError?
+    do {
+      _ = try catalog.run(query)
+      ran = nil
+    } catch let raised {
+      ran = raised
+    }
+    #expect(ran == fault)
+    let derived: SQLError?
+    do {
+      _ = try catalog.columns(of: query, validate: true)
+      derived = nil
+    } catch let raised {
+      derived = raised
+    }
+    #expect(derived == fault)
+  }
+
+  @Test func `a negative FETCH over a windowed GROUPING SETS faults`() throws {
+    // The same guard covers a negative FETCH count: a directly built `Limit`
+    // with a negative count reaches the windowed grouping-sets lowering and
+    // used to trap in `limited`'s prefix; it now faults 2201W ahead of the
+    // early return, on both the run and validate paths, as an ordinary select
+    // does.
+    let base = try parse(select:
+        "SELECT dept, ROW_NUMBER() OVER (ORDER BY SUM(sal)) FROM Emp " +
+        "GROUP BY GROUPING SETS ((dept), ())")
+    let select = Select(projection: base.projection, from: base.from,
+                        grouping: base.grouping, limit: Limit(count: -1))
+    let query = Query.select(select)
+    let catalog = try fixture()
+    let fault = SQLError.state("2201W", "FETCH row count must be non-negative")
+    let ran: SQLError?
+    do {
+      _ = try catalog.run(query)
+      ran = nil
+    } catch let raised {
+      ran = raised
+    }
+    #expect(ran == fault)
+    let derived: SQLError?
+    do {
+      _ = try catalog.columns(of: query, validate: true)
+      derived = nil
+    } catch let raised {
+      derived = raised
+    }
+    #expect(derived == fault)
+  }
+
+  @Test func `a capped projection CASE fault drops with the page`() throws {
+    // #137, the `CASE` shape: a projection-only `CASE` whose result would fault
+    // (`CASE WHEN 1 = 1 THEN 1 / 0 END`) is group-independent — its `WHEN`
+    // guard and `THEN` result name no grouped data — so grounded-outer keeps it
+    // in the outer projection above the `Project(Limit(Sort))` cap, not an arm
+    // below it. A zero `FETCH` drops every row before the projection runs, so
+    // the division never happens and the query returns the empty page, matching
+    // the ordinary `GROUP BY dept` companion. Before this the `CASE` was hard-
+    // coded grounded and lifted into the arm, dividing per group and faulting
+    // even though no row survived. `columns(of: validate:)` agrees over the
+    // union scope, typing its two columns rather than faulting a division no
+    // run reaches.
+    let sql = "SELECT CASE WHEN 1 = 1 THEN 1 / 0 END, ROW_NUMBER() OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept)) FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    let plain = "SELECT CASE WHEN 1 = 1 THEN 1 / 0 END, ROW_NUMBER() OVER () " +
+                "FROM Emp GROUP BY dept FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(plain)
+  }
+
+  @Test func `a projection-only CASE evaluates in the outer projection`()
+      throws {
+    // A stateful `CASE WHEN 1 = 1 THEN tick() END` in the projection is group-
+    // independent, so it stays in the outer projection and evaluates after the
+    // window — its `tick()` per output row — while the window `ORDER BY tick()`
+    // lifts to an arm column evaluated per group before it. Six calls over the
+    // three groups: the arm key 1, 2, 3 (the ranking input), then the
+    // projection 4, 5, 6, matching the ordinary `GROUP BY dept` companion.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT CASE WHEN 1 = 1 THEN tick() END, " +
+        "ROW_NUMBER() OVER (ORDER BY tick()) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept))",
+        yields: [[4, 1], [5, 2], [6, 3]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `the single-set CASE matches the ordinary grouped-window path`()
+      throws {
+    // The oracle for the `CASE` above: the ordinary `GROUP BY dept` windowed
+    // form observes exactly the same values — the arm key `tick()` 1, 2, 3, the
+    // projection `CASE`'s `tick()` 4, 5, 6, six calls — the reference the
+    // grouping-sets form is pinned to.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT CASE WHEN 1 = 1 THEN tick() END, " +
+        "ROW_NUMBER() OVER (ORDER BY tick()) FROM Emp GROUP BY dept",
+        yields: [[4, 1], [5, 2], [6, 3]], routines: routines)
+    #expect(counter.count == 6)
+  }
+
+  @Test func `a grounded CASE keeps its structure in the outer projection`()
+      throws {
+    // A grounded window-free `CASE` — `CASE WHEN dept = 1 THEN SUM(sal) ELSE 0
+    // END` — keeps its `CASE` structure in the outer projection and lifts only
+    // the grouped values its guard and branches reference: the `dept` guard
+    // column and the `SUM(sal)` branch each become a `*gwN` arm column, the
+    // `CASE` itself evaluated outer above the window. Over the single set dept
+    // 1 yields SUM 300, dept 2 and 3 the `ELSE` 0 (their guard false), each
+    // numbered, matching the ordinary `GROUP BY dept` form. Before this fix the
+    // whole `CASE` lifted into the arm; the values are the same here, but the
+    // capped finding below shows why keeping the structure outer matters.
+    let sets = "SELECT CASE WHEN dept = 1 THEN SUM(sal) ELSE 0 END, " +
+               "ROW_NUMBER() OVER () FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[300, 1], [0, 2], [0, 3]])
+    let plain = "SELECT CASE WHEN dept = 1 THEN SUM(sal) ELSE 0 END, " +
+                "ROW_NUMBER() OVER () FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[300, 1], [0, 2], [0, 3]])
+  }
+
+  @Test func `a grounded CASE above a zero FETCH drops with the page`() throws {
+    // The finding: a grounded `CASE` whose branch would fault — `CASE WHEN dept
+    // = 1 THEN 1 / 0 END` — keeps its structure in the outer projection above
+    // the `Project(Limit(Sort))` cap, only its `dept` guard column lifted to a
+    // `*gwN` arm. A zero `FETCH` drops every row before the outer `CASE` runs,
+    // so the division never happens and the query returns the empty page,
+    // matching the ordinary `GROUP BY dept` companion. Before this fix the
+    // whole grounded `CASE` lifted into the arm below the cap, dividing per
+    // group and faulting `.divide` though no row survived. `columns(of:
+    // validate:)` agrees over the union scope — the outer `CASE` sits above the
+    // cap, so a dropped page leaves it unreachable and validate types its two
+    // columns rather than faulting a division the run never reaches.
+    let sql =
+        "SELECT CASE WHEN dept = 1 THEN 1 / 0 END, ROW_NUMBER() OVER () " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept)) FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    let plain =
+        "SELECT CASE WHEN dept = 1 THEN 1 / 0 END, ROW_NUMBER() OVER () " +
+        "FROM Emp GROUP BY dept FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(plain)
+  }
+
+  @Test func `a grounded CASE's stateful branch evaluates in the outer`()
+      throws {
+    // A grounded `CASE` with a grouped guard and a stateful branch — `CASE WHEN
+    // dept = 1 THEN tick() ELSE 0 END` — lifts only the `dept` guard column to
+    // an arm while the `tick()` branch stays outer, evaluated after the window
+    // per output row. The window `ORDER BY tick()` lifts its own `tick()` to a
+    // separate arm column evaluated per group before the window. So the arm
+    // ticks 1, 2, 3 (the ranking input, ranks 1, 2, 3) and the outer `CASE`'s
+    // branch ticks once for the dept-1 row (4) — four calls, matching the
+    // ordinary `GROUP BY dept` companion. Before this fix the whole `CASE`
+    // lifted into the arm, so its branch `tick()` evaluated before the window,
+    // reporting 1 rather than the outer 4.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT CASE WHEN dept = 1 THEN tick() ELSE 0 END, " +
+        "ROW_NUMBER() OVER (ORDER BY tick()) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept))",
+        yields: [[4, 1], [0, 2], [0, 3]], routines: routines)
+    #expect(counter.count == 4)
+    let other = Counter()
+    let plain = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(other.next())
+        }
+    try fixture().expect(
+        "SELECT CASE WHEN dept = 1 THEN tick() ELSE 0 END, " +
+        "ROW_NUMBER() OVER (ORDER BY tick()) FROM Emp GROUP BY dept",
+        yields: [[4, 1], [0, 2], [0, 3]], routines: plain)
+    #expect(other.count == 4)
+  }
+
+  @Test func `a windowed CASE over GROUPING SETS is deferred`() throws {
+    // Preserving #136: a `CASE` nesting a window — `CASE WHEN dept = 1 THEN
+    // ROW_NUMBER() OVER () END` — is a per-row `Predicate`/window shape no
+    // `*gwN` column stands in for, so it still faults the feature diagnostic on
+    // both the run and validate paths, unchanged by the window-free `CASE`
+    // recursion this fix adds.
+    let sql = "SELECT CASE WHEN dept = 1 THEN ROW_NUMBER() OVER () END " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    let fault = SQLError.state(
+        "0A000", "a window in a CASE with GROUPING SETS is not yet supported")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a CASE nesting an uncorrelated subquery recurses`() throws {
+    // A window-free `CASE` whose branch nests an uncorrelated scalar subquery —
+    // `CASE WHEN T.Id = 1 THEN (SELECT SUM(U.v) FROM U) END` — recurses: the
+    // `T.Id` guard lifts to a `*gwN` arm column while the subquery stays outer,
+    // hosted by the union-scope `Resolution`, so the whole `CASE` sits in the
+    // outer projection above the cap rather than lifting whole to an arm. Over
+    // the single set `T.Id` 1 yields the subquery's 401, `T.Id` 2 and 3 the
+    // `ELSE` NULL (guard false), each numbered, matching the ordinary `GROUP BY
+    // T.Id` form.
+    let sets = "SELECT CASE WHEN T.Id = 1 THEN (SELECT SUM(U.v) FROM U) END, " +
+               "ROW_NUMBER() OVER () FROM T GROUP BY GROUPING SETS ((T.Id))"
+    try correlated().expect(sets, yields: [[401, 1], [nil, 2], [nil, 3]])
+    let plain =
+        "SELECT CASE WHEN T.Id = 1 THEN (SELECT SUM(U.v) FROM U) END, " +
+        "ROW_NUMBER() OVER () FROM T GROUP BY T.Id"
+    try correlated().expect(plain, yields: [[401, 1], [nil, 2], [nil, 3]])
+  }
+
+  @Test func `an uncorrelated scalar subquery hosts in the outer layer`()
+      throws {
+    // An uncorrelated scalar subquery in the projection is hosted in the outer
+    // window layer through the union-scope `Resolution`, not lifted to an arm,
+    // so it resolves against the union output and evaluates once per output
+    // row. `(SELECT SUM(U.v) FROM U)` sums every child, the same 401 for all
+    // groups, each numbered, matching the ordinary `GROUP BY T.Id` form.
+    let sets = "SELECT T.Id, (SELECT SUM(U.v) FROM U), ROW_NUMBER() OVER () " +
+               "FROM T GROUP BY GROUPING SETS ((T.Id))"
+    try correlated().expect(sets, yields: [[1, 401, 1], [2, 401, 2],
+                                           [3, 401, 3]])
+    // The validate twin resolves the hosted subquery over the union scope too,
+    // so `columns(of: validate:)` types its three columns rather than faulting
+    // a subquery it cannot host — run ≡ validate over the outer layer.
+    #expect(try correlated().columns(of: parse(query: sets), validate: true)
+                .count == 3)
+    let plain = "SELECT T.Id, (SELECT SUM(U.v) FROM U), ROW_NUMBER() OVER () " +
+                "FROM T GROUP BY T.Id"
+    try correlated().expect(plain, yields: [[1, 401, 1], [2, 401, 2],
+                                            [3, 401, 3]])
+  }
+
+  @Test func `an uncorrelated subquery hosts over multiple sets`() throws {
+    // The multi-set companion: with two grouping sets the arm union is a real
+    // `UNION ALL`, and the uncorrelated `(SELECT SUM(U.v) FROM U)` is hosted in
+    // the outer layer over that union — evaluated once per output row, the same
+    // 401 for every per-set row and the NULL-extended grand-total row alike.
+    // `SUM(T.Id)` groups to each `T.Id` per set and to 6 for the grand total,
+    // the window numbering across all four union rows.
+    let sets = "SELECT SUM(T.Id), (SELECT SUM(U.v) FROM U), " +
+               "ROW_NUMBER() OVER () FROM T GROUP BY GROUPING SETS ((T.Id), ())"
+    try correlated().expect(sets, yields: [[1, 401, 1], [2, 401, 2],
+                                           [3, 401, 3], [6, 401, 4]])
+  }
+
+  @Test func `a correlated subquery still resolves in the arm`() throws {
+    // Approach (B): a scalar subquery correlated to a group key —
+    // `(SELECT SUM(U.v) FROM U WHERE U.k = T.Id)` — names the enclosing `T.Id`,
+    // a group key, so the lifter keeps it arm-lifted (a `*gwN` column) rather
+    // than hosting it outer, resolving `T.Id` in the arm's grouped scope; a
+    // correlated outer host awaits a follow-up (the union scope would have to
+    // expose the group key for the subquery to correlate against). Over the
+    // single set `T.Id` 1 sums its children 201, `T.Id` 2 sums 200, `T.Id` 3
+    // has none (NULL), each numbered, matching the ordinary `GROUP BY T.Id`
+    // form.
+    let sets = "SELECT T.Id, (SELECT SUM(U.v) FROM U WHERE U.k = T.Id), " +
+               "ROW_NUMBER() OVER () FROM T GROUP BY GROUPING SETS ((T.Id))"
+    try correlated().expect(sets, yields: [[1, 201, 1], [2, 200, 2],
+                                           [3, nil, 3]])
+    let plain = "SELECT T.Id, (SELECT SUM(U.v) FROM U WHERE U.k = T.Id), " +
+                "ROW_NUMBER() OVER () FROM T GROUP BY T.Id"
+    try correlated().expect(plain, yields: [[1, 201, 1], [2, 200, 2],
+                                            [3, nil, 3]])
+  }
+
+  @Test func `a stateful derived source materialises per arm`() throws {
+    // The finding: a windowed grouping-sets over a stateful derived table must
+    // materialise that source per arm — as the non-windowed grouping-sets over
+    // the same source does — not once for both arms. The window layer rides
+    // above the arm union, so the query keeps a `.select` body and once took
+    // the ordinary executor, which materialises the derived `d` a single time
+    // and scans those rows in every arm. Routed through the carrier-aware
+    // executor, the `.window` descent carries the union to the setop leaf,
+    // where each arm augments its own `d` — so `tick()` runs afresh per arm.
+    //
+    // The `(x)` arm ticks 1..5, each its own group summing to itself; the `()`
+    // arm ticks a fresh 6..10 summing to 40. Ten calls, the grand total 40 —
+    // where a single materialisation reused 1..5 and summed the grand total to
+    // 15 over five calls. The `tick()` count matches the non-windowed
+    // companion below, proving the `.window` carrier descent (dead before) is
+    // now reached.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT tick() AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x), ())",
+        yields: [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [40, 6]],
+        routines: routines)
+    #expect(counter.count == 10)
+  }
+
+  @Test func `the non-windowed form is the per-arm reference`() throws {
+    // The reference the windowed form is pinned to: the equivalent non-windowed
+    // grouping-sets over the same stateful derived source. It expands to a
+    // `UNION ALL` whose arms run per arm, so `tick()` runs afresh in each — the
+    // `(x)` arm 1..5, the `()` arm a fresh 6..10 summing to 40, ten calls. The
+    // windowed form above reports the same aggregate column and the same ten
+    // calls; the second column is the constant `0` here, `ROW_NUMBER()` there.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT SUM(x), 0 FROM (SELECT tick() AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x), ())",
+        yields: [[1, 0], [2, 0], [3, 0], [4, 0], [5, 0], [40, 0]],
+        routines: routines)
+    #expect(counter.count == 10)
+  }
+
+  @Test func `a deterministic derived source is unchanged by the routing`()
+      throws {
+    // The no-regression guard: routing a windowed grouping-sets through the
+    // carrier-aware executor must not alter a deterministic source's rows.
+    // Materialising `sal` once or per arm yields the identical values, so the
+    // grouped sums and the row numbers are the same either way — the `(x)`
+    // groups 100, 200, 600 (the two 300s), 500 and the grand total 1400.
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x), ())",
+        yields: [[100, 1], [200, 2], [600, 3], [500, 4], [1400, 5]])
+  }
+
+  @Test func `a derived source under a capped sort executes per arm`() throws {
+    // A query `ORDER BY … FETCH n` over a windowed grouping-sets fuses into a
+    // `top` above the window: the generic optimiser a `.select`-bodied plan
+    // takes fuses a bounded limit over a sort, where the set-operation
+    // carrier's own optimise never does. The carrier-aware descent must carry
+    // the union through that `top` to the setop leaf — else the leaf scans a
+    // derived `d` the revealed context no longer binds and faults `.relation`,
+    // breaking run ≡ validate. Over a derived source ordered by the aggregate
+    // and paged to three rows, the head is 100, 200, 500 — the arms
+    // materialising `sal` per arm (the same deterministic values either way).
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER (ORDER BY SUM(x)) " +
+        "FROM (SELECT sal AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x), ()) ORDER BY 1 FETCH FIRST 3 ROWS ONLY",
+        yields: [[100, 1], [200, 2], [500, 3]])
+  }
+
+  @Test func `a single-set derived source materialises for the lone arm`()
+      throws {
+    // The finding: a single-set `GROUPING SETS ((x))` reduces to one grouped
+    // arm — `decompose` returns a plain `.select`, not a `.setop` — so its arm
+    // union is not carrier-routed. The per-arm carrier path assumes a setop and
+    // never materialises the lone arm's derived `d`, and the schema-only bind
+    // it pairs with drops `d`'s rows, so the query faulted an unknown relation.
+    // A single arm augments and runs through the ordinary per-query path
+    // instead: `d` materialises once (one arm, so per-arm and per-query
+    // coincide) and the grouped window reads it. The `(x)` groups are 100, 200,
+    // 600 (the two 300s), 500, numbered 1..4 — exactly the ordinary `GROUP BY
+    // x` companion below.
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x))",
+        yields: [[100, 1], [200, 2], [600, 3], [500, 4]])
+  }
+
+  @Test func `the ordinary derived companion is the single-set reference`()
+      throws {
+    // The reference the single-set form is pinned to: the ordinary `GROUP BY x`
+    // windowed query over the same derived source, which the mature grouped-
+    // window path has always handled. Its grouped sums and row numbers are the
+    // single-set spelling's, proving the single arm reaches this path.
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d GROUP BY x",
+        yields: [[100, 1], [200, 2], [600, 3], [500, 4]])
+  }
+
+  @Test func `a stateful single-set derived source matches the ordinary form`()
+      throws {
+    // A single set has one arm, so per-arm and per-query materialisation
+    // coincide: the ordinary per-query path materialises the stateful `d` once
+    // and its lone arm reads those rows, the same as an arm materialising its
+    // own copy. `tick()` runs once per source row (five Emp rows, five calls),
+    // each `x` distinct so each groups alone summing to itself — 1..5, numbered
+    // 1..5 — the identical `tick()` count and rows the ordinary `GROUP BY x`
+    // companion yields.
+    let sets = Counter()
+    let plain = Counter()
+    func routines(_ counter: Counter) throws -> Routines {
+      try Routines.standard
+          .registering("tick", returns: .integer, deterministic: false) { _ in
+            .integer(counter.next())
+          }
+    }
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT tick() AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x))",
+        yields: [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5]],
+        routines: try routines(sets))
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT tick() AS x FROM Emp) d GROUP BY x",
+        yields: [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5]],
+        routines: try routines(plain))
+    #expect(sets.count == 5)
+    #expect(plain.count == sets.count)
+  }
+
+  @Test func `a grand-total single set matches the implicit-group window`()
+      throws {
+    // The other single set: `GROUPING SETS (())`, the grand total. It too is
+    // one arm — `expand` returns the lone grouped `.select` — so it runs the
+    // ordinary per-query path over the derived source. The whole result is one
+    // group summing 1400, `ROW_NUMBER()` numbering the single row 1 — matching
+    // the `GROUP BY ()` implicit-group window companion below.
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS (())",
+        yields: [[1400, 1]])
+    try fixture().expect(
+        "SELECT SUM(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d GROUP BY ()",
+        yields: [[1400, 1]])
+  }
+
+  @Test func `a single-set GROUPING is zero over the derived source`() throws {
+    // In a single set every argument is a grouping key of the lone set, so
+    // `GROUPING(x)` is 0 for every group — the standard result when no column
+    // is rolled up, identical to the ordinary `GROUP BY x` companion. A window
+    // makes this the windowed single-arm shape, so it confirms the single arm
+    // reaching the ordinary path preserves `GROUPING`.
+    try fixture().expect(
+        "SELECT SUM(x), GROUPING(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d " +
+        "GROUP BY GROUPING SETS ((x))",
+        yields: [[100, 0, 1], [200, 0, 2], [600, 0, 3], [500, 0, 4]])
+    try fixture().expect(
+        "SELECT SUM(x), GROUPING(x), ROW_NUMBER() OVER () " +
+        "FROM (SELECT sal AS x FROM Emp) d GROUP BY x",
+        yields: [[100, 0, 1], [200, 0, 2], [600, 0, 3], [500, 0, 4]])
+  }
+
+  @Test func `a grand-total set with an offset drops the unreachable wrapper`()
+      throws {
+    // The finding: the grand-total single set `GROUPING SETS (())` produces one
+    // whole-result row, so a positive `OFFSET` skips it and the outer
+    // projection never runs. `NULLIF(ROW_NUMBER() OVER (), 'x')` (integer
+    // versus text) would fault 42804 if reachable, but the cap discards the
+    // sole row first — the run returns the empty page and `columns(of:
+    // validate:)` accepts its one column. Deriving the outer layer's single-row
+    // flag from the decomposition (one arm, no keys) makes both paths treat the
+    // grand total as single-row, as the ordinary whole-result aggregate oracle
+    // below does. Before this the flag was hard-coded multi-row, so the offset
+    // left the projection reachable and the comparability preflight faulted
+    // 42804 though the run dropped the row before `NULLIF` could run.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+              "FROM Emp GROUP BY GROUPING SETS (()) OFFSET 1 ROW"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
+    // The ordinary single-row oracle: a whole-result aggregate makes the row
+    // count one, so the same offset skips the sole row and elides its
+    // projection alike, on both paths.
+    let plain = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x'), SUM(sal) " +
+                "FROM Emp OFFSET 1 ROW"
+    try fixture().empty(plain)
+    #expect(try fixture().columns(of: parse(query: plain), validate: true)
+                .count == 2)
+  }
+
+  @Test func `a grand-total set without an offset still faults its wrapper`()
+      throws {
+    // The regression guard against over-sparing: the one grand-total row is
+    // produced with no cap, so the outer projection is reachable and the
+    // incomparable `NULLIF(ROW_NUMBER() OVER (), 'x')` faults 42804 on both
+    // paths — unchanged by the derivation, which spares the projection only
+    // when a row-dropping cap makes it unreachable.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+              "FROM Emp GROUP BY GROUPING SETS (())"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a non-empty single set stays multi-row under an offset`()
+      throws {
+    // The regression guard against under-sparing: `GROUPING SETS ((dept))`
+    // groups by `dept` — three groups, so `OFFSET 1` leaves rows and the outer
+    // projection is reachable. The single-row flag is false for a non-empty
+    // single set (one arm, but keys present), so the incomparable wrapper still
+    // faults 42804 on both paths, unchanged.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept)) OFFSET 1 ROW"
+    let fault = SQLError.state(
+        "42804", "cannot compare integer with character varying")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `a valid grand-total window with an offset returns the page`()
+      throws {
+    // The derivation must not over-reject a well-typed grand total: `SUM(sal)`
+    // over the one whole-result group is 1400, `ROW_NUMBER() OVER ()` numbers
+    // it 1, and `OFFSET 1` skips that sole row — the empty page, on both paths,
+    // matching the ordinary whole-result aggregate window oracle below.
+    let sql = "SELECT SUM(sal), ROW_NUMBER() OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS (()) OFFSET 1 ROW"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    let plain = "SELECT SUM(sal), ROW_NUMBER() OVER () FROM Emp OFFSET 1 ROW"
+    try fixture().empty(plain)
+  }
+
+  @Test func `a windowed GROUPING SETS NULL arm infers the union's text`()
+      throws {
+    // The finding: a constant NULL in a windowed grouping-sets arm places no
+    // type constraint on the set-op's unified column, so the text arm decides
+    // it — column 1 infers text. The schema twin now derives the complete
+    // `ResolvedColumn` (type AND `unconstrained` mask) through the ordinary
+    // projection-output logic, so it no longer hand-stamps the NULL a
+    // constrained integer the merge rejects against the text arm (42804). The
+    // text arm is a `VALUES` row — this dialect projects a computed row through
+    // `VALUES`, not a FROM-less `SELECT`.
+    let sql = "SELECT NULL, ROW_NUMBER() OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept)) " +
+              "UNION ALL VALUES ('x', 1)"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .map(\.type) == [.text, .integer])
+    try fixture().expect(sql,
+                         yields: [[nil, 1], [nil, 2], [nil, 3], ["x", 1]])
+    // The oracle: the equivalent ordinary grouped-window arm of the same shape
+    // infers the same types and rows — the windowed grouping-sets arm must
+    // resolve exactly as its `GROUP BY dept` companion does.
+    let plain = "SELECT NULL, ROW_NUMBER() OVER () " +
+                "FROM Emp GROUP BY dept UNION ALL VALUES ('x', 1)"
+    #expect(try fixture().columns(of: parse(query: plain), validate: true)
+                .map(\.type) == [.text, .integer])
+    try fixture().expect(plain,
+                         yields: [[nil, 1], [nil, 2], [nil, 3], ["x", 1]])
+  }
+
+  @Test func `a windowed GROUPING SETS arm second still infers text`()
+      throws {
+    // The windowed arm as the second operand: the leading text arm still
+    // unifies with the trailing NULL, so column 1 infers text regardless of
+    // arm order — the trailing windowed arm's NULL stays unconstrained through
+    // the merge, not a hand-stamped integer that would fault 42804.
+    let sql = "VALUES ('x', 1) UNION ALL " +
+              "SELECT NULL, ROW_NUMBER() OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .map(\.type) == [.text, .integer])
+    try fixture().expect(sql,
+                         yields: [["x", 1], [nil, 1], [nil, 2], [nil, 3]])
+  }
+
+  @Test func `a constrained windowed GROUPING SETS rejects a text union`()
+      throws {
+    // The regression guard against over-relaxing: `ROW_NUMBER() OVER ()` is a
+    // genuine constrained integer, not a constant NULL, so column 1 keeps its
+    // integer constraint and the text arm is irreconcilable — the merge faults
+    // 42804 on both paths, unchanged by the mask-preserving derivation.
+    let sql = "SELECT ROW_NUMBER() OVER (), 1 " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept)) " +
+              "UNION ALL VALUES ('x', 1)"
+    let fault = SQLError.operand("UNION arms have irreconcilable types")
+    try fixture().expect(sql, fails: fault)
+    #expect(throws: fault) {
+      _ = try fixture().columns(of: parse(query: sql), validate: true)
+    }
+  }
+
+  @Test func `an unused LEAD default never evaluates over GROUPING SETS`()
+      throws {
+    // The finding: a `LEAD` whose offset always lands on an existing row —
+    // offset 0 reads the current row — never needs its default, so the default
+    // must not evaluate. `Window.position` evaluates a `LEAD`/`LAG` default
+    // only for an out-of-range target, so force-lifting the `1 / 0` default
+    // into a `*gwN` arm column, evaluated eagerly per group, wrongly raised
+    // division-by-zero. Kept in the outer window function — only its grouped
+    // values lifted — the default rides the executor's conditional evaluation,
+    // so offset 0 never divides and each group's `dept` is returned, matching
+    // the ordinary `GROUP BY dept` companion. Before the fix the grouping-sets
+    // form faulted `.divide` while the ordinary form did not. (The finding's
+    // bare `OVER ()` faults `0A000` first — `LEAD` requires an `ORDER BY` — so
+    // the window carries the order the offset reads along.)
+    let sets = "SELECT LEAD(dept, 0, 1 / 0) OVER (ORDER BY dept) " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[1], [2], [3]])
+    let plain = "SELECT LEAD(dept, 0, 1 / 0) OVER (ORDER BY dept) " +
+                "FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[1], [2], [3]])
+  }
+
+  @Test func `an unused LEAD default subquery never evaluates`() throws {
+    // The subquery half of the finding: a `LEAD` default nesting a scalar
+    // subquery — `LEAD(dept, 0, (SELECT SUM(sal) / 0 FROM Emp))` — is
+    // hosted in the outer window function, not force-lifted to an arm, so it
+    // rides the executor's conditional evaluation exactly as a scalar default
+    // does. Offset 0 always lands on the current row, so the default never
+    // evaluates and the subquery never divides — each group's `dept` is
+    // returned, matching the ordinary `GROUP BY dept` companion. Were the
+    // subquery arm-lifted (evaluated eagerly per group) the division would
+    // fault, as it would for a `1 / 0` default.
+    let sets =
+        "SELECT LEAD(dept, 0, (SELECT SUM(sal) / 0 FROM Emp)) " +
+        "OVER (ORDER BY dept) FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[1], [2], [3]])
+    let plain =
+        "SELECT LEAD(dept, 0, (SELECT SUM(sal) / 0 FROM Emp)) " +
+        "OVER (ORDER BY dept) FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[1], [2], [3]])
+  }
+
+  @Test func `an uncorrelated subquery under a zero FETCH is not evaluated`()
+      throws {
+    // #138: an uncorrelated scalar subquery in the projection is hosted in the
+    // outer layer above the `Project(Limit(Sort))` cap — not in an arm below it
+    // — so a zero `FETCH` that drops every row leaves it unreached and the
+    // subquery never evaluates. `(SELECT SUM(sal) / 0 FROM Emp)` never divides,
+    // the query returns the empty page, matching the ordinary `GROUP BY dept`
+    // companion. `columns(of: validate:)` agrees — the outer projection sits
+    // above the cap, so a dropped page leaves it unreachable and validate types
+    // its two columns rather than faulting a division no run reaches.
+    let sql =
+        "SELECT (SELECT SUM(sal) / 0 FROM Emp), ROW_NUMBER() OVER () " +
+        "FROM Emp " +
+        "GROUP BY GROUPING SETS ((dept)) FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    let plain =
+        "SELECT (SELECT SUM(sal) / 0 FROM Emp), ROW_NUMBER() OVER () " +
+        "FROM Emp " +
+        "GROUP BY dept FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(plain)
+  }
+
+  @Test func `a needed LEAD default still returns over GROUPING SETS`()
+      throws {
+    // The default still works when the offset genuinely runs off the partition:
+    // offset 100 lands past every row, so `Window.position` evaluates the
+    // default for each. Keeping the default in the outer window layer preserves
+    // that path — every group takes the default `99` — matching the ordinary
+    // `GROUP BY dept` companion, so the outer default is used exactly when the
+    // executor needs it. A non-faulting default also validates cleanly over
+    // the union scope, so run and validate agree, as the ordinary form does.
+    let sets = "SELECT LEAD(dept, 100, 99) OVER (ORDER BY dept) " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[99], [99], [99]])
+    #expect(try fixture().columns(of: parse(query: sets), validate: true)
+                .count == 1)
+    let plain = "SELECT LEAD(dept, 100, 99) OVER (ORDER BY dept) " +
+                "FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[99], [99], [99]])
+    #expect(try fixture().columns(of: parse(query: plain), validate: true)
+                .count == 1)
+  }
+
+  @Test func `a stateful LEAD default evaluates once per out-of-range target`()
+      throws {
+    // A stateful default `tick()` must evaluate once per out-of-range target,
+    // not once per group. The window orders the three groups by `dept` (1, 2,
+    // 3); `LEAD(dept, 1, …)` reads the next group for the first two (2, 3) and
+    // runs off the end for the last, evaluating the default once — `tick()`
+    // yields 1 — so the rows are 2, 3, 1 over one call. Force-lifting the
+    // default into the arm evaluated it per group (three calls) and reported
+    // the arm's per-group tick (…, 3) rather than the single outer evaluation,
+    // diverging from the ordinary `GROUP BY dept` companion, which evaluates
+    // the default once (1). Kept outer, the two forms agree in rows and count.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    try fixture().expect(
+        "SELECT LEAD(dept, 1, tick()) OVER (ORDER BY dept) " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept))",
+        yields: [[2], [3], [1]], routines: routines)
+    #expect(counter.count == 1)
+    let other = Counter()
+    let plain = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(other.next())
+        }
+    try fixture().expect(
+        "SELECT LEAD(dept, 1, tick()) OVER (ORDER BY dept) " +
+        "FROM Emp GROUP BY dept",
+        yields: [[2], [3], [1]], routines: plain)
+    #expect(other.count == 1)
+  }
+
+  @Test func `a grouped-dependent LEAD default lifts only its grouped value`()
+      throws {
+    // A default depending on a grouped value — `SUM(sal)` — lifts that value
+    // to a `*gwN` arm column while the default expression itself stays in the
+    // outer window function. Offset 100 runs off the partition, so each group
+    // takes its own `SUM(sal)` default — 300, 600, 500 — the grouped value
+    // computed in the arm and read by the conditionally evaluated outer
+    // default, matching the ordinary `GROUP BY dept` companion. The default
+    // validates cleanly over the union scope (its grouped leaf resolved in the
+    // arm), so run and validate agree, as the ordinary form does.
+    let sets = "SELECT LEAD(dept, 100, SUM(sal)) OVER (ORDER BY dept) " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[300], [600], [500]])
+    #expect(try fixture().columns(of: parse(query: sets), validate: true)
+                .count == 1)
+    let plain = "SELECT LEAD(dept, 100, SUM(sal)) OVER (ORDER BY dept) " +
+                "FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[300], [600], [500]])
+    #expect(try fixture().columns(of: parse(query: plain), validate: true)
+                .count == 1)
+  }
+
+  @Test func `an unused LEAD default never evaluates over multiple sets`()
+      throws {
+    // The multi-set companion of the finding: with two grouping sets the arm
+    // union is a genuine `UNION ALL`, and the outer window still holds the
+    // conditionally evaluated `1 / 0` default. Offset 0 reads each row's own
+    // `dept` — the grand-total row's rolled-up NULL included — so at run the
+    // default never evaluates and no division occurs. Before the fix the arm's
+    // eager `1 / 0` faulted `.divide`. (Validate constant-folds the `1 / 0`
+    // default and faults it identically to the ordinary grouped-window form —
+    // a pre-existing property of the validator shared by both paths — so this
+    // asserts only the run; the non-faulting defaults above cover run ≡
+    // validate over the union scope.)
+    let sql = "SELECT dept, LEAD(dept, 0, 1 / 0) OVER (ORDER BY dept) " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    try fixture().expect(sql, yields: [[1, 1], [2, 2], [3, 3], [nil, nil]])
+  }
+
+  // The finding's body: a window over two grouping sets, reading a derived
+  // source `d`. The carrier-aware routing that per-arm re-materialises `d`
+  // lived only in the top-level `run`; a view body and a correlated subquery
+  // reached their own executor entry points, which recognised a union only by
+  // a `.setop` body and so scanned the schema-only `d` once — dropping the arm
+  // rows. Every entry point now consults the one `union(windowed:)` decision.
+  private var body: String {
+    "SELECT SUM(x), ROW_NUMBER() OVER () " +
+    "FROM (SELECT sal AS x FROM Emp) d GROUP BY GROUPING SETS ((x), ())"
+  }
+
+  // The finding's body over an `Emp` beside a view `v` whose body is exactly
+  // it, so a run of the view and a run of the body share one catalog.
+  private func viewed() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("Emp", ["dept": .integer, "sal": .integer]) {
+        Row(1, 100)
+        Row(1, 200)
+        Row(2, 300)
+        Row(2, 300)
+        Row(3, 500)
+      }
+      try View("v", body, as: ["s", "n"])
+    }
+  }
+
+  @Test func `a windowed GROUPING SETS view matches the top-level result`()
+      throws {
+    // Selecting from the view returns the same groups running the body at top
+    // level does — the per-arm materialised union, not an empty schema-only
+    // `d`. Both run the same plan, so the row order coincides.
+    try viewed().expect("SELECT s, n FROM v", equals: body)
+  }
+
+  @Test func `a windowed GROUPING SETS view yields the per-set groups`()
+      throws {
+    // The concrete groups: the `(x)` arm sums each distinct salary (100, 200,
+    // 500, and the two 300s to 600) and the `()` arm the grand total 1400. The
+    // window numbers them by that ascending sum, so ordering the view output by
+    // it reads out 100, 200, 500, 600, 1400 numbered 1 through 5.
+    let ordered = "SELECT SUM(x) AS s, "
+                + "ROW_NUMBER() OVER (ORDER BY SUM(x)) AS n "
+                + "FROM (SELECT sal AS x FROM Emp) d "
+                + "GROUP BY GROUPING SETS ((x), ())"
+    let catalog = try Catalog {
+      Relation("Emp", ["dept": .integer, "sal": .integer]) {
+        Row(1, 100)
+        Row(1, 200)
+        Row(2, 300)
+        Row(2, 300)
+        Row(3, 500)
+      }
+      try View("v", ordered, as: ["s", "n"])
+    }
+    try catalog.expect(
+        "SELECT s, n FROM v ORDER BY s",
+        yields: [[100, 1], [200, 2], [500, 3], [600, 4], [1400, 5]])
+  }
+
+  @Test func `a correlated LATERAL windowed GROUPING SETS over a source`()
+      throws {
+    // The body as a correlated LATERAL over a derived source `d`: `d` reads all
+    // of `U`, and a body-level `WHERE d.k = T.Id` correlates to the enclosing
+    // row, so the apply runs through `executed` per outer row. Per `T` row the
+    // arms re-materialise `d` and filter it to that row's children: Id 1 sums
+    // 100, 101 and the total 201; Id 2 sums 200 and the equal total; Id 3 has
+    // no children, so only its grand-total NULL. Before the fix `executed`
+    // scanned the schema-only `d` and dropped the arm rows.
+    try correlated().expect(
+        "SELECT T.Id, d.s, d.n FROM T JOIN LATERAL (" +
+        "SELECT SUM(x) AS s, ROW_NUMBER() OVER (ORDER BY SUM(x)) AS n " +
+        "FROM (SELECT k, v AS x FROM U) d WHERE d.k = T.Id " +
+        "GROUP BY GROUPING SETS ((x), ())) AS d ON 1 = 1 " +
+        "ORDER BY T.Id, d.n",
+        yields: [[1, 100, 1], [1, 101, 2], [1, 201, 3],
+                 [2, 200, 1], [2, 200, 2], [3, nil, 1]])
+  }
+
+  @Test func `a stateful source re-materialises per arm in a view`() throws {
+    // A counting `tick()` in the derived source over the single-row `T` fires
+    // once per arm materialisation: the two grouping sets drive two arms, so
+    // both a top-level run and a view run invoke it twice. Before the fix the
+    // view scanned the schema-only source, never materialising it — zero calls,
+    // the arm rows dropped.
+    let sql = "SELECT SUM(x), ROW_NUMBER() OVER () " +
+              "FROM (SELECT tick() AS x FROM T) d " +
+              "GROUP BY GROUPING SETS ((x), ())"
+    let top = Counter()
+    let plain = try Catalog { Relation("T", ["v": .integer]) { Row(0) } }
+    try plain.expect(sql, yields: [[1, 1], [2, 2]],
+                     routines: ticking(top))
+    #expect(top.count == 2)
+    let counter = Counter()
+    let catalog = try Catalog {
+      Relation("T", ["v": .integer]) { Row(0) }
+      try View("v", sql, as: ["s", "n"])
+    }
+    try catalog.expect("SELECT s, n FROM v", yields: [[1, 1], [2, 2]],
+                       routines: ticking(counter))
+    #expect(counter.count == 2)
+  }
+
+  // The windowed grouping-sets arm reading a derived source, its window ordered
+  // so the row number is a function of the sum.
+  private var arm: String {
+    "SELECT SUM(x) AS s, ROW_NUMBER() OVER (ORDER BY SUM(x)) AS r " +
+    "FROM (SELECT sal AS x FROM Emp) d GROUP BY GROUPING SETS ((x), ())"
+  }
+
+  @Test func `a windowed GROUPING SETS UNION arm keeps its groups`() throws {
+    // The windowed grouping-sets body as an explicit `UNION ALL` arm carried by
+    // an outer `ORDER BY`, so the arm descends through `arms` — the recursive
+    // twin of `executed`. Its per-set sums (100, 200, 500, 600 and the grand
+    // total 1400) must survive beside the plain second arm's rows, not collapse
+    // to the lone schema-only grand total the unfixed `arms` leaf produced.
+    try fixture().expect(
+        "(\(arm)) UNION ALL (SELECT dept, dept FROM Emp) ORDER BY s, r",
+        yields: [[1, 1], [1, 1], [2, 2], [2, 2], [3, 3],
+                 [100, 1], [200, 2], [500, 3], [600, 4], [1400, 5]])
+  }
+
+  @Test func `a view union with a windowed GROUPING SETS arm keeps groups`()
+      throws {
+    // The same union as a view body, so the arm descends through the view-body
+    // `setop` twin. Selecting from the view returns the per-set groups beside
+    // the plain arm, matching the top-level union.
+    let catalog = try Catalog {
+      Relation("Emp", ["dept": .integer, "sal": .integer]) {
+        Row(1, 100)
+        Row(1, 200)
+        Row(2, 300)
+        Row(2, 300)
+        Row(3, 500)
+      }
+      try View("v", "(\(arm)) UNION ALL (SELECT dept, dept FROM Emp)",
+               as: ["s", "r"])
+    }
+    try catalog.expect(
+        "SELECT s, r FROM v ORDER BY s, r",
+        yields: [[1, 1], [1, 1], [2, 2], [2, 2], [3, 3],
+                 [100, 1], [200, 2], [500, 3], [600, 4], [1400, 5]])
+  }
+
+  @Test func `a CASE IN guard over a windowed grouping set maps its key`()
+      throws {
+    // The window (`ROW_NUMBER() OVER (ORDER BY SUM(sal))`) routes the select
+    // through the arm-lift `substitute`, and the `CASE WHEN dept IN (VALUES
+    // (1))` guard tests the group key `dept` — which the lift must substitute
+    // to its `*gwN` arm slot, the same rewrite the bare `dept` projection
+    // takes — while the uncorrelated `VALUES (1)` subquery stays hosted whole.
+    // Before the fix the subquery-bearing guard rebuilt unchanged, leaving a
+    // bare `dept` the union scope could not bind (`unknown column dept`). The
+    // single grouping set is the ordinary windowed `GROUP BY dept` twin, so
+    // both forms guard dept 1 to 1 and the rest to 0, numbering by the sum
+    // (300, 500, 600 → dept 1, 3, 2).
+    let over = "CASE WHEN dept IN (VALUES (1)) THEN 1 ELSE 0 END, "
+             + "ROW_NUMBER() OVER (ORDER BY SUM(sal))"
+    let sets = "SELECT dept, \(over) "
+             + "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    let twin = "SELECT dept, \(over) FROM Emp GROUP BY dept"
+    try fixture().expect(sets, yields: [[1, 1, 1], [2, 0, 3], [3, 0, 2]])
+    try fixture().expect(twin, yields: [[1, 1, 1], [2, 0, 3], [3, 0, 2]])
+    #expect(try fixture().columns(of: parse(query: sets), validate: true)
+                .count == 3)
+  }
+
+  /// A non-deterministic routine set whose `tick()` returns `counter`'s next
+  /// value, so a run counts how many times the source it sits in materialised.
+  private func ticking(_ counter: Counter) throws -> Routines {
+    try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+  }
+
+  @Test func `a CASE grouping key matches a qualifier-variant guard`() throws {
+    // Finding 1: the grouping key is `CASE WHEN T.A = 1 …`, the projection the
+    // same `CASE` with the unqualified guard `A = 1`. Grouped lowering equates
+    // the two — `T.A` and `A` resolve to one ordinal, so both `CASE`s lower to
+    // one `Term` — so the whole-key member match must too. `Expression
+    // .canonical` once copied the guard `Predicate` verbatim, so the key's
+    // `T.A = 1` and the projection's `A = 1` canonicalised apart, the whole-key
+    // match missed, and the walk descended into the guard, lifting a bare `A`
+    // the `(T.A = 1)` arm rejected `.grouping`. Canonicalising the guard by
+    // `Predicate.canonical` collapses the two spellings, so the whole `CASE`
+    // lifts to its `*gw0` arm column — the exact key the arm groups on. The
+    // guard groups are 1 (the dept-1 rows) and 0 (dept-2), the total NULLs the
+    // key; run ≡ validate over the union, matching the ordinary form.
+    let sql = "SELECT CASE WHEN A = 1 THEN 1 ELSE 0 END, " +
+              "ROW_NUMBER() OVER () FROM N AS T GROUP BY " +
+              "GROUPING SETS ((CASE WHEN T.A = 1 THEN 1 ELSE 0 END), ())"
+    try nums().expect(sql, yields: [[1, 1], [0, 2], [nil, 3]])
+    #expect(try nums().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    try nums().expect(
+        "SELECT CASE WHEN A = 1 THEN 1 ELSE 0 END FROM N AS T GROUP BY " +
+        "GROUPING SETS ((CASE WHEN T.A = 1 THEN 1 ELSE 0 END), ())",
+        yields: [[1], [0], [nil]])
+  }
+
+  @Test func `a CASE grouping key matches a case-variant guard`() throws {
+    // The same over a case-folded guard: the projection's `CASE WHEN a = 1 …`
+    // must match the key's `CASE WHEN A = 1 …`. `Predicate.canonical` folds
+    // each guard column exactly as `Expression.canonical` does its results, so
+    // the whole `CASE` lifts whole rather than descending to a bare `a` the arm
+    // rejects. Same groups as the qualifier-variant form; run ≡ validate.
+    let sql = "SELECT CASE WHEN a = 1 THEN 1 ELSE 0 END, " +
+              "ROW_NUMBER() OVER () FROM N GROUP BY " +
+              "GROUPING SETS ((CASE WHEN A = 1 THEN 1 ELSE 0 END), ())"
+    try nums().expect(sql, yields: [[1, 1], [0, 2], [nil, 3]])
+    #expect(try nums().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    try nums().expect(
+        "SELECT CASE WHEN a = 1 THEN 1 ELSE 0 END FROM N GROUP BY " +
+        "GROUPING SETS ((CASE WHEN A = 1 THEN 1 ELSE 0 END), ())",
+        yields: [[1], [0], [nil]])
+  }
+
+  // A single-column-keyed relation grouped on the computed key `A + 1`: A = 1,
+  // 1, 2, so `A + 1` = 2, 2, 3 — two groups the arithmetic key defines, exactly
+  // as a plain `GROUP BY A + 1` would. `V` gives the arms an aggregate to sum.
+  private func nums() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("N", ["A": .integer, "V": .integer]) {
+        Row(1, 100)
+        Row(1, 50)
+        Row(2, 30)
+      }
+    }
+  }
+
+  @Test func `a computed grouping-set key lifts whole under a window`() throws {
+    // The grouping key is the arithmetic expression `A + 1`, not a bare column,
+    // so the lifter must lift the whole `A + 1` to one `*gw0` arm column — the
+    // arm then projects `A + 1`, its actual GROUP BY key, which the grouped arm
+    // accepts. Recursing the operands would lift the bare `A`, which the arm
+    // rejects with `.grouping("A")` — only `A + 1` is a key. The `(A + 1)` arm
+    // groups 2 (summing 150) and 3 (summing 30); the `()` grand total sums 180
+    // with the key NULLed; `ROW_NUMBER() OVER ()` numbers the union in row
+    // order. It matches the ordinary non-windowed twin below.
+    let sql = "SELECT A + 1, SUM(V), ROW_NUMBER() OVER () " +
+              "FROM N GROUP BY GROUPING SETS ((A + 1), ())"
+    try nums().expect(sql, yields: [[2, 150, 1], [3, 30, 2], [nil, 180, 3]])
+    #expect(try nums().columns(of: parse(query: sql), validate: true)
+                .count == 3)
+    // The ordinary `GROUP BY GROUPING SETS ((A + 1), ())` twin the windowed
+    // form must equal on its shared columns — the equivalent query the plain
+    // grouped path already supports.
+    try nums().expect(
+        "SELECT A + 1, SUM(V) FROM N GROUP BY GROUPING SETS ((A + 1), ())",
+        yields: [[2, 150], [3, 30], [nil, 180]])
+  }
+
+  @Test func `a relation-qualified computed key matches the projection`()
+      throws {
+    // The grouping key is qualified by the relation name, `N.A + 1`, the
+    // projection the unqualified `A + 1`. Grouped lowering equates them — `N.A`
+    // and `A` resolve to one ordinal — so the whole-key member match must too,
+    // keyed by canonical (qualifier-stripped) identity rather than raw
+    // structure. Matched, the whole `A + 1` lifts to its `*gw0` arm column and
+    // the arm projects the `N.A + 1` key it groups on. Raw `Expression`
+    // equality treated `A + 1` and `N.A + 1` apart and recursed to the bare `A`
+    // the arm rejects with `.grouping("A")`. The `(N.A + 1)` arm groups 2
+    // (summing 150) and 3 (summing 30); the `()` grand total sums 180 with the
+    // key NULLed; `ROW_NUMBER() OVER ()` numbers the union.
+    let sql = "SELECT A + 1, SUM(V), ROW_NUMBER() OVER () " +
+              "FROM N GROUP BY GROUPING SETS ((N.A + 1), ())"
+    try nums().expect(sql, yields: [[2, 150, 1], [3, 30, 2], [nil, 180, 3]])
+    #expect(try nums().columns(of: parse(query: sql), validate: true)
+                .count == 3)
+    // Equal on its columns to the unqualified-member twin — both canonicalise
+    // to one member the whole key lifts against.
+    try nums().expect(
+        "SELECT A + 1, SUM(V), ROW_NUMBER() OVER () " +
+        "FROM N GROUP BY GROUPING SETS ((A + 1), ())",
+        yields: [[2, 150, 1], [3, 30, 2], [nil, 180, 3]])
   }
 }


### PR DESCRIPTION
A window function over a GROUPING SETS / ROLLUP / CUBE query reads the whole union of the per-set grouped rows and the NULL-extended super- aggregate rows as one result. Rather than rewrite the query into a derived table, lower it directly: lift only the maximal grounded atoms a window operand needs into the union arms, and leave every window-free expression in the outer projection where it stays lazy, so a guarded or capped-away division never evaluates.

An ordinal window ORDER BY shares the projected column's leaf, so a non- deterministic key reads one evaluation per group and the ranking matches the reported value. The window and its cap sit above the union; a single set collapses onto the ordinary grouped path; and limit validation, the carrier-aware execution paths, and uncorrelated subquery hosting all run over the union scope.