### PR TITLE
SQLEngine: support additional windowing

### DIFF
--- a/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
+++ b/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
@@ -1123,16 +1123,14 @@ private struct Lift {
     case let .nullif(lhs, rhs):
       return try .nullif(substitute(lhs), substitute(rhs))
     case let .case(whens, otherwise):
-      // A CASE nesting a window carries a per-row Predicate/window shape no
-      // `*gwN` column stands in for (#136), so defer it; a window-free CASE
-      // keeps its structure outer, its guards and branches recursed so only
-      // their grounded atoms lift to arm columns.
+      // A CASE keeps its structure outer, its guards and branches recursed so
+      // only their grounded atoms lift to arm columns. A nested window keeps
+      // that structure too: the window sits in the outer projection, gathered
+      // by the outer `collect(windows:)`, so the same recursion lowers it
+      // (#136) — the only shape it cannot handle is the stall fallback below,
+      // which arm-lifts the whole CASE to one grounded slot no window occupies.
       let windowed = whens.contains { $0.when.windowed || $0.then.windowed }
           || (otherwise?.windowed ?? false)
-      if windowed {
-        throw .state("0A000", "a window in a CASE with GROUPING SETS is not " +
-                              "yet supported")
-      }
       // A guard predicate's subquery whose bare group key is undecidable over
       // an opaque local blocks hosting and stalls the walk. No `*gwN` column
       // stands in for a whole predicate, so its own rewrite is moot; instead
@@ -1167,6 +1165,14 @@ private struct Lift {
         self.leaves = leaves
         self.index = index
         self.linked = linked
+        // The stall would arm-lift the whole CASE to one grounded slot, but no
+        // arm slot can hold a window — the arm's grouped scope computes one
+        // value per output, with no per-row window channel — so a windowed
+        // CASE that stalls faults cleanly rather than sinking one into an arm.
+        guard !windowed else {
+          throw .state("0A000", "a window in a CASE correlated to an opaque " +
+                       "local with GROUPING SETS is not yet supported")
+        }
         // The window-free CASE would arm-lift whole in place. Under genuinely
         // super-aggregating sets that lift traps — the grand-total `()` arm
         // carries no value for the omitted key the guard's correlation reads —

--- a/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
+++ b/SwiftSQL/Sources/SQLEngine/GroupingSets.swift
@@ -2008,19 +2008,45 @@ private struct Lift {
     case .number, .rank, .dense, .ntile, .percent, .cumulative:
       return function
     case let .aggregate(aggregate, operand, distinct, filter):
-      // A `FILTER` search condition is a `Predicate` no derived column stands
-      // in for; defer it rather than leave a base column unresolved.
-      guard filter == nil else {
-        throw .state("0A000",
-                     "a window FILTER with GROUPING SETS is not yet supported")
-      }
       let lifted: Aggregand = switch operand {
       case .star:
         .star
       case let .expression(expression):
         try .expression(substitute(expression))
       }
-      return .aggregate(aggregate, of: lifted, distinct: distinct)
+      // A `FILTER` search condition recurses through `substitute`, lifting its
+      // grounded group-key atoms to `*gwN` arm columns while literals and
+      // `:parameter`s ride inline — the same walk a `CASE` guard takes, so the
+      // lifted predicate threads back into the outer function. A `FILTER` may
+      // not itself contain an aggregate (`WindowFunction.check` faults the
+      // ordinary window path 42803); that check runs on the outer layer only
+      // after substitution, where the aggregate has become a `*gwN` column, so
+      // enforce the rule here on the original predicate to keep the two paths
+      // in parity. A subquery correlated to an opaque local cannot arm-lift — a
+      // window aggregate owns no arm slot — so it stalls the walk; fault
+      // cleanly then rather than emit an unresolved base column. The stall
+      // save/reset isolates this gate from an enclosing `CASE` catching its own
+      // stall.
+      let gate: Predicate?
+      if let filter {
+        guard !filter.aggregated else {
+          throw .state("42803", "an aggregate is not allowed in a FILTER")
+        }
+        let outer = stalled
+        stalled = false
+        let lowered = try substitute(filter)
+        guard !stalled else {
+          throw .state("0A000",
+                       "a window FILTER correlated to an opaque local with " +
+                       "GROUPING SETS is not yet supported")
+        }
+        stalled = outer
+        gate = lowered
+      } else {
+        gate = nil
+      }
+      return .aggregate(aggregate, of: lifted, distinct: distinct,
+                        filter: gate)
     case let .lead(value, offset, fallback):
       return try .lead(substitute(value), offset: offset,
                        default: substitute(fallback))

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -4734,16 +4734,117 @@ struct WindowOverGroupingSetsTests {
     #expect(other.count == 4)
   }
 
-  @Test func `a windowed CASE over GROUPING SETS is deferred`() throws {
-    // Preserving #136: a `CASE` nesting a window — `CASE WHEN dept = 1 THEN
-    // ROW_NUMBER() OVER () END` — is a per-row `Predicate`/window shape no
-    // `*gwN` column stands in for, so it still faults the feature diagnostic on
-    // both the run and validate paths, unchanged by the window-free `CASE`
-    // recursion this fix adds.
-    let sql = "SELECT CASE WHEN dept = 1 THEN ROW_NUMBER() OVER () END " +
-              "FROM Emp GROUP BY GROUPING SETS ((dept))"
+  @Test func `a windowed CASE over GROUPING SETS keeps its window outer`()
+      throws {
+    // A `CASE` nesting a window keeps its structure outer, its guards and
+    // branches recursed so only their grounded atoms lift to arm columns; the
+    // window sits in the outer projection, gathered by `collect(windows:)`.
+    // `CASE WHEN dept = 1 THEN ROW_NUMBER() OVER () END` lifts the guard's
+    // `dept` to a `*gwN` arm column and computes the window over the union: the
+    // per-set rows number 1, 2, 3 and the super-aggregate `()` row 4, but the
+    // branch value is taken only where `dept = 1` — dept 1's row (1), the rest
+    // NULL, the `()` row's NULL `dept` matching none. The ordinary `GROUP BY
+    // dept` twin reproduces the per-set rows.
+    try fixture().expect(
+        "SELECT CASE WHEN dept = 1 THEN ROW_NUMBER() OVER () END, dept " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 1], [nil, 2], [nil, 3], [nil, nil]])
+    try fixture().expect(
+        "SELECT CASE WHEN dept = 1 THEN ROW_NUMBER() OVER () END, dept " +
+        "FROM Emp GROUP BY dept",
+        yields: [[1, 1], [nil, 2], [nil, 3]])
+    let sql = "SELECT CASE WHEN dept = 1 THEN ROW_NUMBER() OVER () END, dept " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 2)
+  }
+
+  @Test func `a windowed CASE guard evaluates the window over the union`()
+      throws {
+    // The window may live in the guard, not only a branch: `CASE WHEN
+    // ROW_NUMBER() OVER () > 1 THEN dept ELSE 0 END` numbers the union rows
+    // 1..4 and tests each against 1. The first union row (dept 1) is not
+    // greater, taking the `ELSE 0`; the rest take `dept` — dept 2, dept 3, and
+    // the super-aggregate `()` row's NULL. The ordinary `GROUP BY dept` twin
+    // reproduces the per-set rows.
+    try fixture().expect(
+        "SELECT CASE WHEN ROW_NUMBER() OVER () > 1 THEN dept ELSE 0 END " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[0], [2], [3], [nil]])
+    try fixture().expect(
+        "SELECT CASE WHEN ROW_NUMBER() OVER () > 1 THEN dept ELSE 0 END " +
+        "FROM Emp GROUP BY dept",
+        yields: [[0], [2], [3]])
+  }
+
+  @Test func `a single-set windowed CASE matches the ordinary GROUP BY`()
+      throws {
+    // Over a single set the grouping-sets union is the ordinary `GROUP BY`
+    // relation, so a windowed `CASE` resolves identically. The sets form and
+    // its plain twin agree row for row, on the run path and (the tripwire) the
+    // validate path.
+    let sets = "SELECT CASE WHEN dept = 1 THEN ROW_NUMBER() OVER () END " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    let plain = "SELECT CASE WHEN dept = 1 THEN ROW_NUMBER() OVER () END " +
+                "FROM Emp GROUP BY dept"
+    try fixture().expect(sets, equals: plain)
+    #expect(try fixture().columns(of: parse(query: sets), validate: true)
+                .count == 1)
+  }
+
+  @Test func `a windowed CASE mixes an aggregate and a window branch`() throws {
+    // A `CASE` whose branches mix an aggregate and a window lifts each in its
+    // own channel: `CASE WHEN dept = 1 THEN SUM(sal) ELSE ROW_NUMBER() OVER ()
+    // END` lifts `SUM(sal)` to a `*gwN` arm column and computes the window over
+    // the union. Dept 1 takes its total (300); the rest, including the super-
+    // aggregate `()` row whose NULL `dept` matches none, take their union row
+    // number (2, 3, 4). The ordinary `GROUP BY dept` twin reproduces the per-
+    // set rows.
+    try fixture().expect(
+        "SELECT dept, CASE WHEN dept = 1 THEN SUM(sal) " +
+        "ELSE ROW_NUMBER() OVER () END " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 300], [2, 2], [3, 3], [nil, 4]])
+    try fixture().expect(
+        "SELECT dept, CASE WHEN dept = 1 THEN SUM(sal) " +
+        "ELSE ROW_NUMBER() OVER () END FROM Emp GROUP BY dept",
+        yields: [[1, 300], [2, 2], [3, 3]])
+  }
+
+  @Test func `a correlated windowed CASE guard hosts over the union`() throws {
+    // A windowed `CASE` whose guard nests an `EXISTS` correlated to the group
+    // key hosts through the union-scope `Resolution`, its qualified-free `dept`
+    // rewritten to the lifted union column — the same host the ordinary path
+    // takes over the determinable local `(SELECT * FROM U) o`. Each per-set arm
+    // gates on its own `dept` (all of 1, 2, 3 match a `U.v`, taking the row
+    // number) while the super-aggregate `()` row's NULL matches none (NULL);
+    // the window numbers across the union. The `GROUP BY dept` twin reproduces
+    // the per-set rows.
+    let body = "EXISTS (SELECT 1 FROM (SELECT * FROM U) o WHERE o.v = dept)"
+    let sets = "SELECT CASE WHEN \(body) THEN ROW_NUMBER() OVER () END " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    try colliding().expect(sets, yields: [[1], [2], [3], [nil]])
+    #expect(try colliding().columns(of: parse(query: sets), validate: true)
+                .count == 1)
+    try colliding().expect(
+        "SELECT CASE WHEN \(body) THEN ROW_NUMBER() OVER () END " +
+        "FROM Emp GROUP BY dept",
+        yields: [[1], [2], [3]])
+  }
+
+  @Test func `a rejected frame in a windowed CASE faults on both paths`()
+      throws {
+    // The compile-vs-validate parity gate: the compile path runs an explicit
+    // window frame check, and the validate twin must reach it too. A frame
+    // ending at UNBOUNDED PRECEDING is malformed; nested in a windowed `CASE`
+    // over GROUPING SETS it faults `42601` on the run path, and
+    // `columns(of:validate:true)` faults identically rather than accepting a
+    // shape the run rejects — parity holding without a validate-twin change.
+    let sql = "SELECT CASE WHEN dept = 1 THEN ROW_NUMBER() OVER (ORDER BY dept "
+            + "ROWS BETWEEN CURRENT ROW AND UNBOUNDED PRECEDING) END "
+            + "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
     let fault = SQLError.state(
-        "0A000", "a window in a CASE with GROUPING SETS is not yet supported")
+        "42601", "a window frame cannot end at UNBOUNDED PRECEDING")
     try fixture().expect(sql, fails: fault)
     #expect(throws: fault) {
       _ = try fixture().columns(of: parse(query: sql), validate: true)
