### PR TITLE
SQLEngine: collision-proof and complete lifted-reference resolution

### DIFF
--- a/SwiftSQL/Sources/SQLEngine/AST.swift
+++ b/SwiftSQL/Sources/SQLEngine/AST.swift
@@ -695,8 +695,10 @@ public struct Select: Hashable, Sendable {
 /// windowed grouping-sets outer layer share, so the sort-output model cannot
 /// drift. An ordinal names the `position`-th item (1-based); a bare
 /// unqualified name binds a matching output `named` before an input column (the
-/// ISO precedence); any other key keeps its own expression. An out-of-range
-/// ordinal is `compile`'s fault to raise, so it is skipped here.
+/// ISO precedence), unless it is synthetic — a `*gwN` lift key binds
+/// structurally and keeps its own expression, as `Windowed.order` does; any
+/// other key keeps its own expression. An out-of-range ordinal is `compile`'s
+/// fault to raise, so it is skipped here.
 internal func orderKeys(_ items: Array<Projected>, _ order: Order?,
                         named: KeyPath<Projected, String?>)
     -> Array<Expression> {
@@ -709,7 +711,14 @@ internal func orderKeys(_ items: Array<Projected>, _ order: Order?,
         expressions.append(items[position - 1].expression)
       }
     case let .expression(expression):
+      // A synthetic `*gwN` reference — a windowed GROUPING SETS lift key —
+      // bypasses output-alias precedence and keeps its own expression, binding
+      // structurally as the run path's `Windowed.order` resolves it; a
+      // colliding user alias spelled `*gwN` must not capture it here (its
+      // `Column` identity is distinct), or validate would type a projection the
+      // run never evaluates and raise a spurious datatype fault.
       if case let .column(column) = expression, column.qualifier == nil,
+          !column.synthetic,
           let item = items.first(where: {
             $0[keyPath: named]?.lowercased() == column.name.lowercased()
           }) {
@@ -917,9 +926,32 @@ public struct Column: Hashable, Sendable, ExpressibleByStringLiteral {
   /// The column name.
   public let name: String
 
+  /// Whether this is an engine-synthesized internal reference no user
+  /// identifier can mint — the lifted `*gwN` union columns a windowed
+  /// `GROUPING SETS` rewrite addresses (`GroupingSets`). It rides the
+  /// reference's identity so a quoted user alias spelled exactly `"*gw0"`
+  /// stays distinct from the internal `*gw0`: the parser only ever mints a
+  /// non-synthetic reference, and this flag participates in equality, so the
+  /// two never compare equal. The query-level `ORDER BY` binds a synthetic
+  /// reference to its union column structurally (against the arm-synthesized
+  /// union scope) rather than by output-alias precedence, so a colliding user
+  /// alias cannot capture it (`Windowed.order`).
+  public let synthetic: Bool
+
   public init(qualifier: String? = nil, name: String) {
     self.qualifier = qualifier
     self.name = name
+    self.synthetic = false
+  }
+
+  /// Mints a reference, `synthetic` or not — internal to the engine so no user
+  /// identifier can forge a `synthetic` column. Only the windowed `GROUPING
+  /// SETS` lift (`GroupingSets`) mints a `synthetic: true` reference; every
+  /// public entry leaves it `false`.
+  internal init(qualifier: String? = nil, name: String, synthetic: Bool) {
+    self.qualifier = qualifier
+    self.name = name
+    self.synthetic = synthetic
   }
 
   /// Parses a reference from its dotted spelling: the text before the last dot
@@ -942,6 +974,7 @@ public struct Column: Hashable, Sendable, ExpressibleByStringLiteral {
       self.qualifier = nil
       self.name = spelling
     }
+    self.synthetic = false
   }
 
   public init(stringLiteral value: String) {

--- a/SwiftSQL/Sources/SQLEngine/Grouped.swift
+++ b/SwiftSQL/Sources/SQLEngine/Grouped.swift
@@ -575,8 +575,13 @@ internal struct Grouped {
                                 ascending: key.ascending,
                                 column: position - 1))
       case let .expression(expression):
+        // A synthetic `*gwN` reference — a windowed GROUPING SETS lift key a
+        // hosted grouped subquery's own ORDER BY carries — bypasses output-
+        // alias precedence and lowers structurally, as `Select.orderKeys` and
+        // `Windowed.order` resolve it; a user alias spelled `*gwN` must not
+        // capture it (its `Column` identity is distinct).
         if case let .column(reference) = expression,
-            reference.qualifier == nil {
+            reference.qualifier == nil, !reference.synthetic {
           let name = reference.name.lowercased()
           // A name two projections share has no single term to order on —
           // reject it as ambiguous rather than pick the last, matching the

--- a/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
+++ b/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
@@ -61,7 +61,7 @@ extension Query {
   /// decision keeps a future entry point from open-coding a `.setop`-only
   /// recognition that silently scans the schema-only source once.
   internal func union(windowed routines: Routines,
-                      schemas: Dictionary<String, Set<String>>)
+                      schemas: Dictionary<String, Exposure>)
       throws(SQLError) -> Query? {
     guard unioned, case let .select(select) = body,
         case let .sets(sets) = select.grouping else { return nil }
@@ -312,44 +312,80 @@ internal func expand(_ select: Select,
 
 // MARK: - Window over GROUPING SETS
 
+/// The columns a relation exposes to the windowed grouping-sets membership
+/// test, split by the two surfaces the `Lift` reads them through — the
+/// physical∪virtual surface a bare name binds against directly, and the real-
+/// only surface a `SELECT *` over the relation projects.
+internal struct Exposure {
+  /// Every column a bare name may bind against in a subquery whose FROM names
+  /// this relation directly — its real columns AND its virtual ones (`Id`, a
+  /// foreign key), the physical∪virtual surface the engine's `Schema
+  /// .ordinal(of:)` resolves an unqualified name against. A subquery `FROM U
+  /// WHERE Id = …` binds `Id` to U's virtual, so the direct-membership test
+  /// must see it, or a bare `Id` over a relation bearing a virtual `Id` would
+  /// mis-rewrite to the outer key rather than binding its own adapter column.
+  internal let bindable: Set<String>
+
+  /// The real columns alone — the surface a `SELECT *` exposes. The engine's
+  /// `*` expansion (`Scope.terms(.all)`) enumerates each source's real columns
+  /// in chain order and never a virtual column, so a derived `(SELECT * FROM U)
+  /// e` exposes U's real columns, not its virtual `Id`. Deriving a `SELECT *`
+  /// output from `bindable` would expose a virtual the engine omits, mis-
+  /// binding a bare `Id` group-key reference to the derived table rather than
+  /// the outer key (the unsound direction — a false local).
+  internal let real: Set<String>
+
+  /// The virtual columns alone — the adapter surface a `RelationInstance` vends
+  /// (its universal `Id`) that a `Schema.renamed` keeps addressable beside an
+  /// explicit column list. Held explicitly, not derived as `bindable − real`,
+  /// because a name that is both real and virtual (a store relation's real
+  /// output `Id` and its virtual `Id`) is one entry in each set, so the
+  /// difference would drop it and `expose` would omit the virtual `Id` an
+  /// `AS t(x)` rename keeps — mis-binding a bare `Id` to the outer group key.
+  internal let virtuals: Set<String>
+}
+
 extension Catalog where Self: ~Escapable {
-  /// The exposed column names — real and virtual, case-folded — of every
-  /// relation in scope, keyed by its name: the base tables and views this
-  /// catalog vends and the common table expressions and store relations the
-  /// `overlay` binds. It is the schema map the windowed grouping-sets `Lift`
-  /// decides an unqualified group-key-colliding subquery reference against: a
-  /// name a local relation exposes binds locally, one absent from every local
-  /// is the outer group-key correlation.
+  /// The `Exposure` — the bindable (real∪virtual) and the real-only column
+  /// surfaces, case-folded — of every relation in scope, keyed by its name: the
+  /// base tables and views this catalog vends and the common table expressions
+  /// and store relations the `overlay` binds. It is the schema map the windowed
+  /// grouping-sets `Lift` decides an unqualified group-key-colliding subquery
+  /// reference against: a name a local relation exposes binds locally, one
+  /// absent from every local is the outer group-key correlation. A subquery's
+  /// own FROM relation reads the `bindable` surface (a bare `Id` binds a
+  /// virtual), while a `SELECT *` derived table's output takes the `real`
+  /// surface of its own sources (`*` omits virtuals).
   ///
   /// It mirrors the engine's full schema derivation across every relation kind,
   /// not a subset:
   ///
-  ///   - a base table's real columns plus its virtual columns — the engine's
-  ///     `Schema.ordinal(of:)` resolves an adapter `Id` for a bare name, so the
-  ///     membership test must too, or a bare `Id` over a relation bearing a
-  ///     virtual `Id` would be mis-rewritten to the outer key rather than
-  ///     binding its own adapter column;
+  ///   - a base table's real columns (`real`) plus its virtual columns
+  ///     (`bindable` only) — the engine's `Schema.ordinal(of:)` resolves an
+  ///     adapter `Id` for a bare name, so the direct-membership test must too,
+  ///     while `*` omits the virtual, so the star surface must not;
   ///   - a view's declared column names in projection order (`View.columns`,
-  ///     the ISO first-arm naming), with no virtual column (`View.schema`),
-  ///     shadowing a base table of the same name — the precedence a
-  ///     `view(named:)` lookup applies;
+  ///     the ISO first-arm naming), with no virtual column (`View.schema`) on
+  ///     either surface, shadowing a base table of the same name — the
+  ///     precedence a `view(named:)` lookup applies;
   ///   - an engine-provided `View.standard` view (the ISO `information_schema.`
   ///     relations the engine ships with no source registering them) a user
   ///     view or base table does not shadow, resolved through `resolve(view:)`
-  ///     under that same precedence, so a hosted subquery over a built-in view
-  ///     binds its columns locally too;
-  ///   - a CTE's or store relation's declared columns plus the universal
-  ///     virtual `Id` a `RelationInstance` vends (`RelationInstance.schema`),
-  ///     shadowing a base table or view — the innermost overlay precedence the
-  ///     resolver applies. Only the overlay's base layer is read: a CTE is
-  ///     statement-scoped, while a nested subquery's FROM never sees an
-  ///     enclosing SELECT's derived aliases, so the derived layers name no
-  ///     relation a hosted subquery can reference.
+  ///     under that same precedence and with no virtual on either surface, so a
+  ///     hosted subquery over a built-in view binds its columns locally too;
+  ///   - a CTE's or store relation's declared columns (both surfaces) plus the
+  ///     universal virtual `Id` a `RelationInstance` vends (`bindable` only,
+  ///     as `*` omits it), shadowing a base table or view — the innermost
+  ///     overlay precedence the resolver applies. Only the overlay's base layer
+  ///     is read: a CTE is statement-scoped, while a nested subquery's FROM
+  ///     never sees an enclosing SELECT's derived aliases, so the derived
+  ///     layers name no relation a hosted subquery can reference.
   ///
   /// A relation still absent from the map — the residual — cannot be derived
-  /// pre-compile: only a `SELECT *` derived table inside a hosted subquery,
-  /// whose columns the union scope cannot expand here, leaving `expose` to
-  /// record it opaque (the reference conservatively blocked, arm-lifted).
+  /// pre-compile: only a `SELECT *` over a source the map does not name (an
+  /// unresolved or not-yet-bound CTE), whose columns the union scope cannot
+  /// expand here, leaving `expose` to record it opaque (the reference
+  /// conservatively blocked, arm-lifted).
   ///
   /// Every seam that lowers a windowed grouping-sets query — the compile, the
   /// schema derive and typecheck twins, and each runtime `union(windowed:)`
@@ -358,29 +394,35 @@ extension Catalog where Self: ~Escapable {
   /// so all decide local membership identically and run stays in step with
   /// validate.
   internal borrowing func schemas(_ overlay: ScopedRelations = [:])
-      -> Dictionary<String, Set<String>> {
-    var schemas = Dictionary<String, Set<String>>()
+      -> Dictionary<String, Exposure> {
+    var schemas = Dictionary<String, Exposure>()
     for name in relations() {
       guard let table = table(named: name) else { continue }
-      var columns = Set<String>()
-      for column in table.names { columns.insert(column.lowercased()) }
-      for virtual in table.virtuals { columns.insert(virtual.lowercased()) }
-      schemas[name.lowercased()] = columns
+      var real = Set<String>()
+      for column in table.names { real.insert(column.lowercased()) }
+      let virtuals = Set(table.virtuals.map { $0.lowercased() })
+      schemas[name.lowercased()] =
+          Exposure(bindable: real.union(virtuals), real: real,
+                   virtuals: virtuals)
     }
     for name in views() {
       guard let view = view(named: name) else { continue }
-      schemas[name.lowercased()] = Set(view.columns.map { $0.lowercased() })
+      let columns = Set(view.columns.map { $0.lowercased() })
+      schemas[name.lowercased()] =
+          Exposure(bindable: columns, real: columns, virtuals: [])
     }
     for name in View.standard.keys {
       guard view(named: name) == nil, table(named: name) == nil,
             let view = resolve(view: name) else { continue }
       let columns = Set(view.columns.map { $0.lowercased() })
-      schemas[name.lowercased()] = columns
+      schemas[name.lowercased()] =
+          Exposure(bindable: columns, real: columns, virtuals: [])
     }
     for (name, instance) in overlay.bindings {
-      var columns = Set(instance.columns.map { $0.lowercased() })
-      columns.insert("id")
-      schemas[name.lowercased()] = columns
+      let real = Set(instance.columns.map { $0.lowercased() })
+      schemas[name.lowercased()] =
+          Exposure(bindable: real.union(["id"]), real: real,
+                   virtuals: ["id"])
     }
     return schemas
   }
@@ -550,7 +592,7 @@ extension WindowedSets {
 internal func decompose(windowed select: Select,
                         sets: Array<Array<Expression>>,
                         _ routines: Routines,
-                        _ schemas: Dictionary<String, Set<String>>)
+                        _ schemas: Dictionary<String, Exposure>)
     throws(SQLError) -> WindowedSets {
   // `GROUPING SETS ()` has no arm to union — rejected here as in `expand`, so a
   // directly built empty set list faults a syntax error rather than trapping.
@@ -807,20 +849,22 @@ private struct Lift {
   /// serve separate decisions and need not agree.
   private let members: Set<Expression>
 
-  /// The exposed column names — case-folded — of each relation in scope, keyed
-  /// by the relation's name: the catalog's base tables and views, and the
-  /// overlay's common table expressions and store relations. It backs the
-  /// local-membership test an unqualified group-key-colliding reference decides
+  /// The `Exposure` — case-folded — of each relation in scope, keyed by the
+  /// relation's name: the catalog's base tables and views, and the overlay's
+  /// common table expressions and store relations. It backs the local-
+  /// membership test an unqualified group-key-colliding reference decides
   /// against (`expose`): a subquery's FROM relation naming one of these binds
-  /// an unqualified name that appears in its column set locally, so the name is
-  /// its own column, not the outer correlation. Virtual columns count — the
-  /// engine's `Schema.ordinal(of:)` resolves an adapter `Id` for a bare name,
-  /// so a subquery over a `U` bearing a virtual `Id` binds a bare `Id` to that
-  /// `Id`, never the outer key. The map mirrors the engine's full schema
-  /// derivation across every relation kind (`Catalog.schemas`); a relation
-  /// absent from it — only a `SELECT *` derived table — is indeterminate,
-  /// leaving the reference conservatively blocked.
-  private let schemas: Dictionary<String, Set<String>>
+  /// an unqualified name in its `bindable` set locally, so the name is its own
+  /// column, not the outer correlation. Virtual columns count on that surface
+  /// — the engine's `Schema.ordinal(of:)` resolves an adapter `Id` for
+  /// a bare name, so a subquery over a `U` bearing a virtual `Id` binds a bare
+  /// `Id` to that `Id`, never the outer key — while a `SELECT *` over `U` reads
+  /// the `real` surface instead (`*` omits the virtual). The map mirrors the
+  /// engine's full schema derivation across every relation kind
+  /// (`Catalog.schemas`); a relation absent from it — only a `SELECT *` over a
+  /// source the map does not name — is indeterminate, leaving the reference
+  /// conservatively blocked.
+  private let schemas: Dictionary<String, Exposure>
 
   /// Whether the grouping sets genuinely super-aggregate — some arm omits a
   /// group key another arm carries, so the sets are not all identical once
@@ -831,7 +875,10 @@ private struct Lift {
   /// grand-total `()` arm carries no value for an omitted key, so reaching it
   /// traps. Under such sets the two sites fault `0A000` rather than trap; a
   /// single set or all-identical sets arm-lift as before, every arm carrying
-  /// the keys, the lift staying value-correct.
+  /// the keys, the lift staying value-correct. It is reachable only where a
+  /// `SELECT *` source stays opaque at this slice, so a correlation over one
+  /// blocks and would arm-lift; a derivable source hosts outer and never
+  /// reaches the guard.
   private let superaggregating: Bool
 
   /// The local scope a rewrite walk accumulates as it descends — the enriched
@@ -839,10 +886,11 @@ private struct Lift {
   /// carries the in-scope FROM/JOIN `aliases` (for the qualified-local check),
   /// the exposed unqualified column `names` of every determinate local relation
   /// (for the unqualified-local check), and `opaque` — set when an in-scope
-  /// relation's columns could not be derived (only a `SELECT *` derived table
-  /// remains, now that a view and a CTE derive through `schemas`), so an
-  /// unqualified name might still bind there and the reference stays blocked
-  /// rather than rewritten.
+  /// relation's columns could not be derived (only a `SELECT *` over a source
+  /// the schema map does not name remains, now that a base table, view, CTE,
+  /// VALUES, and a `SELECT *` over any of those all derive through `schemas`),
+  /// so an unqualified name might still bind there and the reference stays
+  /// blocked rather than rewritten.
   private struct Locals {
     var aliases: Set<String>
     var names: Set<String>
@@ -922,7 +970,7 @@ private struct Lift {
 
   fileprivate init(_ routines: Routines, keys: Set<String>,
                    members: Set<Expression>,
-                   schemas: Dictionary<String, Set<String>>,
+                   schemas: Dictionary<String, Exposure>,
                    superaggregating: Bool) {
     self.routines = routines
     self.keys = keys
@@ -949,9 +997,13 @@ private struct Lift {
   /// fresh column per occurrence, so each site evaluates it independently. The
   /// reference is unqualified — the compile seam builds the union-output scope
   /// keyed by the empty alias, so a bare `*gwN` resolves against it by name,
-  /// with no derived-table qualifier to match.
+  /// with no derived-table qualifier to match. It is `synthetic`, a `Column`
+  /// identity no user identifier can mint, so a quoted alias spelled `"*gwN"`
+  /// stays distinct and a query-level `ORDER BY` binds this reference to its
+  /// union column structurally rather than by output-alias precedence
+  /// (`Windowed.order`).
   private mutating func reference(_ expression: Expression) -> Expression {
-    .column(Column(name: "*gw\(allocate(expression))"))
+    .column(Column(name: "*gw\(allocate(expression))", synthetic: true))
   }
 
   /// The `*gwN` union reference for a projected `output` a window `ORDER BY`
@@ -966,11 +1018,11 @@ private struct Lift {
   private mutating func reference(_ expression: Expression, output: Int)
       -> Expression {
     if let existing = linked[output] {
-      return .column(Column(name: "*gw\(existing)"))
+      return .column(Column(name: "*gw\(existing)", synthetic: true))
     }
     let position = allocate(expression)
     linked[output] = position
-    return .column(Column(name: "*gw\(position)"))
+    return .column(Column(name: "*gw\(position)", synthetic: true))
   }
 
   /// This expression lifted as the projected output a window `ORDER BY` ordinal
@@ -1338,29 +1390,37 @@ private struct Lift {
     locals.names.formUnion(names)
   }
 
-  /// The exposed unqualified column names of `relation`, or `nil` when they
+  /// The exposed unqualified column names of `relation` — the surface a bare
+  /// name in a subquery whose FROM names it binds against — or `nil` when they
   /// cannot be derived pre-compile (an indeterminate local the caller records
-  /// `opaque`). A `.named` relation resolves through the derived `schemas` (a
-  /// base table's real and virtual columns, a view's declared columns, a CTE's
-  /// or store relation's columns and virtual `Id`); a `.derived` table takes
-  /// its inner query's output names, indeterminate only for a `SELECT *` body
-  /// the union scope cannot expand here — the sole remaining opaque local.
+  /// `opaque`). A `.named` relation resolves through the derived `schemas` on
+  /// its `bindable` surface (a base table's real and virtual columns, a view's
+  /// declared columns, a CTE's or store relation's columns and virtual `Id`); a
+  /// `.derived` table takes its inner query's output names, indeterminate only
+  /// for a `SELECT *` over a source the map does not name.
   ///
   /// An explicit `AS t(c, …)` list renames the real columns, but the engine
-  /// keeps a relation's virtual `Id` unrenamed beside them (`Schema.renamed`),
-  /// and a materialised derived table vends the universal `Id` too, so the
-  /// exposed set carries that virtual past the list — a bare `Id` over a
-  /// renamed base table, CTE, store relation, or derived table binds locally
-  /// rather than being mis-rewritten to an outer group key. A view exposes no
-  /// virtual (its bindable surface is its real columns), so its listed form
-  /// stays `Id`-free.
+  /// keeps a relation's virtuals (its universal `Id`) unrenamed beside them
+  /// (`Schema.renamed`), and a materialised derived table vends the universal
+  /// `Id` too, so the exposed set carries that virtual past the list — a bare
+  /// `Id` over a renamed base table, CTE, store relation, or derived table
+  /// binds locally rather than being mis-rewritten to an outer group key. A
+  /// view exposes no virtual (`bindable == real`), so its listed form stays
+  /// `Id`-free.
   private func expose(_ relation: Relation) -> Set<String>? {
     switch relation.source {
     case let .named(name):
-      guard let bindable = schemas[name.lowercased()] else { return nil }
-      guard !relation.columns.isEmpty else { return bindable }
-      let listed = Set(relation.columns.map { $0.lowercased() })
-      return bindable.contains("id") ? listed.union(["id"]) : listed
+      guard let exposure = schemas[name.lowercased()] else { return nil }
+      guard !relation.columns.isEmpty else { return exposure.bindable }
+      // An explicit `AS t(c, …)` list renames the real columns; the engine
+      // keeps the relation's virtuals (its universal `Id`) unrenamed beside
+      // them, so union the listed names with those virtuals. A view has no
+      // virtual, so its listed form stays `Id`-free. The virtuals are held
+      // explicitly rather than derived as `bindable − real`: a name both real
+      // and virtual (a store relation's `Id`) is one entry in each, so the
+      // difference would drop it and lose the addressable virtual `Id`.
+      return Set(relation.columns.map { $0.lowercased() })
+          .union(exposure.virtuals)
     case let .derived(query):
       let names = relation.columns.isEmpty
           ? outputs(of: query) : Set(relation.columns.map { $0.lowercased() })
@@ -1370,17 +1430,21 @@ private struct Lift {
   }
 
   /// The unqualified output names a derived table's `query` exposes, or `nil`
-  /// when they cannot be derived — a `SELECT *` projection, whose columns the
-  /// union scope cannot expand here. An explicit projection contributes each
-  /// named item (an alias, else a bare column) and an unnamed computed item its
-  /// synthesized `column N` positional header (with the space), the same name
-  /// the schema derivation gives it — so a subquery over the derived table
-  /// binds that local synthesized column rather than an equally spelled outer
-  /// group key. A set operation takes the left
-  /// column names the engine's `VALUES` schema derivation assigns — `column1 …
-  /// columnN` for an N-column row (`Query.names`) — so an unqualified `column1`
-  /// over a `(VALUES …)` derived table binds locally rather than being
-  /// mis-rewritten to an outer group key.
+  /// when they cannot be derived — a `SELECT *` over a source the map does not
+  /// name. An explicit projection contributes each named item (an alias, else a
+  /// bare column) and an unnamed computed item its synthesized `column N`
+  /// positional header (with the space), the same name the schema derivation
+  /// gives it — so a subquery over the derived table binds that local
+  /// synthesized column rather than an equally spelled outer group key. A
+  /// `SELECT *` derives through `starred` — the real columns of its own
+  /// FROM/JOIN sources, the engine's `*` expansion (`Scope.terms(.all)`), so a
+  /// `(SELECT * FROM Emp) e` exposes `Emp`'s real columns and an unqualified
+  /// group-key-colliding name binds there rather than arm-lifting. A set
+  /// operation takes the left arm's names (ISO 9075 output naming); a `VALUES`
+  /// body exposes the default column names the engine's `VALUES` schema
+  /// derivation assigns — `column1 … columnN` for an N-column row
+  /// (`Query.names`) — so an unqualified `column1` over a `(VALUES …)` derived
+  /// table binds locally rather than being mis-rewritten to an outer group key.
   /// The output names this `select`'s own `ORDER BY` may bind before it falls
   /// through to the source and enclosing scope, mirroring `Select.orderKeys`
   /// (`keys(named: aggregates ? \.name : \.alias)`) reduced to a name set. It
@@ -1416,7 +1480,7 @@ private struct Lift {
     case let .select(select):
       switch select.projection {
       case .all:
-        return nil
+        return starred(select)
       case let .columns(columns):
         return Set(columns.map { $0.name.lowercased() })
       case let .expressions(items):
@@ -1439,15 +1503,16 @@ private struct Lift {
   /// binds, so it must fall through and correlate to its `*gwN` union column,
   /// not ride), and a `VALUES` arm's `columnN` headers are likewise non-
   /// spellable, so an arm exposes none. An explicit `AS` alias and a bare
-  /// projected column's own name both ride, as each binds the carrier order.
-  /// `nil` propagates as in `outputs(of query:)`, so an opaque arm rides
-  /// verbatim, the conservative prior behaviour.
+  /// projected column's own name both ride, as each binds the carrier order; a
+  /// `SELECT *` arm rides its expanded real names (`starred`). `nil` propagates
+  /// as in `outputs(of query:)`, so an opaque arm rides verbatim, the
+  /// conservative prior behaviour.
   private func bindable(of query: Query) -> Set<String>? {
     switch query.body {
     case let .select(select):
       switch select.projection {
       case .all:
-        return nil
+        return starred(select)
       case let .columns(columns):
         return Set(columns.map { $0.name.lowercased() })
       case let .expressions(items):
@@ -1457,6 +1522,61 @@ private struct Lift {
       return bindable(of: left)
     case .values:
       return []
+    }
+  }
+
+  /// The unqualified column names a `SELECT *` over `select`'s sources exposes
+  /// — the engine's `*` expansion (`Scope.expansion`/`Scope.names`),
+  /// which prepends each `NATURAL`/`USING` merged column once, then enumerates
+  /// each source relation's real columns in chain order (never a virtual column
+  /// and never a merged constituent the union enumeration subsumes), unioned as
+  /// a set since membership tests names alone. A merged column may be a virtual
+  /// (a foreign key) that `reals` omits, so the merged names are added
+  /// explicitly: a `USING` clause names them; a `NATURAL` join merges the
+  /// columns both sides share. That common set is the intersection of the two
+  /// sides' real, `SELECT *`-visible names — virtuals excluded on both sides,
+  /// matching the engine's `Compilation.merging` (its `prefix.names` reads the
+  /// real-only expansion and the right side is probed through `joined.names`),
+  /// so an adapter foreign key never becomes a `NATURAL` common column. `nil`
+  /// when any source's real columns cannot be derived (a nested `SELECT *` over
+  /// a source the map does not name), so the whole `*` output is opaque.
+  private func starred(_ select: Select) -> Set<String>? {
+    guard var columns = reals(of: select.from) else { return nil }
+    // The left side's accumulated real, `*`-visible names — the merge probe
+    // both sides restrict to, never a virtual. A `USING`-named virtual joins
+    // `columns` (it is `*`-visible) but not `real`, so a later `NATURAL` join
+    // cannot merge on it, as the engine's real-only common set does not.
+    var real = columns
+    for join in select.joins {
+      guard let names = reals(of: join.relation) else { return nil }
+      switch join.using {
+      case .none:
+        break
+      case let .columns(named):
+        columns.formUnion(named.map { $0.lowercased() })
+      case .natural:
+        columns.formUnion(real.intersection(names))
+      }
+      columns.formUnion(names)
+      real.formUnion(names)
+    }
+    return columns
+  }
+
+  /// The real columns `relation` contributes to a `SELECT *` expansion — an
+  /// explicit `AS t(c, …)` list, a base table's/view's/CTE's real columns (the
+  /// `real` surface, never a virtual `Id`, which `*` omits), or a derived
+  /// table's own output names (recursing `outputs`). `nil` when a `.named`
+  /// source is absent from the map or a nested derived `SELECT *` is opaque.
+  private func reals(of relation: Relation) -> Set<String>? {
+    if !relation.columns.isEmpty {
+      return Set(relation.columns.map { $0.lowercased() })
+    }
+    switch relation.source {
+    case let .named(name):
+      return schemas[name.lowercased()]?.real
+    case let .derived(query):
+      return outputs(of: query)
     }
   }
 
@@ -1573,8 +1693,8 @@ private struct Lift {
         // from every determinate local with no opaque local in scope is the
         // outer group key, rewritten to its `*gwN` union column; a name absent
         // from the determinate locals but possibly hiding in an opaque local
-        // (a `SELECT *` derived table) is undecidable, so it blocks and the
-        // subquery arm-lifts.
+        // (a `SELECT *` over a source the schema map does not name) is
+        // undecidable, so it blocks and the subquery arm-lifts.
         if riding {
           guard let surface else { return expression }
           if surface.contains(name) { return expression }

--- a/SwiftSQL/Sources/SQLEngine/Resolution.swift
+++ b/SwiftSQL/Sources/SQLEngine/Resolution.swift
@@ -1772,7 +1772,14 @@ internal func order(_ order: Order, _ projection: Array<Term>,
       resolved = projection[position - 1]
       column = position - 1
     case let .expression(expression):
+      // A synthetic `*gwN` reference — a windowed GROUPING SETS lift key a
+      // hosted subquery's own ORDER BY carries — bypasses output-alias
+      // precedence and lowers structurally, as `Select.orderKeys` and
+      // `Windowed.order` resolve it; a user alias spelled `*gwN` must not
+      // capture it here (its `Column` identity is distinct), or the run would
+      // sort by the aliased scalar where validate binds the correlated key.
       if case let .column(name) = expression, name.qualifier == nil,
+          !name.synthetic,
           let index = names.firstIndex(where: {
             $0?.lowercased() == name.name.lowercased()
           }) {

--- a/SwiftSQL/Sources/SQLEngine/Windowed.swift
+++ b/SwiftSQL/Sources/SQLEngine/Windowed.swift
@@ -1747,8 +1747,13 @@ internal struct Windowed {
                                 ascending: key.ascending,
                                 column: position - 1))
       case let .expression(expression):
+        // A synthetic reference — the lifted `*gwN` union column a windowed
+        // `GROUPING SETS` rewrite addresses — bypasses output-alias precedence
+        // and binds structurally against the arm-synthesized union scope
+        // (`term`), so a colliding user alias spelled `"*gwN"` in this
+        // projection cannot capture it (its `Column` identity is distinct).
         if case let .column(reference) = expression,
-            reference.qualifier == nil {
+            reference.qualifier == nil, !reference.synthetic {
           let name = reference.name.lowercased()
           if ambiguous.contains(name) { throw .ambiguous(reference.name) }
           if let alias = aliases[name] {

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -3820,6 +3820,44 @@ struct WindowOverGroupingSetsTests {
         yields: [[nil, 1400, 4], [2, 600, 3], [3, 500, 2], [1, 300, 1]])
   }
 
+  @Test func `a user alias colliding with a lifted column cannot capture it`()
+      throws {
+    // The lifted union columns a windowed `GROUPING SETS` rewrite reads are
+    // named `*gwN`. A user may quote that exact spelling as an output alias
+    // (`AS "*gw0"`), so the query-level `ORDER BY dept` — rewritten to the
+    // lifted `dept` union column — must not bind to that alias by output-alias
+    // precedence. The lifted reference is a synthetic `Column` identity the
+    // parser can never mint, so it binds structurally to its union column:
+    // `ORDER BY dept ASC` sorts on `dept`, numbering by `dept DESC` (3 → 1,
+    // 2 → 2, 1 → 3), so the rows come out `dept` 1, 2, 3 carrying 3, 2, 1.
+    try fixture().expect(
+        "SELECT ROW_NUMBER() OVER (ORDER BY dept DESC) AS \"*gw0\" " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept)) ORDER BY dept ASC",
+        yields: [[3], [2], [1]])
+  }
+
+  @Test func `a non-colliding alias yields the same lifted ordering`() throws {
+    // The oracle for the colliding case: the identical query with an ordinary
+    // alias behaves the same, since `ORDER BY dept` always names the lifted
+    // `dept` union column, never the row-number output. The two results agree.
+    try fixture().expect(
+        "SELECT ROW_NUMBER() OVER (ORDER BY dept DESC) AS x " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept)) ORDER BY dept ASC",
+        yields: [[3], [2], [1]])
+  }
+
+  @Test func `a user reference to a colliding alias still binds it`() throws {
+    // The synthetic-reference bypass is surgical: only the engine's lifted
+    // references skip output-alias precedence. A user naming their own quoted
+    // `"*gw0"` alias in the query `ORDER BY` still binds it, so ordering by the
+    // aliased row number descending (`dept` 1 → 1, 2 → 2, 3 → 3, sorted
+    // descending) yields `dept` 3, 2, 1 carrying 3, 2, 1.
+    try fixture().expect(
+        "SELECT dept, ROW_NUMBER() OVER (ORDER BY dept) AS \"*gw0\" " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept)) ORDER BY \"*gw0\" DESC",
+        yields: [[3, 3], [2, 2], [1, 1]])
+  }
+
   @Test func `run and validate agree on a windowed GROUPING SETS`() throws {
     // Both paths enter `Query.expanded`, so they drive the one rewrite over the
     // union: the schema path types the same three-column shape the run
@@ -4012,6 +4050,23 @@ struct WindowOverGroupingSetsTests {
         Row(1, 100)
         Row(1, 101)
         Row(2, 200)
+      }
+    }
+  }
+
+  // A `T` with a zero group beside a `c` whose lone real column is `Id`. `c`
+  // also vends the universal virtual `Id`, so a real and a virtual `Id` share
+  // the name — the pair the Exposure once collapsed. Its virtual `Id` is the
+  // 1-based row index (1, 2), both positive.
+  private func renamed() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("T", ["Id": .integer]) {
+        Row(0)
+        Row(1)
+      }
+      Relation("c", ["Id": .integer]) {
+        Row(10)
+        Row(20)
       }
     }
   }
@@ -4250,6 +4305,23 @@ struct WindowOverGroupingSetsTests {
     try fixture().empty(sql)
     #expect(try fixture().columns(of: parse(query: sql), validate: true)
                 .count == 2)
+  }
+
+  @Test func `a COALESCE over a window never reaches its guarded arm`()
+      throws {
+    // A window-free `COALESCE(ROW_NUMBER() OVER (), 1 / 0)` wraps the window in
+    // the outer projection, evaluated lazily per output row over the union. The
+    // row number is never NULL, so the guarded `1 / 0` is never reached and the
+    // division never happens — the union's rows number 1, 2, 3, matching the
+    // ordinary `GROUP BY dept` form. A window-free wrapper force-lifted into an
+    // arm would evaluate the whole `COALESCE` eagerly per group and fault
+    // `.divide`; kept outer and lazy, the dead arm stays unevaluated.
+    let sets = "SELECT COALESCE(ROW_NUMBER() OVER (), 1 / 0) " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[1], [2], [3]])
+    let plain = "SELECT COALESCE(ROW_NUMBER() OVER (), 1 / 0) " +
+                "FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[1], [2], [3]])
   }
 
   @Test func `an ordinal-linked window key shares the reported leaf`() throws {
@@ -4924,6 +4996,26 @@ struct WindowOverGroupingSetsTests {
                          yields: [[1, 1], [2, 1], [3, 1], [4, 1], [5, 1]])
   }
 
+  @Test func `a synthetic ORDER BY key does not bind a colliding alias`()
+      throws {
+    // F6: a windowed GROUPING SETS query lifts its `ORDER BY dept` to the
+    // synthetic `*gw0` union column. The shared `orderKeys` resolver — driving
+    // both the run compile and the validate typecheck — must let that synthetic
+    // key bind structurally, as `Windowed.order` does, not capture a user
+    // projection aliased `"*gw0"`. Here that alias is `NULLIF(ROW_NUMBER() OVER
+    // (), 'x')`, an invalid integer-versus-text compare; resolving the sort key
+    // to it type-checked the `NULLIF` and raised a spurious 42804. `FETCH FIRST
+    // 0 ROWS` drops every row, so the `NULLIF` never evaluates — both the run
+    // and `columns(of: validate:)` succeed on the empty page. Before the fix
+    // both faulted 42804.
+    let sql = "SELECT NULLIF(ROW_NUMBER() OVER (), 'x') AS \"*gw0\" " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept)) " +
+              "ORDER BY dept FETCH FIRST 0 ROWS ONLY"
+    try fixture().empty(sql)
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 1)
+  }
+
   @Test func `a correlated EXISTS CASE guard hosts outer over the union`()
       throws {
     // Finding 1: a correlated predicate subquery in a `CASE` guard — `EXISTS
@@ -5123,62 +5215,54 @@ struct WindowOverGroupingSetsTests {
     try colliding().expect(plain, yields: [[1, 1], [1, 2], [0, 3]])
   }
 
-  @Test func `a self-correlating CASE over non-identical sets faults`() throws {
-    // An `EXISTS` guard correlating an unqualified `dept` — a group key —
-    // through the opaque derived `(SELECT * FROM U) o` blocks hosting and
-    // stalls the walk, so this window-free `CASE` arm-lifts whole in place.
-    // Under `GROUPING SETS ((dept), ())` the sets genuinely super-aggregate:
-    // the grand-total `()` arm omits `dept`, so the arm-lifted guard's
-    // correlation to it has no arm column and once trapped `Index out of
-    // range`. The guard now faults `0A000` on both the run and validate paths.
+  @Test func `a self-correlating CASE over non-identical sets resolves`()
+      throws {
+    // At this slice the derived `(SELECT * FROM U) o` is derivable — `starred`
+    // exposes its real `{v}` — so the `EXISTS` guard's unqualified `dept`, a
+    // group key absent from it, is decided the outer key, rewritten to its
+    // `*gwN` union column and the guard hosted outer. There is no in-place
+    // arm-lift, so the grand-total `()` arm NULL-extends `dept` rather than
+    // trapping (the merged slice, unable to derive the `SELECT *`, must instead
+    // fault `0A000` here). `dept` 1, 2, 3 each match a `U.v` (guard 1); the
+    // super-aggregate row's `dept` is NULL, matching none (guard 0); the window
+    // numbers across all four union rows, on both the run and validate paths.
     let sets =
         "SELECT CASE WHEN EXISTS (" +
         "SELECT 1 FROM (SELECT * FROM U) o WHERE o.v = dept) " +
         "THEN 1 ELSE 0 END, ROW_NUMBER() OVER () " +
         "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
-    let fault = SQLError.state(
-        "0A000", "a correlated predicate over an opaque local with " +
-                 "GROUPING SETS is not yet supported")
-    try colliding().expect(sets, fails: fault)
-    #expect(throws: fault) {
-      _ = try colliding().columns(of: parse(query: sets), validate: true)
-    }
-    // The single-set form has no super-aggregate arm to omit the key, so the
-    // in-place arm-lift stays value-correct and the guard permits it: each
-    // `dept` finds a matching `U.v`, so the `CASE` yields 1, each numbered.
-    let single =
+    try colliding().expect(sets, yields: [[1, 1], [1, 2], [1, 3], [0, 4]])
+    #expect(try colliding().columns(of: parse(query: sets), validate: true)
+                .count == 2)
+    // The ordinary `GROUP BY dept` twin gives the per-set rows the sets query
+    // reproduces, the `()` super-aggregate row the only addition.
+    let plain =
         "SELECT CASE WHEN EXISTS (" +
         "SELECT 1 FROM (SELECT * FROM U) o WHERE o.v = dept) " +
-        "THEN 1 ELSE 0 END, ROW_NUMBER() OVER () " +
-        "FROM Emp GROUP BY GROUPING SETS ((dept))"
-    try colliding().expect(single, yields: [[1, 1], [1, 2], [1, 3]])
+        "THEN 1 ELSE 0 END, ROW_NUMBER() OVER () FROM Emp GROUP BY dept"
+    try colliding().expect(plain, yields: [[1, 1], [1, 2], [1, 3]])
   }
 
-  @Test func `a self-correlating scalar over non-identical sets faults`()
+  @Test func `a self-correlating scalar over non-identical sets resolves`()
       throws {
     // The scalar twin: `(SELECT SUM(o.v) FROM (SELECT * FROM U) o WHERE o.v =
-    // dept)` correlates an unqualified `dept` over the opaque derived table, so
-    // `host` returns nil and it arm-lifts in place. Under `GROUPING SETS
-    // ((dept), ())` that lift trapped on the grand-total `()` arm's omitted
-    // `dept`; it now faults `0A000` on both the run and validate paths.
+    // dept)` correlates the outer `dept` over the now-derivable derived table,
+    // so `host` rewrites it to `*gwN` and hosts the subquery outer over the
+    // union rather than arm-lifting it in place (the merged slice faults
+    // `0A000` here instead). The `()` arm NULL-extends the key. `dept` 1, 2, 3
+    // sum their lone matching `U.v` (1, 2, 3); the super-aggregate row matches
+    // none (NULL); the window numbers across all four, on run and validate.
     let sets =
         "SELECT (SELECT SUM(o.v) FROM (SELECT * FROM U) o " +
         "WHERE o.v = dept), ROW_NUMBER() OVER () " +
         "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
-    let fault = SQLError.state(
-        "0A000", "a correlated subquery over an opaque local with " +
-                 "GROUPING SETS is not yet supported")
-    try colliding().expect(sets, fails: fault)
-    #expect(throws: fault) {
-      _ = try colliding().columns(of: parse(query: sets), validate: true)
-    }
-    // The single-set form arm-lifts value-correctly and the guard permits it:
-    // each `dept` sums its lone matching `U.v`, each numbered.
-    let single =
+    try colliding().expect(sets, yields: [[1, 1], [2, 2], [3, 3], [nil, 4]])
+    #expect(try colliding().columns(of: parse(query: sets), validate: true)
+                .count == 2)
+    let plain =
         "SELECT (SELECT SUM(o.v) FROM (SELECT * FROM U) o " +
-        "WHERE o.v = dept), ROW_NUMBER() OVER () " +
-        "FROM Emp GROUP BY GROUPING SETS ((dept))"
-    try colliding().expect(single, yields: [[1, 1], [2, 2], [3, 3]])
+        "WHERE o.v = dept), ROW_NUMBER() OVER () FROM Emp GROUP BY dept"
+    try colliding().expect(plain, yields: [[1, 1], [2, 2], [3, 3]])
   }
 
   @Test func `an absent key LEAD fallback over a zero group stays lazy`()
@@ -5964,49 +6048,6 @@ struct WindowOverGroupingSetsTests {
         }
   }
 
-  @Test func `a CASE grouping key matches a qualifier-variant guard`() throws {
-    // Finding 1: the grouping key is `CASE WHEN T.A = 1 …`, the projection the
-    // same `CASE` with the unqualified guard `A = 1`. Grouped lowering equates
-    // the two — `T.A` and `A` resolve to one ordinal, so both `CASE`s lower to
-    // one `Term` — so the whole-key member match must too. `Expression
-    // .canonical` once copied the guard `Predicate` verbatim, so the key's
-    // `T.A = 1` and the projection's `A = 1` canonicalised apart, the whole-key
-    // match missed, and the walk descended into the guard, lifting a bare `A`
-    // the `(T.A = 1)` arm rejected `.grouping`. Canonicalising the guard by
-    // `Predicate.canonical` collapses the two spellings, so the whole `CASE`
-    // lifts to its `*gw0` arm column — the exact key the arm groups on. The
-    // guard groups are 1 (the dept-1 rows) and 0 (dept-2), the total NULLs the
-    // key; run ≡ validate over the union, matching the ordinary form.
-    let sql = "SELECT CASE WHEN A = 1 THEN 1 ELSE 0 END, " +
-              "ROW_NUMBER() OVER () FROM N AS T GROUP BY " +
-              "GROUPING SETS ((CASE WHEN T.A = 1 THEN 1 ELSE 0 END), ())"
-    try nums().expect(sql, yields: [[1, 1], [0, 2], [nil, 3]])
-    #expect(try nums().columns(of: parse(query: sql), validate: true)
-                .count == 2)
-    try nums().expect(
-        "SELECT CASE WHEN A = 1 THEN 1 ELSE 0 END FROM N AS T GROUP BY " +
-        "GROUPING SETS ((CASE WHEN T.A = 1 THEN 1 ELSE 0 END), ())",
-        yields: [[1], [0], [nil]])
-  }
-
-  @Test func `a CASE grouping key matches a case-variant guard`() throws {
-    // The same over a case-folded guard: the projection's `CASE WHEN a = 1 …`
-    // must match the key's `CASE WHEN A = 1 …`. `Predicate.canonical` folds
-    // each guard column exactly as `Expression.canonical` does its results, so
-    // the whole `CASE` lifts whole rather than descending to a bare `a` the arm
-    // rejects. Same groups as the qualifier-variant form; run ≡ validate.
-    let sql = "SELECT CASE WHEN a = 1 THEN 1 ELSE 0 END, " +
-              "ROW_NUMBER() OVER () FROM N GROUP BY " +
-              "GROUPING SETS ((CASE WHEN A = 1 THEN 1 ELSE 0 END), ())"
-    try nums().expect(sql, yields: [[1, 1], [0, 2], [nil, 3]])
-    #expect(try nums().columns(of: parse(query: sql), validate: true)
-                .count == 2)
-    try nums().expect(
-        "SELECT CASE WHEN a = 1 THEN 1 ELSE 0 END FROM N GROUP BY " +
-        "GROUPING SETS ((CASE WHEN A = 1 THEN 1 ELSE 0 END), ())",
-        yields: [[1], [0], [nil]])
-  }
-
   // A single-column relation grouped on a computed key `A + 1`: A = 1, 1, 2, so
   // `A + 1` = 2, 2, 3 — two groups the arithmetic key defines, exactly as a
   // plain `GROUP BY A + 1` would.
@@ -6179,6 +6220,49 @@ struct WindowOverGroupingSetsTests {
         yields: [[2], [3], [nil]])
   }
 
+  @Test func `a CASE grouping key matches a qualifier-variant guard`() throws {
+    // Finding 1: the grouping key is `CASE WHEN T.A = 1 …`, the projection the
+    // same `CASE` with the unqualified guard `A = 1`. Grouped lowering equates
+    // the two — `T.A` and `A` resolve to one ordinal, so both `CASE`s lower to
+    // one `Term` — so the whole-key member match must too. `Expression
+    // .canonical` once copied the guard `Predicate` verbatim, so the key's
+    // `T.A = 1` and the projection's `A = 1` canonicalised apart, the whole-key
+    // match missed, and the walk descended into the guard, lifting a bare `A`
+    // the `(T.A = 1)` arm rejected `.grouping`. Canonicalising the guard by
+    // `Predicate.canonical` collapses the two spellings, so the whole `CASE`
+    // lifts to its `*gw0` arm column — the exact key the arm groups on. The
+    // guard groups are 1 (the dept-1 rows) and 0 (dept-2), the total NULLs the
+    // key; run ≡ validate over the union, matching the ordinary form.
+    let sql = "SELECT CASE WHEN A = 1 THEN 1 ELSE 0 END, " +
+              "ROW_NUMBER() OVER () FROM N AS T GROUP BY " +
+              "GROUPING SETS ((CASE WHEN T.A = 1 THEN 1 ELSE 0 END), ())"
+    try nums().expect(sql, yields: [[1, 1], [0, 2], [nil, 3]])
+    #expect(try nums().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    try nums().expect(
+        "SELECT CASE WHEN A = 1 THEN 1 ELSE 0 END FROM N AS T GROUP BY " +
+        "GROUPING SETS ((CASE WHEN T.A = 1 THEN 1 ELSE 0 END), ())",
+        yields: [[1], [0], [nil]])
+  }
+
+  @Test func `a CASE grouping key matches a case-variant guard`() throws {
+    // The same over a case-folded guard: the projection's `CASE WHEN a = 1 …`
+    // must match the key's `CASE WHEN A = 1 …`. `Predicate.canonical` folds
+    // each guard column exactly as `Expression.canonical` does its results, so
+    // the whole `CASE` lifts whole rather than descending to a bare `a` the arm
+    // rejects. Same groups as the qualifier-variant form; run ≡ validate.
+    let sql = "SELECT CASE WHEN a = 1 THEN 1 ELSE 0 END, " +
+              "ROW_NUMBER() OVER () FROM N GROUP BY " +
+              "GROUPING SETS ((CASE WHEN A = 1 THEN 1 ELSE 0 END), ())"
+    try nums().expect(sql, yields: [[1, 1], [0, 2], [nil, 3]])
+    #expect(try nums().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+    try nums().expect(
+        "SELECT CASE WHEN a = 1 THEN 1 ELSE 0 END FROM N GROUP BY " +
+        "GROUPING SETS ((CASE WHEN A = 1 THEN 1 ELSE 0 END), ())",
+        yields: [[1], [0], [nil]])
+  }
+
   // A grouped `Emp` beside the three relations a hosted subquery joins in
   // prefix order — `P` a single carrier row, `Q` keyed on the group key `dept`
   // (its `id` the dept's value ×100), and `R` joined on `Q.id` and, crucially,
@@ -6341,6 +6425,197 @@ struct WindowOverGroupingSetsTests {
         """
     #expect(try catalog.run(Statement(parsing: plain), routines) == expected)
     #expect(counter.count == 0)
+  }
+
+  @Test func `a SELECT-star derived table binds a group key locally`() throws {
+    // Finding 2: a `LEAD` default nests `(SELECT tick() FROM (SELECT * FROM
+    // Emp) e WHERE dept = dept)`. The engine's `*` expansion projects `Emp`'s
+    // real columns, so `e` exposes `dept` — the unqualified `dept` binds
+    // locally, the subquery is uncorrelated and hosts lazily in the outer
+    // `LEAD`. Offset 0 always lands on the current row, so the default never
+    // evaluates and `tick()` never runs. `outputs(of:)` once returned nil for a
+    // `SELECT *` body, marking `e` opaque, so the `dept` reference blocked and
+    // the whole subquery arm-lifted — running `tick()` eagerly per group.
+    // Deriving the star output binds `dept` locally, matching `GROUP BY dept`.
+    // (A literal `1 / 0` default the union scope could stand in for constant-
+    // folds at compile whether hosted or lifted, so a non-deterministic
+    // `tick()` with a call counter is the observable a hosted default is lazy.)
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    let sets = "SELECT dept, LEAD(dept, 0, (SELECT tick() " +
+               "FROM (SELECT * FROM Emp) e WHERE dept = dept)) " +
+               "OVER (ORDER BY dept) FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[1, 1], [2, 2], [3, 3]],
+                         routines: routines)
+    #expect(counter.count == 0)
+    #expect(try fixture().columns(of: parse(query: sets), routines: routines,
+                                  validate: true).count == 2)
+    let plain = "SELECT dept, LEAD(dept, 0, (SELECT tick() " +
+                "FROM (SELECT * FROM Emp) e WHERE dept = dept)) " +
+                "OVER (ORDER BY dept) FROM Emp GROUP BY dept"
+    try fixture().expect(plain, yields: [[1, 1], [2, 2], [3, 3]],
+                         routines: routines)
+    #expect(counter.count == 0)
+  }
+
+  @Test func `a SELECT-star over a join binds a group key locally`() throws {
+    // The join variant: the star spans `(VALUES (0)) AS z JOIN Emp`, so `*`
+    // concatenates each source's real columns — `z`'s `column1` and `Emp`'s
+    // `dept`/`sal` — and `e` exposes `dept` from the joined-in relation, not
+    // just the FROM. The unqualified `dept` binds locally, the subquery hosts
+    // lazily, and offset 0 never evaluates `tick()`. `starred` unions the FROM
+    // and every join's real columns; without the join half `dept` would block
+    // and the subquery arm-lift, ticking per group. Matches the ordinary form.
+    let counter = Counter()
+    let routines = try Routines.standard
+        .registering("tick", returns: .integer, deterministic: false) { _ in
+          .integer(counter.next())
+        }
+    let sets = "SELECT dept, LEAD(dept, 0, (SELECT tick() FROM " +
+               "(SELECT * FROM (VALUES (0)) AS z JOIN Emp ON 1 = 1) e " +
+               "WHERE dept = dept)) OVER (ORDER BY dept) " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[1, 1], [2, 2], [3, 3]],
+                         routines: routines)
+    #expect(counter.count == 0)
+    #expect(try fixture().columns(of: parse(query: sets), routines: routines,
+                                  validate: true).count == 2)
+  }
+
+  @Test func `a SELECT-star keeps a qualified outer correlation outer`()
+      throws {
+    // Soundness: deriving `e`'s columns from `SELECT * FROM Emp` exposes
+    // `dept`, but a reference qualified by the outer alias — `T.dept` — is
+    // still the outer correlation, never `e`'s local column, so the qualifier
+    // check keeps it rewritten to the `*gwN` union key rather than falsely
+    // binding it local. The subquery counts `e`'s rows whose `dept` is below
+    // the group's `T.dept` — dept-1 sees 0, dept-2 sees 2 (the two dept-1
+    // rows), dept-3 sees 4 (the dept-1 and dept-2 rows) — a genuine
+    // correlation, matching `GROUP BY dept`.
+    let sets = "SELECT dept, (SELECT COUNT(*) FROM (SELECT * FROM Emp) e " +
+               "WHERE e.dept < T.dept), ROW_NUMBER() OVER () " +
+               "FROM Emp AS T GROUP BY GROUPING SETS ((dept))"
+    try fixture().expect(sets, yields: [[1, 0, 1], [2, 2, 2], [3, 4, 3]])
+    #expect(try fixture().columns(of: parse(query: sets), validate: true)
+                .count == 3)
+    let plain = "SELECT dept, (SELECT COUNT(*) FROM (SELECT * FROM Emp) e " +
+                "WHERE e.dept < T.dept), ROW_NUMBER() OVER () " +
+                "FROM Emp AS T GROUP BY dept"
+    try fixture().expect(plain, yields: [[1, 0, 1], [2, 2, 2], [3, 4, 3]])
+  }
+
+  @Test func `a SELECT-star merged USING column binds a group key locally`()
+      throws {
+    // A hosted subquery's derived `(SELECT * FROM U JOIN W USING (fk)) e`
+    // merges a virtual foreign key `fk` that both `U` and `W` expose. The
+    // engine's `*` emits that merged column once (`Scope.expansion`), so `e`
+    // exposes `fk` and the bare `fk` inside `MIN(fk)` binds locally to it (99),
+    // leaving the subquery uncorrelated and hosted outer. Deriving `e`'s output
+    // from the inputs' real columns alone dropped the merged virtual `fk`, so
+    // the bare `fk` was misclassified as the outer grouping key and rewritten
+    // to its `*gwN` union column — returning the group value (1, 2) rather than
+    // 99. The window `ROW_NUMBER() OVER ()` engages the lift, and the result
+    // matches the ordinary `GROUP BY fk` form. The `USING (Id)` shape is masked
+    // — the derived-table path backfills `Id` — so `fk` is a distinct virtual
+    // foreign key, exposed here through a custom catalog the fixture cannot.
+    let catalog = KeyedCatalog([
+      "O": KeyedRelation(columns: [(name: "fk", type: .integer)], extras: [],
+                         rows: [[.integer(1)], [.integer(2)]], keys: [[], []]),
+      "U": KeyedRelation(columns: [(name: "u", type: .integer)],
+                         extras: ["fk"], rows: [[.integer(100)]],
+                         keys: [[.integer(99)]]),
+      "W": KeyedRelation(columns: [(name: "w", type: .integer)],
+                         extras: ["fk"], rows: [[.integer(200)]],
+                         keys: [[.integer(99)]]),
+    ])
+    let sets = "SELECT fk, (SELECT MIN(fk) FROM " +
+               "(SELECT * FROM U JOIN W USING (fk)) e), " +
+               "ROW_NUMBER() OVER () FROM O GROUP BY GROUPING SETS ((fk))"
+    let expected: Array<Array<Value>> =
+        [[.integer(1), .integer(99), .integer(1)],
+         [.integer(2), .integer(99), .integer(2)]]
+    #expect(try catalog.run(parse(query: sets)) == expected)
+    #expect(try catalog.columns(of: parse(query: sets), validate: true)
+                .count == 3)
+    let plain = "SELECT fk, (SELECT MIN(fk) FROM " +
+                "(SELECT * FROM U JOIN W USING (fk)) e), " +
+                "ROW_NUMBER() OVER () FROM O GROUP BY fk"
+    #expect(try catalog.run(parse(query: plain)) == expected)
+  }
+
+  @Test func `a SELECT-star NATURAL join does not merge a virtual key`()
+      throws {
+    // The `NATURAL` twin of the `USING` case: `U` and `W` share only the
+    // virtual foreign key `fk` (no common real column), so a `NATURAL` join
+    // merges nothing — the engine's common set is the real-only intersection,
+    // virtuals excluded — and the derived `(SELECT * FROM U NATURAL JOIN W) e`
+    // exposes just `u` and `w`, never `fk`. The bare `fk` inside `MIN(fk)` is
+    // therefore the outer group key, correlated and substituted to its `*gwN`
+    // union column, so it reports the group value (1, 2), matching the ordinary
+    // `GROUP BY fk` form. Before the fix `starred` intersected the bindable
+    // (real∪virtual) surfaces, wrongly merged `fk`, and classified the
+    // reference as a local column of `e` the derived `*` does not expose.
+    let catalog = KeyedCatalog([
+      "O": KeyedRelation(columns: [(name: "fk", type: .integer)], extras: [],
+                         rows: [[.integer(1)], [.integer(2)]], keys: [[], []]),
+      "U": KeyedRelation(columns: [(name: "u", type: .integer)],
+                         extras: ["fk"], rows: [[.integer(100)]],
+                         keys: [[.integer(99)]]),
+      "W": KeyedRelation(columns: [(name: "w", type: .integer)],
+                         extras: ["fk"], rows: [[.integer(200)]],
+                         keys: [[.integer(99)]]),
+    ])
+    let sets = "SELECT fk, (SELECT MIN(fk) FROM " +
+               "(SELECT * FROM U NATURAL JOIN W) e), " +
+               "ROW_NUMBER() OVER () FROM O GROUP BY GROUPING SETS ((fk))"
+    let expected: Array<Array<Value>> =
+        [[.integer(1), .integer(1), .integer(1)],
+         [.integer(2), .integer(2), .integer(2)]]
+    #expect(try catalog.run(parse(query: sets)) == expected)
+    #expect(try catalog.columns(of: parse(query: sets), validate: true)
+                .count == 3)
+    let plain = "SELECT fk, (SELECT MIN(fk) FROM " +
+                "(SELECT * FROM U NATURAL JOIN W) e), " +
+                "ROW_NUMBER() OVER () FROM O GROUP BY fk"
+    #expect(try catalog.run(parse(query: plain)) == expected)
+  }
+
+  @Test func `a renamed relation's virtual Id binds a bare key locally`()
+      throws {
+    // Finding H: `c`'s lone real column is `Id`, and `c` also vends the
+    // universal virtual `Id`. Renamed `FROM c AS t(x)`, the engine renames the
+    // real `Id` to `x` while `Schema.renamed` keeps the virtual `Id`
+    // addressable, so the bare `Id` in `WHERE Id > 0` binds `t`'s local virtual
+    // — the subquery counts `c`'s two rows, uncorrelated and constant. The
+    // Exposure derived its virtuals as `bindable − real`, which drops a name
+    // both real and virtual, so `expose` recorded only `{x}` and the bare `Id`
+    // was misclassified as the outer group key `T.Id`, correlating to its
+    // `*gwN` column and counting zero for the `T.Id = 0` group. Holding the
+    // virtuals explicitly keeps the virtual `Id`, so both groups count two,
+    // matching the ordinary `GROUP BY T.Id` form on both run and validate.
+    let sets = "SELECT (SELECT COUNT(*) FROM c AS t(x) WHERE Id > 0) AS n, " +
+               "ROW_NUMBER() OVER () FROM T GROUP BY GROUPING SETS ((T.Id))"
+    try renamed().expect(sets, yields: [[2, 1], [2, 2]])
+    #expect(try renamed().columns(of: parse(query: sets), validate: true)
+                .count == 2)
+    let plain = "SELECT (SELECT COUNT(*) FROM c AS t(x) WHERE Id > 0) AS n, " +
+                "ROW_NUMBER() OVER () FROM T GROUP BY T.Id"
+    try renamed().expect(plain, yields: [[2, 1], [2, 2]])
+  }
+
+  @Test func `the public Column initialiser mints a non-synthetic reference`() {
+    // `Column.synthetic` is minted only by the engine's internal initialiser
+    // (the windowed `GROUPING SETS` lift); the public initialiser no longer
+    // accepts the flag, so every user-constructed reference stays non-
+    // synthetic. The alias-collision cases above prove the internal minting
+    // still yields a distinct `synthetic` identity a quoted `"*gw0"` alias
+    // cannot forge.
+    #expect(Column(name: "dept").synthetic == false)
+    #expect(Column(qualifier: "e", name: "dept").synthetic == false)
+    #expect(Column("e.dept").synthetic == false)
   }
 
   // A single integer column whose name is literally `column 1` — the spelling
@@ -6626,5 +6901,149 @@ struct WindowOverGroupingSetsTests {
     try fixture().expect(sql, yields: [[1, 1], [2, 2], [3, 3], [nil, 4]])
     #expect(try fixture().columns(of: parse(query: sql), validate: true)
                 .count == 2)
+  }
+
+  // A relation to correlate over from a hosted subquery, and a relation whose
+  // input order differs from its name order so a mis-resolved ORDER BY is
+  // observable: input `Zed`, `Amy` sorts by name to `Amy`, `Zed`.
+  private func staffed() throws -> FixtureCatalog {
+    try Catalog {
+      Relation("employees", ["dept": .integer]) {
+        Row(1)
+        Row(2)
+      }
+      Relation("staff", ["name": .text]) {
+        Row("Zed")
+        Row("Amy")
+      }
+    }
+  }
+
+  @Test func `a hosted subquery ORDER BY on a lifted key ignores an alias`()
+      throws {
+    // The subquery's own `ORDER BY outer_q.dept` correlates the outer group
+    // key, rewritten to the synthetic `*gw0` union column; the subquery also
+    // projects a quoted `AS "*gw0"` alias spelling that same name. The ordinary
+    // and grouped output-alias resolvers once captured the alias and sorted by
+    // `s.name` — a run diverging from the validate walks (`Select.orderKeys`
+    // and `Windowed.order`), which skip a synthetic reference — picking `Amy`.
+    // Skipping alias capture for a synthetic key binds it structurally, so the
+    // constant group key orders `staff` in input order and `FETCH FIRST 1 ROW`
+    // takes `Zed`, matching the ordinary `GROUP BY dept` twin whose qualified
+    // `outer_q.dept` never rewrites and never collides.
+    let sets = "SELECT (SELECT s.name AS \"*gw0\" FROM staff s " +
+               "ORDER BY outer_q.dept FETCH FIRST 1 ROW ONLY), " +
+               "ROW_NUMBER() OVER () " +
+               "FROM employees AS outer_q GROUP BY GROUPING SETS ((dept))"
+    try staffed().expect(sets, yields: [["Zed", 1], ["Zed", 2]])
+    #expect(try staffed().columns(of: parse(query: sets), validate: true)
+                .count == 2)
+    let plain = "SELECT (SELECT s.name AS \"*gw0\" FROM staff s " +
+                "ORDER BY outer_q.dept FETCH FIRST 1 ROW ONLY), " +
+                "ROW_NUMBER() OVER () " +
+                "FROM employees AS outer_q GROUP BY dept"
+    try staffed().expect(sets, equals: plain)
+  }
+}
+
+/// A base relation exposing real columns plus optional extra virtual columns
+/// beyond the universal `Id` — a virtual foreign key a `USING`/`NATURAL` join
+/// merges, which the `SQLTestSupport` fixture (whose only virtual is `Id`)
+/// cannot express. Each row carries its real cells (`rows`) and its extra
+/// virtual cells (`keys`, aligned to `extras`).
+private struct KeyedRelation: Sendable {
+  let columns: Array<(name: String, type: ValueType)>
+  let extras: Array<String>
+  let rows: Array<Array<Value>>
+  let keys: Array<Array<Value>>
+}
+
+/// A catalog over `KeyedRelation`s, resolved case-insensitively by name.
+private struct KeyedCatalog: SQLEngine.Catalog {
+  let store: Array<(name: String, relation: KeyedRelation)>
+
+  init(_ store: Dictionary<String, KeyedRelation>) {
+    self.store = store.map { (name: $0.key, relation: $0.value) }
+  }
+
+  borrowing func table(named name: String) -> KeyedTable? {
+    let folded = name.lowercased()
+    for entry in store where entry.name.lowercased() == folded {
+      return KeyedTable(entry.relation)
+    }
+    return nil
+  }
+
+  borrowing func relations() -> Array<String> { store.map(\.name) }
+}
+
+/// A table over one `KeyedRelation` — its real columns at ordinals `0 ..<
+/// width`, the universal virtual `Id` at `width`, and each extra virtual at
+/// `width + 1 + i`.
+private struct KeyedTable: SQLEngine.Table {
+  let relation: KeyedRelation
+
+  init(_ relation: KeyedRelation) { self.relation = relation }
+
+  var width: Int { relation.columns.count }
+  var names: Array<String> { relation.columns.map(\.name) }
+  var types: Array<ValueType> { relation.columns.map(\.type) }
+  var virtuals: Array<String> { ["Id"] + relation.extras }
+  var extent: Int { width + 1 + relation.extras.count }
+
+  func ordinal(of name: String) -> Int? {
+    let folded = name.lowercased()
+    if let index = relation.columns.firstIndex(where: {
+          $0.name.lowercased() == folded }) {
+      return index
+    }
+    if folded == "id" { return width }
+    if let extra = relation.extras.firstIndex(where: {
+          $0.lowercased() == folded }) {
+      return width + 1 + extra
+    }
+    return nil
+  }
+
+  func bound(_ column: Int, _ value: Int, strict: Bool) -> Int? { nil }
+
+  borrowing func cursor() -> KeyedCursor { KeyedCursor(relation) }
+}
+
+/// An index-addressed cursor over a `KeyedRelation`'s rows.
+private struct KeyedCursor: SQLEngine.Cursor {
+  let relation: KeyedRelation
+
+  init(_ relation: KeyedRelation) { self.relation = relation }
+
+  var count: Int { relation.rows.count }
+
+  borrowing func row(_ index: Int) -> KeyedRow? {
+    index < relation.rows.count ? KeyedRow(relation, index) : nil
+  }
+}
+
+/// A positional view over one `KeyedRelation` row's cells — real, then the
+/// virtual `Id`, then each extra virtual.
+private struct KeyedRow: SQLEngine.Row {
+  let relation: KeyedRelation
+  let index: Int
+
+  init(_ relation: KeyedRelation, _ index: Int) {
+    self.relation = relation
+    self.index = index
+  }
+
+  subscript(_ column: Int) -> Value {
+    borrowing get {
+      let width = relation.columns.count
+      if column < width { return relation.rows[index][column] }
+      if column == width { return .integer(index + 1) }
+      let extra = column - width - 1
+      if extra < relation.keys[index].count {
+        return relation.keys[index][extra]
+      }
+      return .null
+    }
   }
 }


### PR DESCRIPTION
The lifted group-key references a hosted subquery carries must not collide with a user alias, and the scope a hosted body resolves against must expose every name the engine's own scope does. A lifted reference is a synthetic `Column` identity the run and the validate walks both except from ordinary alias capture, so a user alias sharing its spelling cannot bind it and a user reference to that alias still resolves normally. A CASE guard rewrite canonicalizes the group key the same way its scalar sibling does.

A derived `SELECT *` output now exposes the `NATURAL`/`USING` merged columns alongside the inputs' real columns, mirroring `Scope.expansion`: a merged column may be a virtual foreign key the real-column enumeration omits, so a bare reference to it in a hosted subquery binds the merged local column rather than being misclassified as the outer grouping key.