@@ -5430,8 +5531,9 @@ struct WindowOverGroupingSetsTests {
     // its own `Emp`, an uncorrelated subquery, not the group key. Every group's
     // `dept` is in the subquery's `{1, 2, 3}`, so `CASE` yields 1 per group,
     // each numbered, matching the ordinary `GROUP BY dept` companion on run and
-    // validate. The windowed CASE value that still defers (#136) is covered by
-    // `a windowed CASE over GROUPING SETS is deferred` above.
+    // validate. A windowed CASE value now lowers too (#136), its window kept
+    // outer, covered by `a windowed CASE over GROUPING SETS keeps its window
+    // outer` above.
     let sets =
         "SELECT CASE WHEN dept IN (SELECT dept FROM Emp) " +
         "THEN 1 ELSE 0 END, ROW_NUMBER() OVER () " +

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -3916,14 +3916,128 @@ struct WindowOverGroupingSetsTests {
     }
   }
 
-  @Test func `a window FILTER over GROUPING SETS is deferred`() throws {
-    // An aggregate window's `FILTER` is a per-row `Predicate` no derived union
-    // column stands in for, so it remains deferred — faulting the feature
-    // diagnostic on both the run and validate paths, in parity.
-    let sql = "SELECT dept, SUM(sal) FILTER (WHERE sal > 0) OVER () " +
+  @Test func `a window FILTER over GROUPING SETS lifts its group keys`()
+      throws {
+    // An aggregate window's `FILTER` recurses the arm-union substitution walk:
+    // its grounded group-key atoms lift to `*gwN` arm columns, the outer window
+    // reading the lifted predicate over the union. `SUM(SUM(sal)) FILTER (WHERE
+    // dept <> 2) OVER ()` sums the per-set totals whose `dept` is not 2 — dept
+    // 1 (300) and dept 3 (500), 800 — over every union row; the super-aggregate
+    // `()` row, its `dept` rolled up to NULL, is UNKNOWN under `dept <> 2` and
+    // excluded, but the window value is 800 across all four rows, each numbered
+    // by the second window.
+    try fixture().expect(
+        "SELECT dept, SUM(SUM(sal)) FILTER (WHERE dept <> 2) OVER (), " +
+        "ROW_NUMBER() OVER () FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 800, 1], [2, 800, 2], [3, 800, 3], [nil, 800, 4]])
+    let sql = "SELECT dept, SUM(SUM(sal)) FILTER (WHERE dept <> 2) OVER (), " +
+              "ROW_NUMBER() OVER () " +
               "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
-    let fault = SQLError.state(
-        "0A000", "a window FILTER with GROUPING SETS is not yet supported")
+    #expect(try fixture().columns(of: parse(query: sql), validate: true)
+                .count == 3)
+  }
+
+  @Test func `a single-set window FILTER matches the ordinary GROUP BY`()
+      throws {
+    // Over a single set the grouping-sets union is the ordinary `GROUP BY`
+    // relation, so a group-key `FILTER` resolves identically — `FILTER (WHERE
+    // dept = 1)` gates the window input to dept 1's row (300), the window
+    // reporting 300 for every group. The sets form and its plain twin agree row
+    // for row, on the run path and (the tripwire) the validate path.
+    let sets = "SELECT SUM(SUM(sal)) FILTER (WHERE dept = 1) OVER () " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept))"
+    let plain = "SELECT SUM(SUM(sal)) FILTER (WHERE dept = 1) OVER () " +
+                "FROM Emp GROUP BY dept"
+    try fixture().expect(sets, equals: plain)
+    #expect(try fixture().columns(of: parse(query: sets), validate: true)
+                .count == 1)
+  }
+
+  @Test func `a super-aggregate window FILTER on a lifted key resolves`()
+      throws {
+    // The grand-total `()` arm NULL-extends the lifted key, so a `FILTER (WHERE
+    // dept = 1)` over `((dept), ())` gates on the lifted `dept` in every arm
+    // including the super-aggregate one — whose `dept` is NULL, UNKNOWN under
+    // `dept = 1` and excluded, exactly as the ordinary `GROUP BY dept` twin
+    // gates its own rows. The window sums dept 1's lone passing total (300)
+    // over all four union rows; the twin, lacking the `()` row, reports the
+    // three per-set rows the sets form reproduces.
+    try fixture().expect(
+        "SELECT dept, SUM(SUM(sal)) FILTER (WHERE dept = 1) OVER () " +
+        "FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 300], [2, 300], [3, 300], [nil, 300]])
+    try fixture().expect(
+        "SELECT dept, SUM(SUM(sal)) FILTER (WHERE dept = 1) OVER () " +
+        "FROM Emp GROUP BY dept",
+        yields: [[1, 300], [2, 300], [3, 300]])
+  }
+
+  @Test func `a window FILTER under an explicit frame accumulates`() throws {
+    // A `FILTER` composes with an explicit frame over the union: a running
+    // `ROWS UNBOUNDED PRECEDING → CURRENT ROW` frame ordered by the lifted
+    // `dept` accumulates only the rows the `FILTER (WHERE dept <> 2)` admits.
+    // NULLs order first, so the super-aggregate `()` row leads: its own
+    // contribution is UNKNOWN (excluded), leaving its running sum empty (NULL);
+    // dept 1 adds 300, dept 2 is excluded (still 300), dept 3 adds 500 (800) —
+    // reported in union output order.
+    try fixture().expect(
+        """
+        SELECT dept, SUM(SUM(sal)) FILTER (WHERE dept <> 2) OVER (ORDER BY dept
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+        FROM Emp GROUP BY GROUPING SETS ((dept), ())
+        """,
+        yields: [[1, 300], [2, 300], [3, 800], [nil, nil]])
+  }
+
+  @Test func `a window FILTER partitions by a lifted key`() throws {
+    // A `FILTER` composes with `PARTITION BY` a lifted key: each `dept` is its
+    // own partition, so `SUM(SUM(sal)) FILTER (WHERE dept <> 2)` sums only the
+    // admitted row within each partition. Dept 1 (300) and dept 3 (500) each
+    // report their own total; dept 2's partition admits no row (SUM over the
+    // empty set is NULL); the super-aggregate `()` partition, its NULL `dept`
+    // UNKNOWN under the filter, is empty too.
+    try fixture().expect(
+        "SELECT dept, SUM(SUM(sal)) FILTER (WHERE dept <> 2) " +
+        "OVER (PARTITION BY dept) FROM Emp GROUP BY GROUPING SETS ((dept), ())",
+        yields: [[1, 300], [2, nil], [3, 500], [nil, nil]])
+  }
+
+  @Test func `a correlated window FILTER subquery hosts over the union`()
+      throws {
+    // A `FILTER` nesting an `EXISTS` correlated to the group key hosts through
+    // the union-scope `Resolution`, its qualified-free `dept` rewritten to the
+    // lifted union column — the same host the ordinary path takes. Over the
+    // determinable local `(SELECT * FROM U) o`, `dept` decides the outer key,
+    // so each per-set arm gates on its own `dept` (all of 1, 2, 3 match a
+    // `U.v`, admitting 100, 300, 500) while the super-aggregate `()` row's NULL
+    // matches none; the window sums the admitted totals, 900, over each row.
+    // The ordinary `GROUP BY dept` twin reproduces the per-set rows.
+    let body = "EXISTS (SELECT 1 FROM (SELECT * FROM U) o WHERE o.v = dept)"
+    let sets = "SELECT dept, SUM(SUM(sal)) FILTER (WHERE \(body)) OVER () " +
+               "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    try colliding().expect(sets,
+                           yields: [[1, 900], [2, 900], [3, 900], [nil, 900]])
+    #expect(try colliding().columns(of: parse(query: sets), validate: true)
+                .count == 2)
+    try colliding().expect(
+        "SELECT dept, SUM(SUM(sal)) FILTER (WHERE \(body)) OVER () " +
+        "FROM Emp GROUP BY dept",
+        yields: [[1, 900], [2, 900], [3, 900]])
+  }
+
+  @Test func `an aggregate in a window FILTER over GROUPING SETS is rejected`()
+      throws {
+    // The parity the lift preserves: a `FILTER` may not itself contain an
+    // aggregate (ISO forbids one in a filter's search condition). The
+    // substitution rewrites a group-key atom to a `*gwN` column, so the outer
+    // `WindowFunction.check` would no longer see the aggregate; the lift
+    // enforces the rule on the original predicate instead, faulting 42803 as
+    // the ordinary grouped-window path does, on both the run and validate
+    // paths.
+    let sql = "SELECT SUM(SUM(sal)) FILTER (WHERE SUM(sal) > 400) OVER () " +
+              "FROM Emp GROUP BY GROUPING SETS ((dept), ())"
+    let fault = SQLError.state("42803",
+                               "an aggregate is not allowed in a FILTER")
     try fixture().expect(sql, fails: fault)
     #expect(throws: fault) {
       _ = try fixture().columns(of: parse(query: sql), validate: true)


### PR DESCRIPTION
This pull request significantly enhances support for window functions and CASE expressions in queries using GROUPING SETS in the SwiftSQL engine. The changes remove previous limitations, allowing window functions and CASE expressions to interact more naturally with grouping sets, and add comprehensive test coverage for these cases. The update also ensures that FILTER clauses in window aggregates properly lift group keys and that error handling is improved for unsupported or malformed queries.

**Improvements to window function and CASE support with GROUPING SETS:**

* Window functions inside CASE expressions and as FILTERs in aggregates now keep their structure "outer" and are properly handled across the grouping sets union, instead of being rejected or deferred. This allows queries like `CASE WHEN dept = 1 THEN ROW_NUMBER() OVER () END` or `SUM(SUM(sal)) FILTER (WHERE dept <> 2) OVER ()` to work as expected, with group keys lifted and windows evaluated over the union. [[1]](diffhunk://#diff-408a0f60943880d4f19f746d4f98a3b9783320907ffcef1c0c636c6cba9ac3a0L1126-L1135) [[2]](diffhunk://#diff-3cd6481332e34c7283dc06fba1d8a9f3a0d3e5e8f5bdc758155300c38690b39aL4623-R4847) [[3]](diffhunk://#diff-3cd6481332e34c7283dc06fba1d8a9f3a0d3e5e8f5bdc758155300c38690b39aL5319-R5536)

* FILTER clauses in window aggregates now recurse through substitution, lifting grounded group-key atoms to arm columns and enforcing that aggregates are not allowed within the FILTER predicate, matching SQL standard behavior.

**Improvements to error handling and edge cases:**

* When a windowed CASE or FILTER cannot be properly lifted due to correlation with an opaque local, the engine now throws a clear and specific error, rather than failing silently or deferring indefinitely. [[1]](diffhunk://#diff-408a0f60943880d4f19f746d4f98a3b9783320907ffcef1c0c636c6cba9ac3a0R1168-R1175) [[2]](diffhunk://#diff-408a0f60943880d4f19f746d4f98a3b9783320907ffcef1c0c636c6cba9ac3a0L2011-R2055)

* The engine now enforces that aggregates are not allowed inside FILTER predicates, throwing a standard SQL error code (`42803`) in these cases. [[1]](diffhunk://#diff-408a0f60943880d4f19f746d4f98a3b9783320907ffcef1c0c636c6cba9ac3a0L2011-R2055) [[2]](diffhunk://#diff-3cd6481332e34c7283dc06fba1d8a9f3a0d3e5e8f5bdc758155300c38690b39aL3919-R4040)

**Expanded and improved test coverage:**

* The test suite for window functions over grouping sets has been greatly expanded. It now covers correct behavior for windowed CASE expressions, FILTERs with group keys, explicit window frames, correlated subqueries in filters and guards, and proper error reporting for invalid cases. [[1]](diffhunk://#diff-3cd6481332e34c7283dc06fba1d8a9f3a0d3e5e8f5bdc758155300c38690b39aL3919-R4040) [[2]](diffhunk://#diff-3cd6481332e34c7283dc06fba1d8a9f3a0d3e5e8f5bdc758155300c38690b39aL4623-R4847)

These changes collectively make window function and CASE support with GROUPING SETS more robust, standards-compliant, and user-friendly.