### PR TITLE
winmd-inspect: closure rendering

### DIFF
--- a/Sources/SQLEngineWinMD/Database+SQL.swift
+++ b/Sources/SQLEngineWinMD/Database+SQL.swift
@@ -56,8 +56,10 @@ public import WinMD
 extension WinMD.Storage: SQLEngine.Catalog {
   /// The optional tables the bundled queries reference — tables ECMA-335 lets a
   /// database omit from the tables stream (`TypeSpec` §II.22.39 when nothing is
-  /// generic-instantiated, `NestedClass` §II.22.32 when nothing nests) that a
-  /// bundled view or the closure walk still names. `table(named:)` resolves an
+  /// generic-instantiated, `NestedClass` §II.22.32 when nothing nests,
+  /// `ClassLayout` §II.22.8 when no type declares an explicit layout or packing)
+  /// that a bundled view or the closure walk still names. `table(named:)`
+  /// resolves an
   /// absent one to an empty relation and `relations()` enumerates it, so a
   /// `SELECT … FROM` such a table reads no rows rather than faulting on a
   /// missing relation. Only these are synthesised — not the whole table
@@ -65,7 +67,8 @@ extension WinMD.Storage: SQLEngine.Catalog {
   /// physically-present tables plus the referenced optionals.
   private static var optionals: Array<(name: String, schema: TableSchema.Type)> {
     [(name: "TypeSpec", schema: Metadata.Tables.TypeSpec.self),
-     (name: "NestedClass", schema: Metadata.Tables.NestedClass.self)]
+     (name: "NestedClass", schema: Metadata.Tables.NestedClass.self),
+     (name: "ClassLayout", schema: Metadata.Tables.ClassLayout.self)]
   }
 
   /// The relation named `name`, resolved case-insensitively against the
@@ -1057,13 +1060,15 @@ extension WinMD.Storage {
   /// undecodable signature, or an unresolvable one.
   package borrowing func decode(return method: Int,
                                  generics: Array<String>? = nil,
-                                 in dialect: Dialect) -> String? {
+                                 in dialect: Dialect,
+                                 qualifying: Set<String> = []) -> String? {
     guard let table = opened("MethodDef") else { return nil }
     let cursor = WinMD.Cursor(copy self, table)
     guard let tuple = cursor[method - 1],
         let row = Row<Metadata.Tables.MethodDef>(tuple),
         let signature = try? row.prototype,
-        let resolver = try? Resolver(of: signature, with: self) else {
+        let resolver = try? Resolver(of: signature, with: self,
+                                     qualifying: qualifying) else {
       return nil
     }
     return signature.returns.decode(generics: generics, with: resolver,
@@ -1086,7 +1091,8 @@ extension WinMD.Storage {
   /// it, so threading it is always safe.
   package borrowing func decode(parameter: Int,
                                  generics: Array<String>? = nil,
-                                 for dialect: Dialect) -> String? {
+                                 for dialect: Dialect,
+                                 qualifying: Set<String> = []) -> String? {
     guard let table = opened("Param") else { return nil }
     let params = WinMD.Cursor(copy self, table)
     guard let param = params[parameter - 1],
@@ -1106,7 +1112,8 @@ extension WinMD.Storage {
     guard position >= 1, position <= signature.parameters.count else {
       return nil
     }
-    guard let resolver = try? Resolver(of: signature, with: self) else {
+    guard let resolver = try? Resolver(of: signature, with: self,
+                                       qualifying: qualifying) else {
       return nil
     }
     let name = param.ordinal(for: "Name").flatMap { try? param.string($0) }
@@ -1125,13 +1132,15 @@ extension WinMD.Storage {
   /// type through it. `nil` mirrors the same undecodable contract — an absent
   /// row, an undecodable signature, or an unresolvable one — so the walk can
   /// treat a malformed field as a frontier.
-  package borrowing func decode(field: Int, in dialect: Dialect) -> String? {
+  package borrowing func decode(field: Int, in dialect: Dialect,
+                                qualifying: Set<String> = []) -> String? {
     guard let table = opened("FieldDef") else { return nil }
     let cursor = WinMD.Cursor(copy self, table)
     guard let tuple = cursor[field - 1],
         let row = Row<Metadata.Tables.FieldDef>(tuple),
         let signature = try? row.declaration,
-        let resolver = try? Resolver(of: signature, with: self) else {
+        let resolver = try? Resolver(of: signature, with: self,
+                                     qualifying: qualifying) else {
       return nil
     }
     return signature.type.decode(with: resolver, dialect: dialect)
@@ -1178,26 +1187,42 @@ extension WinMD.Storage {
     return resolver.identities
   }
 
-  /// The integer value of the `Constant` row keyed to the `FieldDef` at 1-based
+  /// The decimal text of the `Constant` row keyed to the `FieldDef` at 1-based
   /// `field` `Id` — an enum member's raw value (ECMA-335 §II.22.9) — or `nil`
   /// when the field bears no constant or its value does not decode.
   ///
   /// An enum's member fields each carry a `Constant` row whose `Parent`
   /// (`HasConstant`) coded index names the `FieldDef` and whose `Value` `#Blob`
-  /// holds the literal, typed by the row's `Type` element type. The `Constant`
-  /// table is small and scanned: the row whose `Parent` decodes to the
-  /// `FieldDef` tag and this field's `Id` is the match, its little-endian value
-  /// blob widened to `Int` (sign-extended for a signed element type). A field
-  /// with no matching row — every non-literal field — yields `nil`.
-  package borrowing func value(field: Int) -> Int? {
+  /// holds the literal, typed by the row's `Type` element type. The match is the
+  /// row whose `Parent` decodes to the `FieldDef` tag and this field's `Id`, its
+  /// little-endian value blob formatted signed or unsigned per the element type
+  /// — so an unsigned 64-bit member with bit 63 set stays a positive `UInt64`
+  /// decimal, not a negative `Int` the generated `UInt64` raw value would reject.
+  /// A field with no matching row — every non-literal field — yields `nil`.
+  ///
+  /// `Parent` is the table's sort key (§II.22.9), so when this database stores
+  /// the table sorted the match is found by a binary search on the raw coded
+  /// `Parent` column rather than a full scan: a `FieldDef` `Id` `field` encodes
+  /// to the raw cell `(field << HasConstant.bits) | 0` — the tag of `FieldDef`
+  /// within `HasConstant` is `0` — and the sorted column's lower bound lands on
+  /// its unique row. The encoding is a bijection, so the bounded row is the exact
+  /// match; the found row's tag and row are re-verified regardless (a
+  /// belt-and-braces check that also rejects the near-miss the lower bound
+  /// returns when no row encodes `field`). An unsorted table falls back to the
+  /// linear scan, so behaviour is identical either way — a pure speedup.
+  package borrowing func value(field: Int) -> String? {
     guard let table = opened("Constant") else { return nil }
     let cursor = WinMD.Cursor(copy self, table)
-    for index in 0 ..< Int(table.rows) {
+    let count = Int(table.rows)
+    // The decoded literal of the `Constant` row at `index` when its `Parent`
+    // names this `FieldDef` — `nil` when it names another member or its value
+    // blob does not decode.
+    func constant(at index: Int) -> String? {
       guard let tuple = cursor[index],
-          let parent = tuple.ordinal(for: "Parent") else { continue }
+          let parent = tuple.ordinal(for: "Parent") else { return nil }
       // `HasConstant` selects `FieldDef` at tag 0; the row is the 1-based Id.
       let coded = HasConstant(rawValue: tuple[parent])
-      guard coded.tag == 0, coded.row == field else { continue }
+      guard coded.tag == 0, coded.row == field else { return nil }
       guard let column = tuple.ordinal(for: "Type"),
           let payload = tuple.ordinal(for: "Value"),
           let bytes = try? tuple.bytes(of: payload) else {
@@ -1207,15 +1232,32 @@ extension WinMD.Storage {
           CorElementType(rawValue: UInt8(truncatingIfNeeded: tuple[column]))
       return Storage.literal(bytes, of: element)
     }
+    // Sorted on the raw coded `Parent` key: seek the unique row that encodes
+    // this field (tag 0), matching the quantity the table is physically ordered
+    // by, then re-verify the decoded key on the bounded row.
+    if let key = table.schema.key,
+        sorted & (1 << table.schema.number) != 0 {
+      let encoded = (field << HasConstant.bits) | 0
+      let lower = bound(table, key, encoded, count, strict: false)
+      guard lower < count else { return nil }
+      return constant(at: lower)
+    }
+    // Unsorted: scan the whole table for the field's row.
+    for index in 0 ..< count {
+      if let value = constant(at: index) { return value }
+    }
     return nil
   }
 
-  /// The little-endian integer a constant `Value` blob's `bytes` encode for the
-  /// `element` type, sign-extended for a signed type — the reconstruction of an
-  /// enum member's raw value from its stored bytes. `nil` for a non-integer
-  /// element type or a blob too short for the type's width.
+  /// The decimal text of the little-endian integer a constant `Value` blob's
+  /// `bytes` encode for the `element` type — an enum member's raw value spelled
+  /// for the generated `rawValue:` literal. It is formatted signed or unsigned
+  /// per the element type, NOT funnelled through `Int`: an unsigned 64-bit value
+  /// with bit 63 set stays a positive `UInt64` decimal rather than turning into
+  /// a negative `Int`, which a `UInt64` raw value could not accept. `nil` for a
+  /// non-integer element type or a blob too short for the type's width.
   private static func literal(_ bytes: Array<UInt8>,
-                              of element: CorElementType) -> Int? {
+                              of element: CorElementType) -> String? {
     let width: Int
     let signed: Bool
     if element == .etInt1 { (width, signed) = (1, true) }
@@ -1237,6 +1279,10 @@ extension WinMD.Storage {
     if signed, width < 8, value & (1 << (width * 8 - 1)) != 0 {
       value |= ~UInt64(0) << (width * 8)
     }
-    return Int(bitPattern: UInt(value))
+    // Format per signedness: a signed element reinterprets the (sign-extended)
+    // bits as `Int64`, so a negative value spells with its minus sign; an
+    // unsigned one spells the `UInt64` directly, so a high-bit-set value stays
+    // positive rather than becoming a negative `Int` a `UInt64` rejects.
+    return signed ? String(Int64(bitPattern: value)) : String(value)
   }
 }

--- a/Sources/SQLEngineWinMD/Database+SQL.swift
+++ b/Sources/SQLEngineWinMD/Database+SQL.swift
@@ -1114,4 +1114,129 @@ extension WinMD.Storage {
         .decode(parameter: name, generics: generics, with: resolver,
                 dialect: dialect)
   }
+
+  /// The decoded type spelling of the `FieldDef` at 1-based `field` `Id`, in
+  /// `dialect`, or `nil` when the row or its signature does not decode.
+  ///
+  /// The `decode(return:in:)`/`decode(parameter:for:)` sibling for a field: it
+  /// opens the `FieldDef` row, decodes its `declaration` signature, builds a
+  /// `Resolver` over the storage, and spells the field's single `type`. The
+  /// render spells a struct's field (edge E6) and an enum's `value__` underlying
+  /// type through it. `nil` mirrors the same undecodable contract — an absent
+  /// row, an undecodable signature, or an unresolvable one — so the walk can
+  /// treat a malformed field as a frontier.
+  package borrowing func decode(field: Int, in dialect: Dialect) -> String? {
+    guard let table = opened("FieldDef") else { return nil }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[field - 1],
+        let row = Row<Metadata.Tables.FieldDef>(tuple),
+        let signature = try? row.declaration,
+        let resolver = try? Resolver(of: signature, with: self) else {
+      return nil
+    }
+    return signature.type.decode(with: resolver, dialect: dialect)
+  }
+
+  /// The distinct type identities named in the signature of the `MethodDef` at
+  /// 1-based `method` `Id` — the referenced-type set the closure walk enqueues
+  /// (edges E3/E7).
+  ///
+  /// It builds the same per-method `Resolver` the return/parameter decode does,
+  /// but returns the resolved references rather than a text spelling — each an
+  /// identity paired with the coded-index row it was named through, so the walk
+  /// resolves it to a local definition by its exact Id. An absent row, an
+  /// undecodable signature, or an unresolvable one yields the empty set, the
+  /// natural frontier — the walk enqueues nothing for it.
+  package borrowing func identities(method: Int) -> Set<Referent> {
+    guard let table = opened("MethodDef") else { return [] }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[method - 1],
+        let row = Row<Metadata.Tables.MethodDef>(tuple),
+        let signature = try? row.prototype,
+        let resolver = try? Resolver(of: signature, with: self) else {
+      return []
+    }
+    return resolver.identities
+  }
+
+  /// The distinct type identities named in the signature of the `FieldDef` at
+  /// 1-based `field` `Id` — the referenced-type set a struct's field contributes
+  /// to the closure walk (edge E6).
+  ///
+  /// The field sibling of `identities(method:)`: it builds a `Resolver` over
+  /// the field's `declaration` signature and returns its references, the empty
+  /// set on any undecodable row.
+  package borrowing func identities(field: Int) -> Set<Referent> {
+    guard let table = opened("FieldDef") else { return [] }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[field - 1],
+        let row = Row<Metadata.Tables.FieldDef>(tuple),
+        let signature = try? row.declaration,
+        let resolver = try? Resolver(of: signature, with: self) else {
+      return []
+    }
+    return resolver.identities
+  }
+
+  /// The integer value of the `Constant` row keyed to the `FieldDef` at 1-based
+  /// `field` `Id` — an enum member's raw value (ECMA-335 §II.22.9) — or `nil`
+  /// when the field bears no constant or its value does not decode.
+  ///
+  /// An enum's member fields each carry a `Constant` row whose `Parent`
+  /// (`HasConstant`) coded index names the `FieldDef` and whose `Value` `#Blob`
+  /// holds the literal, typed by the row's `Type` element type. The `Constant`
+  /// table is small and scanned: the row whose `Parent` decodes to the
+  /// `FieldDef` tag and this field's `Id` is the match, its little-endian value
+  /// blob widened to `Int` (sign-extended for a signed element type). A field
+  /// with no matching row — every non-literal field — yields `nil`.
+  package borrowing func value(field: Int) -> Int? {
+    guard let table = opened("Constant") else { return nil }
+    let cursor = WinMD.Cursor(copy self, table)
+    for index in 0 ..< Int(table.rows) {
+      guard let tuple = cursor[index],
+          let parent = tuple.ordinal(for: "Parent") else { continue }
+      // `HasConstant` selects `FieldDef` at tag 0; the row is the 1-based Id.
+      let coded = HasConstant(rawValue: tuple[parent])
+      guard coded.tag == 0, coded.row == field else { continue }
+      guard let column = tuple.ordinal(for: "Type"),
+          let payload = tuple.ordinal(for: "Value"),
+          let bytes = try? tuple.bytes(of: payload) else {
+        return nil
+      }
+      let element =
+          CorElementType(rawValue: UInt8(truncatingIfNeeded: tuple[column]))
+      return Storage.literal(bytes, of: element)
+    }
+    return nil
+  }
+
+  /// The little-endian integer a constant `Value` blob's `bytes` encode for the
+  /// `element` type, sign-extended for a signed type — the reconstruction of an
+  /// enum member's raw value from its stored bytes. `nil` for a non-integer
+  /// element type or a blob too short for the type's width.
+  private static func literal(_ bytes: Array<UInt8>,
+                              of element: CorElementType) -> Int? {
+    let width: Int
+    let signed: Bool
+    if element == .etInt1 { (width, signed) = (1, true) }
+    else if element == .etBoolean || element == .etUInt1 {
+      (width, signed) = (1, false)
+    } else if element == .etInt2 { (width, signed) = (2, true) }
+    else if element == .etChar || element == .etUInt2 {
+      (width, signed) = (2, false)
+    } else if element == .etInt4 { (width, signed) = (4, true) }
+    else if element == .etUInt4 { (width, signed) = (4, false) }
+    else if element == .etInt8 { (width, signed) = (8, true) }
+    else if element == .etUInt8 { (width, signed) = (8, false) }
+    else { return nil }
+    guard bytes.count >= width else { return nil }
+    var value: UInt64 = 0
+    for byte in 0 ..< width {
+      value |= UInt64(bytes[byte]) << (8 * byte)
+    }
+    if signed, width < 8, value & (1 << (width * 8 - 1)) != 0 {
+      value |= ~UInt64(0) << (width * 8)
+    }
+    return Int(bitPattern: UInt(value))
+  }
 }

--- a/Sources/SQLEngineWinMD/Resources/Queries/fields.sql
+++ b/Sources/SQLEngineWinMD/Resources/Queries/fields.sql
@@ -1,0 +1,8 @@
+CREATE VIEW fields AS
+SELECT
+  Id,
+  Name
+FROM
+  FieldDef
+WHERE
+  TypeDef = :parent

--- a/Sources/WinMD/Storage.swift
+++ b/Sources/WinMD/Storage.swift
@@ -224,4 +224,520 @@ public struct Storage: ~Escapable {
     }
     return nil
   }
+
+  // MARK: - Nesting
+
+  /// The lexically enclosing type of the type `tuple` names — its immediate
+  /// encloser — or `nil` when the type is top-level.
+  ///
+  /// A `TypeRef` nests through its `ResolutionScope`: a scope that is itself a
+  /// `TypeRef` is the enclosing reference, and any other scope (a `Module`, a
+  /// `ModuleRef`, or an `AssemblyRef`) makes the reference top-level. A
+  /// `TypeDef` nests through the `NestedClass` table (§II.22.32) — the
+  /// `EnclosingClass` of the row whose `NestedClass` names this definition,
+  /// found by binary search when the table is stored sorted on its key and by a
+  /// linear scan otherwise. Any other table has no enclosing and yields `nil`.
+  /// It is `package` so the synthesis decode and the render adapter compose one
+  /// nested type's dot-path from the same walk.
+  @_lifetime(copy self)
+  package func enclosing(_ tuple: borrowing Tuple)
+      throws(WinMDError) -> Tuple? {
+    // The enclosing tuple is opened off `self` (not off the borrowed `tuple`)
+    // so its lifetime tracks the storage rather than the shorter-lived
+    // argument, which is what a recursive walk returns through.
+    switch tuple.table.number {
+    case Metadata.Tables.TypeRef.number:
+      guard let scope = tuple.ordinal(for: "ResolutionScope") else {
+        return nil
+      }
+      // Tag 3 of `ResolutionScope` selects `TypeRef`: a scope that is itself a
+      // `TypeRef` is the enclosing reference; a `Module`/`ModuleRef`/
+      // `AssemblyRef` scope makes the reference top-level.
+      let coded = ResolutionScope(rawValue: tuple[scope])
+      guard coded.tag == 3, coded.row != 0 else { return nil }
+      return try self.tuple(coded.row - 1,
+                            of: Metadata.Tables.TypeRef.self)
+    case Metadata.Tables.TypeDef.number:
+      guard let table = opened(Metadata.Tables.NestedClass.number) else {
+        return nil
+      }
+      // The `NestedClass` (ordinal 0) column holds the 1-based `TypeDef` Id of
+      // the nested type; `EnclosingClass` (ordinal 1) its encloser.
+      let child = tuple.row + 1
+      let count = Int(table.rows)
+      if sorted & (1 << Metadata.Tables.NestedClass.number) != 0 {
+        let lower = bound(table, 0, child, count, strict: false)
+        guard lower < count, Tuple(lower, table, self)[0] == child else {
+          return nil
+        }
+        return try self.tuple(Tuple(lower, table, self)[1] - 1,
+                              of: Metadata.Tables.TypeDef.self)
+      }
+      for index in 0 ..< count where Tuple(index, table, self)[0] == child {
+        return try self.tuple(Tuple(index, table, self)[1] - 1,
+                              of: Metadata.Tables.TypeDef.self)
+      }
+      return nil
+    default:
+      return nil
+    }
+  }
+
+  /// The dot-path name of the type `tuple` names, from its outermost encloser —
+  /// `Foo.Bar` for a `Bar` nested under `Foo`, `Foo.Bar.Baz` for a deeper
+  /// nesting — or the bare `TypeName` for a top-level type.
+  ///
+  /// The components are joined raw (unescaped); a caller that spells the path
+  /// as target source escapes each component separately, so a keyword component
+  /// is delimited within the path rather than treated as one identifier.
+  package func qualified(_ tuple: borrowing Tuple)
+      throws(WinMDError) -> String {
+    let name = try bare(tuple)
+    guard let outer = try enclosing(tuple) else { return name }
+    return try qualified(outer) + "." + name
+  }
+
+  /// The enclosing `TypeDef` chain of the `TypeDef` at 1-based `id`, outermost
+  /// first — each an `(id, name)` pair — for the render to group a nested type
+  /// under a container per level. An empty array for a top-level type.
+  package func nesting(of id: Int)
+      throws(WinMDError) -> Array<(id: Int, name: String)> {
+    guard let tuple = try self.tuple(id - 1, of: Metadata.Tables.TypeDef.self),
+        let outer = try enclosing(tuple) else {
+      return []
+    }
+    return try nesting(of: outer.row + 1) + [(outer.row + 1, bare(outer))]
+  }
+
+  // MARK: - Kind and qualification
+
+  /// The projection kind of a named type — how the render spells and nests it.
+  ///
+  /// The partition is the one the SQL `types` view draws: an `interface` (the
+  /// `tdInterface` flag), a `delegate`/`structure`/`enumeration` (told apart by
+  /// the base its `Extends` names — `System.MulticastDelegate`/`System.ValueType`
+  /// /`System.Enum`), or a runtime `class` (anything else). Only a `structure`
+  /// or `enumeration` is a value type, spelled fully namespace-qualified and
+  /// nested; the rest spell by their bare name.
+  package enum Kind: Sendable, Equatable {
+    case interface
+    case delegate
+    case structure
+    case enumeration
+    case `class`
+
+    /// Whether the kind is a value type — a `structure` or an `enumeration` —
+    /// the render namespace-qualifies and nests, as opposed to a `protocol`
+    /// (`interface`/`delegate`) or a runtime `class` it spells bare.
+    package var value: Bool {
+      self == .structure || self == .enumeration
+    }
+  }
+
+  /// The projection kind of the `TypeDef` the `tuple` names, classified exactly
+  /// as the SQL `types` view does so the decode spelling and the emit nesting
+  /// agree from one source.
+  ///
+  /// The `tdInterface` flag (`0x20`) marks an interface regardless of its base;
+  /// otherwise the base type the `Extends` coded index names classifies the row
+  /// — `System.Enum` an enumeration, `System.MulticastDelegate` a delegate,
+  /// `System.ValueType` a structure, anything else (or no base) a runtime class.
+  package func kind(_ tuple: borrowing Tuple) throws(WinMDError) -> Kind {
+    if let flags = tuple.ordinal(for: "Flags"), tuple[flags] & 0x20 == 0x20 {
+      return .interface
+    }
+    guard let extends = tuple.ordinal(for: "Extends") else { return .class }
+    let base = TypeDefOrRef(rawValue: tuple[extends])
+    guard let parent = try resolve(base) else { return .class }
+    switch try names(parent) {
+    case ("System", "Enum"):              return .enumeration
+    case ("System", "MulticastDelegate"): return .delegate
+    case ("System", "ValueType"):         return .structure
+    default:                              return .class
+    }
+  }
+
+  /// The CLR namespace the value type at 1-based `id` nests under — the
+  /// namespace segments its fully-qualified spelling and its fabricated
+  /// namespace `enum` containers share.
+  ///
+  /// A nested type carries an empty `TypeNamespace`; the CLR namespace lives on
+  /// its outermost encloser, so the walk climbs the enclosing chain to that
+  /// outermost `TypeDef` and reads its namespace. A top-level type is its own
+  /// outermost, so this reads its own namespace. The empty string is the global
+  /// namespace, which fabricates no container.
+  package func namespace(of id: Int) throws(WinMDError) -> String {
+    let chain = try nesting(of: id)
+    let outermost = chain.first?.id ?? id
+    guard let tuple = try self.tuple(outermost - 1,
+                                     of: Metadata.Tables.TypeDef.self),
+        let space = tuple.ordinal(for: "TypeNamespace") else {
+      return ""
+    }
+    return try tuple.string(space)
+  }
+
+  /// The namespace-qualified render spelling of the named type `reference`
+  /// names, or `nil` when it spells by its bare (or enclosing) name — the
+  /// fallback a caller already applies for an unresolvable reference or a
+  /// non-ambiguous type.
+  ///
+  /// Qualification is collision-only: a value type spells its full CLR
+  /// namespace, enclosing-`TypeDef` dot-path, and own name
+  /// (`Windows.Win32.Foundation.Point`, `A.B.Outer.Inner`) — matching the
+  /// fabricated namespace `enum` and real container nesting the emit builds —
+  /// only when its simple `TypeName` is ambiguous, which the caller-supplied
+  /// `qualifying` set names (see `collisions()`).
+  ///
+  /// Qualification is applied to a value-type *identity*, not to a bare name:
+  /// only a value type is ever wrapped in a namespace container, so a reference
+  /// that shares the ambiguous name yet names an interface/delegate (a bare
+  /// `protocol`), a runtime `class`, or an external type (the consumer supplies
+  /// it bare) yields `nil` and keeps its bare name — else it would spell
+  /// `NS.Point` for a type no `NS.Point` declaration is emitted for. So it gates
+  /// on the reference's full `namespace.name`: `collisions()` records that
+  /// identity only for an ambiguous *value* type, so a same-named non-value
+  /// reference's identity is simply absent and the reference spells bare — with
+  /// no per-reference resolution.
+  ///
+  /// The bare-name membership test is the fast path, applied *before* forming the
+  /// identity: a reference whose bare (or outermost) name is not ambiguous
+  /// returns `nil` at once. The components join raw; a caller escapes each
+  /// separately.
+  package func spelling(of reference: TypeDefOrRef, qualifying: Set<String>)
+      throws(WinMDError) -> String? {
+    guard let resolved = try resolve(reference) else { return nil }
+    let (space, raw) = try names(resolved)
+    // The projected (arity-stripped) name, so a generic reference tests and
+    // spells the one name the emission carries — matching the collision tally.
+    let name = projected(raw)
+    // A top-level reference is its own outermost encloser: its own CLR namespace
+    // and name spell it, read straight off the resolved row — the fast path,
+    // with no enclosing walk. (A Module-scoped `TypeRef` shares its target's
+    // `(namespace, name)`, so the spelling agrees with the emit.) The bare name
+    // fast-rejects; the `namespace.rawName` identity confirms a value type of
+    // that *raw* name is ambiguous — keyed on the raw name, not the projected
+    // one, so a same-namespace generic protocol whose raw name carries an arity
+    // suffix does not borrow the value type's wrap; and `local` — following the
+    // `ResolutionScope` — confirms *this* reference resolves to that local
+    // definition, not an external `AssemblyRef`-scoped type of the same
+    // identity (which the closure drops as nonlocal, and must not spell as the
+    // wrapper).
+    if !space.isEmpty {
+      guard qualifying.contains(name),
+          qualifying.contains(space + "." + raw),
+          try local(reference) else { return nil }
+      return space + "." + name
+    }
+    // A nested (or global) reference carries an empty own namespace. It is
+    // already disambiguated by its enclosing dot-path, so qualify only when its
+    // outermost encloser's name is ambiguous — climbing the reference's own
+    // enclosing chain (cheap along a `TypeRef` scope chain). The outermost's
+    // namespace prefixes the reference's enclosing dot-path, and its
+    // `namespace.rawName` identity confirms the outermost is a value type —
+    // keyed on the raw name, so a same-named generic type does not borrow it.
+    let outer = try outermost(resolved)
+    let (root, outerRaw) = try names(outer)
+    let outerName = projected(outerRaw)
+    let identity = root.isEmpty ? outerRaw : root + "." + outerRaw
+    guard qualifying.contains(outerName), qualifying.contains(identity),
+        try local(reference) else { return nil }
+    let path = try qualified(resolved)
+    return root.isEmpty ? path : root + "." + path
+  }
+
+  /// Whether `reference` resolves to a definition in this module — a `TypeDef`,
+  /// or a `TypeRef` whose `ResolutionScope` chain terminates at the `Module`,
+  /// not a `ModuleRef`/`AssemblyRef` (an external assembly). A qualified
+  /// spelling is a local ambiguous value type's namespace path, so an external
+  /// reference sharing that `(namespace, name)` — which the closure's SQL drops
+  /// as nonlocal — must not take it, or the signature would bind the unrelated
+  /// local wrapper (or an undefined name) instead of the consumer-supplied
+  /// external type. This follows the scope chain only, not the `toplevel`/
+  /// `nested` definition scan, so it confirms locality in O(depth) without the
+  /// per-reference table walk.
+  private func local(_ reference: TypeDefOrRef) throws(WinMDError) -> Bool {
+    guard let tuple = try resolve(reference) else { return false }
+    switch tuple.table.number {
+    case Metadata.Tables.TypeDef.number:
+      return true
+    case Metadata.Tables.TypeRef.number:
+      return try local(reference: tuple)
+    default:
+      return false
+    }
+  }
+
+  /// Whether the `TypeRef` `tuple`'s `ResolutionScope` chain is local — a
+  /// `TypeRef`-scoped (tag 3) nested reference whose enclosing reference is
+  /// local, or a `Module`-scoped (tag 0) top-level reference. A `ModuleRef`/
+  /// `AssemblyRef`, or a null scope, is external.
+  private func local(reference tuple: borrowing Tuple)
+      throws(WinMDError) -> Bool {
+    guard let ordinal = tuple.ordinal(for: "ResolutionScope") else {
+      return false
+    }
+    let scope = ResolutionScope(rawValue: tuple[ordinal])
+    if scope.tag == 3, scope.row != 0 {
+      guard let enclosing = try self.tuple(scope.row - 1,
+                                           of: Metadata.Tables.TypeRef.self)
+      else { return false }
+      return try local(reference: enclosing)
+    }
+    return scope.tag == 0 && scope.row != 0
+  }
+
+  /// The outermost encloser of the type `tuple` names — the top of its nesting
+  /// chain, itself when top-level — reached by climbing `enclosing`. The result
+  /// is opened off `self`, so its lifetime tracks the storage.
+  @_lifetime(copy self)
+  private func outermost(_ tuple: borrowing Tuple)
+      throws(WinMDError) -> Tuple {
+    guard let up = try enclosing(tuple) else {
+      return Tuple(tuple.row, tuple.table, self)
+    }
+    return try outermost(up)
+  }
+
+  /// The namespace-qualification sets a collision-only render keys off, computed
+  /// in one scan so neither the decode nor the emit repeats the work per
+  /// reference.
+  ///
+  /// The projection is one flat top-level Swift scope: an interface or delegate
+  /// is a bare `protocol`, a runtime `class` and an external reference are bare
+  /// frontiers the consumer supplies, and only a value type
+  /// (`structure`/`enumeration`) can be wrapped — in a fabricated namespace
+  /// `enum` — to disambiguate. A value type's simple `TypeName` is therefore
+  /// ambiguous when two or more distinct top-level `TypeDef`s bear it *of any
+  /// kind* — a second value type, an interface/delegate, or a runtime class —
+  /// because spelled bare it would clash with that other top-level declaration.
+  /// When it is, the value type — and any type nested under it — is spelled and
+  /// emitted namespace-qualified, while the colliding protocol/class stays bare
+  /// (a bare `protocol Point` and a wrapped `NS.Point` no longer clash).
+  ///
+  /// Only top-level definitions are counted: a nested type is already
+  /// disambiguated by its enclosing-type dot-path (`Foo.Bar`) and never occupies
+  /// the top-level scope, so qualification keys off the outermost encloser's
+  /// name, which the nested count would only pollute. This also keeps the
+  /// ubiquitous anonymous nested record names — Win32 gives every one the same
+  /// generated `_Anonymous_e__…`, yet each is unique under its distinct
+  /// encloser — out of the tally, so a nested record stays bare
+  /// (`VARIANT._Anonymous_e__Struct`) rather than drowning the projection in
+  /// namespace paths.
+  ///
+  /// The scan tallies every top-level `TypeDef` name and derives from a name's
+  /// multiplicity:
+  /// - `names`: the ambiguous top-level `TypeName`s, so the decode gates its
+  ///   namespace-qualification on an O(1) membership test of a reference's own
+  ///   (or outermost encloser's) name before it resolves the reference's kind;
+  /// - `ids`: the ambiguous *value-type* `TypeDef` `Id`s alone — the only kind
+  ///   the emit wraps in a namespace `enum` — so a colliding protocol or class,
+  ///   which the emit leaves bare, is absent (a nested value type nests under
+  ///   its encloser regardless).
+  ///
+  /// `reached`, when non-nil, restricts the tally to the `TypeDef` `Id`s in
+  /// it — the declarations a `--closure` render actually emits — so a name is
+  /// ambiguous only among the reached set. An unreachable definition never
+  /// becomes a Swift declaration, so it cannot clash with one: leaving it out
+  /// keeps a closure from wrapping (and possibly faulting) a value type on
+  /// account of a same-named type the closure does not emit. A nil `reached`
+  /// (the flat render, which emits the whole assembly) tallies every top-level
+  /// `TypeDef`.
+  package func collisions(among reached: Set<Int>? = nil)
+      throws(WinMDError) -> (names: Set<String>, ids: Set<Int>) {
+    guard let table = opened(Metadata.Tables.TypeDef.number) else {
+      return ([], [])
+    }
+    // The nested `TypeDef` Ids, read once from `NestedClass` (its ordinal-0
+    // column is the nested type's Id), so a top-level test is an O(1) membership
+    // check rather than a per-row `enclosing` scan of a relation that need not be
+    // sorted — which would make this whole scan quadratic.
+    var nested = Set<Int>()
+    if let relation = opened(Metadata.Tables.NestedClass.number) {
+      for row in 0 ..< Int(relation.rows) {
+        nested.insert(Tuple(row, relation, self)[0])
+      }
+    }
+    // Each top-level value `TypeDef` as its `Id`, CLR namespace, and simple
+    // name, with a tally of how many distinct top-level types — of any kind —
+    // bear each name.
+    var values = Array<(id: Int, space: String, name: String, raw: String)>()
+    var counts = Dictionary<String, Int>()
+    for row in 0 ..< Int(table.rows) {
+      let tuple = Tuple(row, table, self)
+      guard !nested.contains(tuple.row + 1) else { continue }
+      // A closure render tallies only the declarations it emits: an unreachable
+      // top-level type is skipped, so it cannot make a reached name ambiguous.
+      if let reached, !reached.contains(tuple.row + 1) { continue }
+      let (space, raw) = try names(tuple)
+      // Tally the projected (arity-stripped) name, not the raw `TypeName`, so a
+      // generic `Foo` backtick `1` collides with a non-generic `Foo` exactly as
+      // the two project to the one emitted `Foo`.
+      let name = projected(raw)
+      counts[name, default: 0] += 1
+      if try kind(tuple).value {
+        values.append((tuple.row + 1, space, name, raw))
+      }
+    }
+    // A name two or more top-level types bear is ambiguous: its value-type
+    // bearers gate the decode spelling and the emit wrap, while a colliding
+    // protocol or class stays bare. `names` carries two kinds of token, disjoint
+    // by shape so one set threads to every seam: a bare ambiguous `TypeName` (no
+    // dot) drives the decode's O(1) fast-reject and name lookups, and an
+    // ambiguous value type's full `namespace.name` identity (dotted) gates the
+    // value-aware qualification — a same-named protocol, class, or external
+    // reference, whose identity is absent, spells bare with no per-reference
+    // resolution.
+    var names = Set<String>()
+    var ids = Set<Int>()
+    for value in values where (counts[value.name] ?? 0) >= 2 {
+      names.insert(value.name)
+      // The identity keys off the *raw* `TypeName`, not the projected one, so a
+      // value type `A.Foo` and a same-namespace generic protocol `A.Foo` +
+      // arity — which the projected name collapses to one identity — stay
+      // distinct: only the value type's raw identity is here, so a reference to
+      // the generic protocol (whose raw name carries the arity suffix) does not
+      // match and stays bare, while the value type qualifies. The counting
+      // above still uses the projected name, so the two collide and the value
+      // type wraps.
+      names.insert(value.space.isEmpty ? value.raw
+                                       : value.space + "." + value.raw)
+      ids.insert(value.id)
+    }
+    return (names, ids)
+  }
+
+  /// The local `TypeDef` the named type `reference` resolves to, or `nil` when
+  /// it names no local definition.
+  ///
+  /// A `TypeDef` reference already names a local definition. A `TypeRef` resolves
+  /// through its `ResolutionScope` chain — a module-scoped reference to the
+  /// non-nested `TypeDef` of the same (namespace, name), a `TypeRef`-scoped
+  /// (nested) reference to the nested `TypeDef` under the local definition its
+  /// enclosing reference resolves to — exactly the walk the render's `references`
+  /// CTE performs. A reference whose chain terminates at a `ModuleRef` or
+  /// `AssemblyRef` (an external assembly) resolves to nothing; a `TypeSpec`
+  /// names no definition.
+  @_lifetime(copy self)
+  package func definition(of reference: TypeDefOrRef)
+      throws(WinMDError) -> Tuple? {
+    guard let tuple = try resolve(reference) else { return nil }
+    switch tuple.table.number {
+    case Metadata.Tables.TypeDef.number:
+      return tuple
+    case Metadata.Tables.TypeRef.number:
+      return try definition(reference: tuple)
+    default:
+      return nil
+    }
+  }
+
+  /// The local `TypeDef` the `TypeRef` `tuple` resolves to through its
+  /// `ResolutionScope` chain, or `nil` when the reference is external.
+  @_lifetime(copy self)
+  private func definition(reference tuple: borrowing Tuple)
+      throws(WinMDError) -> Tuple? {
+    guard let ordinal = tuple.ordinal(for: "ResolutionScope") else {
+      return nil
+    }
+    let scope = ResolutionScope(rawValue: tuple[ordinal])
+    let target = try names(tuple)
+    // A `TypeRef`-scoped (tag 3) reference is nested: resolve its enclosing
+    // reference to a local `TypeDef`, then match the nested `TypeDef` directly
+    // under it by `TypeName` — a nested type's namespace is empty, so the match
+    // is by name under the encloser, never by namespace.
+    if scope.tag == 3, scope.row != 0 {
+      guard let enclosing = try self.tuple(scope.row - 1,
+                                           of: Metadata.Tables.TypeRef.self),
+          let encloser = try definition(reference: enclosing) else {
+        return nil
+      }
+      return try nested(target.name, in: encloser.row + 1)
+    }
+    // A `Module`-scoped (tag 0) reference is local and top-level; any other
+    // scope — a `ModuleRef`/`AssemblyRef`, or a null scope — is external.
+    guard scope.tag == 0, scope.row != 0 else { return nil }
+    return try toplevel(target.namespace, target.name)
+  }
+
+  /// The non-nested local `TypeDef` named (`namespace`, `name`), or `nil` — the
+  /// anchor a module-scoped reference resolves to.
+  @_lifetime(copy self)
+  private func toplevel(_ namespace: String, _ name: String)
+      throws(WinMDError) -> Tuple? {
+    guard let table = opened(Metadata.Tables.TypeDef.number) else { return nil }
+    for row in 0 ..< Int(table.rows) {
+      let tuple = Tuple(row, table, self)
+      let (space, simple) = try names(tuple)
+      guard space == namespace, simple == name else { continue }
+      // A nested type shares a bare (namespace, name) with a top-level one only
+      // by coincidence, and the empty namespace collapses every nested type's
+      // pair — so the module-scoped reference names the non-nested definition.
+      switch try enclosing(tuple) {
+      case .none: return tuple
+      case .some: continue
+      }
+    }
+    return nil
+  }
+
+  /// The local nested `TypeDef` named `name` directly under the `TypeDef` at
+  /// 1-based `encloser` `Id`, or `nil` — the nested reference's resolution step.
+  @_lifetime(copy self)
+  private func nested(_ name: String, in encloser: Int)
+      throws(WinMDError) -> Tuple? {
+    guard let table = opened(Metadata.Tables.NestedClass.number) else {
+      return nil
+    }
+    // The `NestedClass` column (ordinal 0) is the nested `TypeDef` Id, the
+    // `EnclosingClass` column (ordinal 1) its encloser.
+    for index in 0 ..< Int(table.rows) {
+      let link = Tuple(index, table, self)
+      guard link[1] == encloser else { continue }
+      guard let child = try self.tuple(link[0] - 1,
+                                       of: Metadata.Tables.TypeDef.self) else {
+        continue
+      }
+      if try bare(child) == name { return child }
+    }
+    return nil
+  }
+
+  /// The bare `TypeName` of the type `tuple` names — the empty string when it
+  /// carries no such column.
+  private func bare(_ tuple: borrowing Tuple) throws(WinMDError) -> String {
+    guard let name = tuple.ordinal(for: "TypeName") else { return "" }
+    return try tuple.string(name)
+  }
+
+  /// A `TypeName` with its CLR generic-arity suffix removed — the projected
+  /// declaration name the render actually emits and the decode spells. The
+  /// suffix is a backtick and an arity count (`Foo` backtick `1`), which the
+  /// projection strips, so a generic `Foo` and a non-generic `Foo` project to
+  /// the one Swift name and collide. The collision tally and the qualification
+  /// identity key off this projected name so they match the emission; a name
+  /// without the suffix is returned unchanged.
+  private func projected(_ name: String) -> String {
+    String(name.prefix { $0 != "`" })
+  }
+
+  /// The (namespace, name) the `TypeDef`/`TypeRef` `tuple` names — the empty
+  /// string for either column it lacks.
+  private func names(_ tuple: borrowing Tuple)
+      throws(WinMDError) -> (namespace: String, name: String) {
+    let name = try bare(tuple)
+    guard let space = tuple.ordinal(for: "TypeNamespace") else {
+      return ("", name)
+    }
+    return (try tuple.string(space), name)
+  }
+
+  /// The open table numbered `number`, or `nil` when the database omits it —
+  /// the population-count slot lookup `rows(of:)`/`tuple(_:of:)` share, reduced
+  /// to the `Table` for a direct row read.
+  private func opened(_ number: Int) -> Table? {
+    guard valid & (1 << number) != 0 else { return nil }
+    let slot = (valid & ((1 << number) - 1)).nonzeroBitCount
+    return tables[slot]
+  }
 }

--- a/Sources/WinMDSynthesis/Decode.swift
+++ b/Sources/WinMDSynthesis/Decode.swift
@@ -426,11 +426,30 @@ extension TypeDefOrRef {
     if identity == kGuid {
       return classification(parameter, dialect: dialect)
     }
-    // A named type's simple name is a bare identifier that may collide with a
-    // target keyword (`protocol`, `repeat`); escape it as the render escapes a
-    // declaration name. A well-known spelling is curated and never a keyword.
-    return dialect.known[identity] ?? dialect.escape(identity.name)
+    // A well-known spelling (a Win32 primitive, curated and never a keyword)
+    // wins first, keyed on the `Identity` — so a known value type keeps its
+    // target name rather than a namespace-qualified path. Otherwise the type
+    // spells through its kind-aware path: a local value type's
+    // namespace-qualified `Namespace.…Name` (from `resolver.spelling(of:)`), or
+    // — for a protocol, a runtime class, or an unresolvable reference the
+    // resolver holds no spelling for — the bare `Identity` name it did before.
+    // Either is a possibly dot-pathed identifier escaped per component
+    // (`dialect.escape` escapes one identifier, so a keyword component like
+    // `repeat` is delimited within the path rather than the whole treated as a
+    // single name); a top-level name has no dot and escapes unchanged.
+    if let known = dialect.known[identity] { return known }
+    return qualify(resolver.spelling(of: self) ?? identity.name, dialect)
   }
+}
+
+/// Escapes a possibly dot-pathed named-type spelling per component through
+/// `dialect`, rejoining with `.` — so a nested type (`Foo.repeat`) escapes each
+/// identifier in turn (`` Foo.`repeat` ``) rather than the path as a whole. A
+/// top-level name (no dot) escapes as the single identifier it is.
+private func qualify(_ name: String, _ dialect: Dialect) -> String {
+  name.split(separator: ".", omittingEmptySubsequences: false)
+      .map { dialect.escape(String($0)) }
+      .joined(separator: ".")
 }
 
 /// The `System.Guid` identity that decodes to `IID`/`CLSID`.
@@ -467,10 +486,21 @@ extension SignatureType {
     // opaque pointer; a generic over it is meaningless, so degrade to that
     // opaque pointer rather than emit `UnsafeMutableRawPointer<…>`.
     if base == dialect.opaque { return base }
-    // Strip the CLR arity suffix, THEN escape the base identifier: the full
-    // `Foo``1` never matches a keyword, so a keyword base (`protocol``1`) must
-    // be escaped after the strip, not before, to spell `` `protocol`<…> ``.
-    let name = dialect.escape(String(base.prefix { $0 != "`" }))
+    // Strip the CLR arity suffix from the base's leaf component, then escape
+    // each dotted component independently through the same `qualify` discipline
+    // the non-generic path uses: the full `Foo``1` never matches a keyword, so
+    // a keyword base must be escaped after the strip, not before. Escaping the
+    // whole dotted string would spare a keyword leaf under a namespace-qualified
+    // base (`Outer.protocol``1` strips to `Outer.protocol`, which is not itself
+    // a keyword), spelling the invalid `Outer.protocol<…>`; escaping per
+    // component delimits the leaf (`Outer.`protocol`<…>`), so the generic and
+    // non-generic paths escape identically.
+    var components =
+        base.split(separator: ".", omittingEmptySubsequences: false)
+            .map(String.init)
+    components[components.count - 1] =
+        String(components[components.count - 1].prefix { $0 != "`" })
+    let name = qualify(components.joined(separator: "."), dialect)
     let arguments = arguments
         .map { $0.decode(parameter: parameter, generics: generics,
                          with: resolver, dialect: dialect) }

--- a/Sources/WinMDSynthesis/Resolver.swift
+++ b/Sources/WinMDSynthesis/Resolver.swift
@@ -101,8 +101,35 @@ public struct Resolver: TypeResolver {
   /// The pre-resolved `rawValue → Identity` table.
   private let table: Dictionary<Int, Identity>
 
+  /// The pre-resolved `rawValue → namespace-qualified spelling` table — an
+  /// ambiguous value type's full namespace path alone (see
+  /// `Storage.spelling(of:qualifying:)`). A reference absent here — a
+  /// non-ambiguous value type, a protocol/class, a database-free resolver, or
+  /// one built over an unresolvable reference — spells by its `Identity` name,
+  /// the bare-or-enclosing behaviour that predates namespace preservation.
+  private let spellings: Dictionary<Int, String>
+
+  /// The coded indices `table` holds that occur *only* as a custom modifier,
+  /// never as an ordinary type — kept in `table` for the decode's `IsConst`
+  /// resolution but excluded from `identities`, since the generated signature
+  /// never spells a modifier type. A token that also occurs ordinarily is not
+  /// here, so its ordinary occurrence still enqueues its declaration.
+  private let modifiers: Set<Int>
+
   public init(_ table: Dictionary<Int, Identity>) {
     self.table = table
+    self.spellings = [:]
+    self.modifiers = []
+  }
+
+  /// Builds a resolver over the pre-resolved tables — the storage-backed
+  /// initializers' shared destination.
+  private init(_ table: Dictionary<Int, Identity>,
+               _ spellings: Dictionary<Int, String>,
+               _ modifiers: Set<Int>) {
+    self.table = table
+    self.spellings = spellings
+    self.modifiers = modifiers
   }
 
   /// Builds the `rawValue → Identity` table from a decoded signature, resolved
@@ -118,11 +145,16 @@ public struct Resolver: TypeResolver {
   /// (which resolves a single method's signature on demand) share one
   /// collection. A reference that does not resolve — a `TypeSpec`, a null index
   /// — is left out, and `Decode` renders an opaque pointer for it.
-  package init(of signature: MethodSignature,
-               with storage: borrowing Storage) throws(WinMDError) {
+  package init(of signature: MethodSignature, with storage: borrowing Storage,
+               qualifying: Set<String> = []) throws(WinMDError) {
     var table = Dictionary<Int, Identity>()
-    try collect(signature, into: &table, with: storage)
-    self.init(table)
+    var spellings = Dictionary<Int, String>()
+    var spelled = Set<Int>()
+    var modifiers = Set<Int>()
+    try collect(signature, into: &table, spelling: &spellings,
+                spelled: &spelled, modifiers: &modifiers, with: storage,
+                qualifying: qualifying)
+    self.init(table, spellings, modifiers.subtracting(spelled))
   }
 
   /// Builds the `rawValue → Identity` table from a decoded field signature,
@@ -134,11 +166,16 @@ public struct Resolver: TypeResolver {
   /// the field's type names (directly or nested under a pointer, array, or
   /// instantiation). A closure walk over a struct's fields (edge E6) resolves a
   /// field's named value type exactly the way it resolves a method parameter.
-  package init(of signature: FieldSignature,
-               with storage: borrowing Storage) throws(WinMDError) {
+  package init(of signature: FieldSignature, with storage: borrowing Storage,
+               qualifying: Set<String> = []) throws(WinMDError) {
     var table = Dictionary<Int, Identity>()
-    try collect(signature.type, into: &table, with: storage)
-    self.init(table)
+    var spellings = Dictionary<Int, String>()
+    var spelled = Set<Int>()
+    var modifiers = Set<Int>()
+    try collect(signature.type, into: &table, spelling: &spellings,
+                spelled: &spelled, modifiers: &modifiers, with: storage,
+                qualifying: qualifying)
+    self.init(table, spellings, modifiers.subtracting(spelled))
   }
 
   /// The distinct references the table holds — every type a signature named,
@@ -150,11 +187,21 @@ public struct Resolver: TypeResolver {
   /// referenced types without re-walking it, then resolves each — by its `token`
   /// row, not its name — to a local `TypeDef` and enqueues the unvisited.
   public var identities: Set<Referent> {
-    Set(table.map { Referent(identity: $0.value, token: $0.key) })
+    Set(table.filter { !modifiers.contains($0.key) }
+        .map { Referent(identity: $0.value, token: $0.key) })
   }
 
   public func resolve(_ reference: TypeDefOrRef, kind: NamedKind) -> Identity? {
     table[reference.rawValue]
+  }
+
+  /// The namespace-qualified render spelling `reference` was pre-resolved to,
+  /// or `nil` when it names no ambiguous local value type (or the resolver
+  /// carries no spellings) — the signal the decode falls back to the
+  /// reference's bare-or-enclosing `Identity` name. Populated only by the
+  /// storage-backed initializers, from `Storage.spelling(of:qualifying:)`.
+  public func spelling(of reference: TypeDefOrRef) -> String? {
+    spellings[reference.rawValue]
   }
 }
 
@@ -177,47 +224,115 @@ extension Tuple {
   }
 }
 
-/// Resolves every `TypeDefOrRef` `signature` names into `table`.
+/// Resolves every `TypeDefOrRef` `signature` names into the tables, recording
+/// each ordinary (spelled) occurrence in `spelled` and each custom-modifier
+/// occurrence in `modifiers`.
 private func collect(_ signature: MethodSignature,
                      into table: inout Dictionary<Int, Identity>,
-                     with storage: borrowing Storage) throws(WinMDError) {
-  try collect(signature.returns, into: &table, with: storage)
+                     spelling spellings: inout Dictionary<Int, String>,
+                     spelled: inout Set<Int>, modifiers: inout Set<Int>,
+                     with storage: borrowing Storage,
+                     qualifying: Set<String>) throws(WinMDError) {
+  try collect(signature.returns, into: &table, spelling: &spellings,
+              spelled: &spelled, modifiers: &modifiers, with: storage,
+              qualifying: qualifying)
   for parameter in signature.parameters {
-    try collect(parameter, into: &table, with: storage)
+    try collect(parameter, into: &table, spelling: &spellings,
+                spelled: &spelled, modifiers: &modifiers, with: storage,
+                qualifying: qualifying)
   }
 }
 
-/// Resolves every `TypeDefOrRef` `type` names into `table`, recursively.
+/// Resolves every `TypeDefOrRef` `type` names into the tables, recursively,
+/// recording each ordinary occurrence in `spelled` and each custom-modifier
+/// occurrence in `modifiers`, so the closure walk can omit a token used *only*
+/// as a modifier: such a type stays in `table` for the decode's `IsConst`
+/// check, but the generated signature never names it (a non-`IsConst` modifier
+/// is
+/// ignored, `IsConst` only changes pointer constness), so enqueuing it would
+/// emit an orphan. A token that also occurs as an ordinary type is spelled and
+/// so kept — subtracting every token ever seen as a modifier would drop it.
 private func collect(_ type: SignatureType,
                      into table: inout Dictionary<Int, Identity>,
-                     with storage: borrowing Storage) throws(WinMDError) {
+                     spelling spellings: inout Dictionary<Int, String>,
+                     spelled: inout Set<Int>, modifiers: inout Set<Int>,
+                     with storage: borrowing Storage,
+                     qualifying: Set<String>) throws(WinMDError) {
   switch type {
   case .primitive, .variable, .function:
     break
   case let .pointer(pointee), let .reference(pointee),
        let .array(pointee), let .matrix(pointee, _):
-    try collect(pointee, into: &table, with: storage)
+    try collect(pointee, into: &table, spelling: &spellings, spelled: &spelled,
+                modifiers: &modifiers, with: storage, qualifying: qualifying)
   case let .named(_, reference):
-    try record(reference, into: &table, with: storage)
+    try record(reference, into: &table, spelling: &spellings, with: storage,
+               qualifying: qualifying)
+    spelled.insert(reference.rawValue)
   case let .instance(base, arguments):
-    try collect(base, into: &table, with: storage)
+    try collect(base, into: &table, spelling: &spellings, spelled: &spelled,
+                modifiers: &modifiers, with: storage, qualifying: qualifying)
     for argument in arguments {
-      try collect(argument, into: &table, with: storage)
+      try collect(argument, into: &table, spelling: &spellings,
+                  spelled: &spelled, modifiers: &modifiers, with: storage,
+                  qualifying: qualifying)
     }
-  case let .modified(inner, modifiers):
-    try collect(inner, into: &table, with: storage)
-    for modifier in modifiers {
-      try record(modifier.type, into: &table, with: storage)
+  case let .modified(inner, modifiers: mods):
+    try collect(inner, into: &table, spelling: &spellings, spelled: &spelled,
+                modifiers: &modifiers, with: storage, qualifying: qualifying)
+    for modifier in mods {
+      try record(modifier.type, into: &table, spelling: &spellings,
+                 with: storage, qualifying: qualifying)
+      modifiers.insert(modifier.type.rawValue)
     }
   }
 }
 
-/// Resolves a single `TypeDefOrRef` to its `Identity` and records it.
+/// Resolves a single `TypeDefOrRef` to its `Identity` and its kind-aware
+/// spelling and records both.
 private func record(_ reference: TypeDefOrRef,
                     into table: inout Dictionary<Int, Identity>,
-                    with storage: borrowing Storage) throws(WinMDError) {
+                    spelling spellings: inout Dictionary<Int, String>,
+                    with storage: borrowing Storage,
+                    qualifying: Set<String>) throws(WinMDError) {
   guard table[reference.rawValue] == nil else { return }
   guard let tuple = try storage.resolve(reference) else { return }
   guard let identity = try tuple.identity else { return }
-  table[reference.rawValue] = identity
+  // The `Identity` still carries the type's own namespace and the enclosing
+  // dot-path (`Foo.Bar`), the key the decode's well-known and `System.Guid`
+  // lookups resolve on — and the bare-or-enclosing spelling the decode falls
+  // back to when no namespace-qualified spelling rides alongside. A spelling is
+  // recorded only for an ambiguous value type (its name in `qualifying`): its
+  // full namespace-qualified path (`Storage.spelling(of:qualifying:)`), which
+  // the decode prefers. A non-ambiguous type, a protocol/class, and an external
+  // `TypeRef` record no spelling and keep spelling by this `Identity` name — the
+  // bare-or-enclosing behaviour that predates namespaces.
+  let name = try storage.qualified(tuple)
+  table[reference.rawValue] =
+      Identity(namespace: identity.namespace, name: name)
+  // Only a value type whose (outermost encloser's) name is ambiguous is spelled
+  // namespace-qualified; the bare-or-enclosing `name` above serves every other
+  // type. `Storage.spelling(of:qualifying:)` is the single source of that
+  // decision — it applies the O(1) ambiguity test and, only then, resolves the
+  // reference to confirm its definition is a value type (a protocol, a runtime
+  // class, or an external `TypeRef` sharing the ambiguous name stays bare). An
+  // earlier inline fast path here recomputed the top-level case from the
+  // `identity` alone and, spelling it directly, skipped that value-type check,
+  // qualifying a same-named protocol or class to a phantom `NS.Point`.
+  //
+  // The guard here is only a pre-filter on *whether* to call `spelling`, never a
+  // second copy of the decision: a top-level reference (a non-empty own
+  // namespace) whose leaf name is not ambiguous cannot qualify — `spelling`
+  // tests that very name first and would return `nil` — so skipping the call is
+  // exactly equivalent and spares the resolution for the common bare reference.
+  // A nested or global reference (an empty own namespace) qualifies off its
+  // outermost encloser's name, which the leaf `identity.name` does not reveal,
+  // so it always defers to `spelling`'s chain walk.
+  guard identity.namespace.isEmpty || qualifying.contains(identity.name) else {
+    return
+  }
+  if let spelling =
+      try storage.spelling(of: reference, qualifying: qualifying) {
+    spellings[reference.rawValue] = spelling
+  }
 }

--- a/Sources/WinMDSynthesis/Resolver.swift
+++ b/Sources/WinMDSynthesis/Resolver.swift
@@ -22,6 +22,61 @@ public struct Identity: Sendable, Hashable {
   }
 }
 
+/// A signature-referenced type paired with the coded-index row the signature
+/// named it through — the `TypeDefOrRef` `rawValue` (its tag and 1-based row).
+///
+/// The `identity` still spells the type (namespace and name); the `token` is
+/// what lets a closure walk resolve the reference to a local definition by
+/// binding the exact `TypeRef`/`TypeDef` Id rather than matching on the name. A
+/// bare name mislocates: two nested types share the empty namespace and a bare
+/// name, and an external `TypeRef` may share a local type's (namespace, name)
+/// yet resolve elsewhere. Binding the row instead routes a `TypeDef` straight to
+/// its definition and a `TypeRef` through the scope-chain resolution the local
+/// resolution needs. A `TypeSpec` names no identity, so a `Resolver` never holds
+/// one — every `Referent` is a `TypeDef` or a `TypeRef`.
+public struct Referent: Sendable, Hashable {
+  /// Which table the coded index names — a local `TypeDef` a caller resolves by
+  /// its Id directly, or a `TypeRef` it resolves through the scope chain. A
+  /// `Resolver` never holds a `TypeSpec` (which names no identity), so a
+  /// reference is one or the other.
+  public enum Kind: Sendable, Hashable {
+    case definition
+    case reference
+  }
+
+  /// The resolved spelling identity — the type's namespace and name.
+  public let identity: Identity
+
+  /// The `TypeDefOrRef` coded-index raw value the signature named the type
+  /// through; `kind` and `row` decode it.
+  public let token: Int
+
+  public init(identity: Identity, token: Int) {
+    self.identity = identity
+    self.token = token
+  }
+
+  /// The decoded coded index — its `tag` selects the table and its `row` is the
+  /// 1-based Id a caller binds to resolve the reference to a local definition.
+  public var coded: TypeDefOrRef {
+    TypeDefOrRef(rawValue: token)
+  }
+
+  /// Whether the reference names a local `TypeDef` directly or a `TypeRef` the
+  /// caller resolves through the scope chain, keyed off the coded index's
+  /// selected table rather than a hard-coded tag.
+  public var kind: Kind {
+    TypeDefOrRef.tables[coded.tag]?.number == Metadata.Tables.TypeDef.number
+        ? .definition : .reference
+  }
+
+  /// The 1-based Id the reference names in the table `kind` selects — the
+  /// `TypeDef` Id for a definition, the `TypeRef` Id for a reference.
+  public var row: Int {
+    coded.row
+  }
+}
+
 /// Resolves a `TypeDefOrRef` (with its `NamedKind`) to an `Identity`.
 ///
 /// The decode tier is injected with a resolver so it needs no live database: a
@@ -68,6 +123,34 @@ public struct Resolver: TypeResolver {
     var table = Dictionary<Int, Identity>()
     try collect(signature, into: &table, with: storage)
     self.init(table)
+  }
+
+  /// Builds the `rawValue → Identity` table from a decoded field signature,
+  /// resolved against a borrowed `Storage` — the field-signature sibling of the
+  /// method-signature initializer.
+  ///
+  /// A field carries a single `type`, so this reuses the same `collect` walk the
+  /// method initializer runs over each parameter, resolving every `TypeDefOrRef`
+  /// the field's type names (directly or nested under a pointer, array, or
+  /// instantiation). A closure walk over a struct's fields (edge E6) resolves a
+  /// field's named value type exactly the way it resolves a method parameter.
+  package init(of signature: FieldSignature,
+               with storage: borrowing Storage) throws(WinMDError) {
+    var table = Dictionary<Int, Identity>()
+    try collect(signature.type, into: &table, with: storage)
+    self.init(table)
+  }
+
+  /// The distinct references the table holds — every type a signature named,
+  /// each paired with the coded-index row it was named through.
+  ///
+  /// The table keys by coded-index raw value, so one `Referent` is yielded per
+  /// distinct `TypeDefOrRef` the signature carries; two uses of the same coded
+  /// row collapse to one. A closure walk reads this to enumerate a signature's
+  /// referenced types without re-walking it, then resolves each — by its `token`
+  /// row, not its name — to a local `TypeDef` and enqueues the unvisited.
+  public var identities: Set<Referent> {
+    Set(table.map { Referent(identity: $0.value, token: $0.key) })
   }
 
   public func resolve(_ reference: TypeDefOrRef, kind: NamedKind) -> Identity? {

--- a/Sources/winmd-inspect/Resources/Render/fields.sql
+++ b/Sources/winmd-inspect/Resources/Render/fields.sql
@@ -1,10 +1,19 @@
 -- A struct's fields, in declaration order, through the `fields` view bound by
 -- the struct's `Id` — each field's `Id` (for the render to decode its type from
--- its `FieldDef` signature) and its keyword-escaped `Name`. The render spells
--- each field's type at render time from the target `Dialect`, so the query
--- projects only the identity and name, the way `params` does for a method.
+-- its `FieldDef` signature), its keyword-escaped `Name`, its `Flags`, and its
+-- raw (unsanitized) metadata name. The render spells each field's type
+-- at render time from the target `Dialect`, so the query projects the identity
+-- and name the way `params` does for a method; the `Flags` let the struct
+-- render drop a static or literal field (the `fdStatic` bit), which is not
+-- instance storage, while the enum render (which reads the same view for its
+-- members) keeps them. The raw name lets the enum render find its `value__`
+-- storage field by its metadata name, unaffected by a `SANITIZE` override that
+-- would change the escaped spelling the way a member's does.
 SELECT
-  Id,
-  SANITIZE(Name) AS Name
+  f.Id,
+  SANITIZE(f.Name) AS Name,
+  d.Flags AS Flags,
+  f.Name AS Raw
 FROM
-  fields
+  fields f
+  JOIN FieldDef d ON d.Id = f.Id

--- a/Sources/winmd-inspect/Resources/Render/fields.sql
+++ b/Sources/winmd-inspect/Resources/Render/fields.sql
@@ -1,0 +1,10 @@
+-- A struct's fields, in declaration order, through the `fields` view bound by
+-- the struct's `Id` — each field's `Id` (for the render to decode its type from
+-- its `FieldDef` signature) and its keyword-escaped `Name`. The render spells
+-- each field's type at render time from the target `Dialect`, so the query
+-- projects only the identity and name, the way `params` does for a method.
+SELECT
+  Id,
+  SANITIZE(Name) AS Name
+FROM
+  fields

--- a/Sources/winmd-inspect/Resources/Render/flags.sql
+++ b/Sources/winmd-inspect/Resources/Render/flags.sql
@@ -1,0 +1,53 @@
+-- Whether the enum `TypeDef` at `:parent` bears a `System.FlagsAttribute`
+-- custom attribute — the `[flags]` marking that makes the enum a bitmask. It
+-- returns the enum's `Id` when the attribute is present and no row otherwise,
+-- so the render projects a `[flags]` enum as an `OptionSet` (its members
+-- combine) and a plain enum as a native fixed-size Swift `enum`.
+--
+-- The attribute is matched by its (namespace, name) the way `guid.sql` and the
+-- `interfaces` view match `GuidAttribute` — through the three encodings a
+-- `CustomAttribute` names its constructor by: a `MemberRef` to a `TypeRef` (an
+-- external reference, the shape real metadata uses for `System.FlagsAttribute`),
+-- a `MethodDef` on the attribute `TypeDef` (a local definition), and a
+-- `MemberRef` to a `TypeDef` (a `MemberRef` naming a local definition). Only the
+-- namespace and name differ from `guid.sql`: `System.FlagsAttribute`, not the
+-- Win32 metadata `GuidAttribute`.
+--
+-- `CustomAttribute`/`MemberRef` are present in real metadata; a fixture that
+-- omits the matching rows simply yields no row, so the enum reads as not a
+-- `[flags]` enum — the same graceful non-match the `guid` query relies on.
+SELECT
+  t.Id AS flags
+FROM
+  TypeDef t
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.Id
+  JOIN MemberRef r ON c.Type_MemberRef = r.Id
+  JOIN TypeRef g ON r.Class_TypeRef = g.Id
+WHERE
+  g.TypeNamespace = 'System'
+  AND g.TypeName = 'FlagsAttribute'
+  AND t.Id = :parent
+UNION
+SELECT
+  t.Id AS flags
+FROM
+  TypeDef t
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.Id
+  JOIN MethodDef m ON c.Type_MethodDef = m.Id
+  JOIN TypeDef g ON m.TypeDef = g.Id
+WHERE
+  g.TypeNamespace = 'System'
+  AND g.TypeName = 'FlagsAttribute'
+  AND t.Id = :parent
+UNION
+SELECT
+  t.Id AS flags
+FROM
+  TypeDef t
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.Id
+  JOIN MemberRef r ON c.Type_MemberRef = r.Id
+  JOIN TypeDef g ON r.Class_TypeDef = g.Id
+WHERE
+  g.TypeNamespace = 'System'
+  AND g.TypeName = 'FlagsAttribute'
+  AND t.Id = :parent

--- a/Sources/winmd-inspect/Resources/Render/invoke.sql
+++ b/Sources/winmd-inspect/Resources/Render/invoke.sql
@@ -1,0 +1,11 @@
+-- A delegate's `Invoke` method, through the `methods` view bound by the
+-- delegate's `Id`. A WinRT delegate is a `TypeDef` whose signature lives on its
+-- `Invoke` method (its `.ctor` aside); selecting that one method's `Id` gives
+-- the render the signature to decode as the delegate's parameters and return
+-- (edge E7), the same way an interface method is decoded.
+SELECT
+  Id
+FROM
+  methods
+WHERE
+  Name = 'Invoke'

--- a/Sources/winmd-inspect/Resources/Render/layout.sql
+++ b/Sources/winmd-inspect/Resources/Render/layout.sql
@@ -1,0 +1,43 @@
+-- Whether the value type at `:parent` has an ABI layout the `@frozen` struct
+-- projection cannot faithfully reproduce: it returns the type's `Id` when the
+-- type must be rejected, no row when it renders safely.
+--
+-- Only a sequential layout is safe. The `0x18` LayoutMask (§II.23.1.15) marks a
+-- value type auto (`0x00`), sequential (`0x08` tdSequentialLayout), or explicit
+-- (`0x10` tdExplicitLayout). An auto layout lets the runtime lay the fields out
+-- in whatever order it chooses, so their declaration (FieldDef) order need not
+-- be their memory order — a Swift `struct`, which lays its stored properties out
+-- in source order, would then mismatch. An explicit layout places fields at
+-- declared offsets — an overlapping union or a hand-laid record — which a Swift
+-- `struct` cannot express. Only a sequential layout guarantees the fields lie in
+-- declaration order at their natural offsets, the one arrangement a `struct`
+-- reproduces, so the check admits `0x08` alone and rejects auto, explicit, and
+-- the reserved `0x18`.
+--
+-- A non-default packing (a `ClassLayout` row whose `PackingSize` is not zero)
+-- tightens the fields below their natural alignment, shifting every offset past
+-- the first. A declared size (a `ClassLayout` row whose `ClassSize` is not zero,
+-- §II.22.8) fixes the total in-memory extent — padding the record out to a
+-- larger size, or forcing tail padding a naturally-laid struct would not carry —
+-- which no `@frozen` `struct` reproduces either. `@frozen` only freezes the
+-- layout Swift itself chooses; it applies neither an explicit offset, a packing,
+-- nor a declared size, so such a type would decode to the wrong size and field
+-- offsets when passed to a native API. The closure walk rejects a type this
+-- query returns a row for, leaving it a frontier the consumer defines rather
+-- than an ABI-incompatible declaration. A `ClassSize` of zero is unspecified
+-- (the natural size stands), so it is safe; any non-zero declared size is
+-- rejected conservatively.
+--
+-- `ClassLayout` is an optional table (`table(named:)` resolves it to an empty
+-- relation when absent), so a database with no laid-out type reads no packing or
+-- size row and the LEFT JOIN yields NULL, which `COALESCE` treats as the default.
+SELECT
+  t.Id
+FROM
+  TypeDef t
+  LEFT JOIN ClassLayout c ON c.Parent = t.Id
+WHERE
+  t.Id = :parent
+  AND (BITAND(t.Flags, 24) <> 8
+       OR COALESCE(c.PackingSize, 0) <> 0
+       OR COALESCE(c.ClassSize, 0) <> 0)

--- a/Sources/winmd-inspect/Resources/Render/members.sql
+++ b/Sources/winmd-inspect/Resources/Render/members.sql
@@ -1,0 +1,13 @@
+-- An enum's members, through the `fields` view bound by the enum's `Id` — every
+-- `FieldDef` row save the `value__` instance field, which is not a member but
+-- the enum's underlying storage (its type spells the enum's raw-value type,
+-- decoded separately). Each surviving row is a member: its `Id` (for the render
+-- to read its constant value from the `Constant` table) and its keyword-escaped
+-- `Name`.
+SELECT
+  Id,
+  SANITIZE(Name) AS Name
+FROM
+  fields
+WHERE
+  Name <> 'value__'

--- a/Sources/winmd-inspect/Resources/Render/references.sql
+++ b/Sources/winmd-inspect/Resources/Render/references.sql
@@ -1,0 +1,77 @@
+-- Resolve a signature-referenced type to its local `types` row for the closure
+-- walk to classify and enqueue. A signature names a type through a
+-- `TypeDefOrRef`, and the walk binds that reference's row rather than its
+-- (namespace, name): a bare name conflates two nested types (which share the
+-- empty namespace) and mislocates an external `TypeRef` that shares a local
+-- type's identity.
+--
+-- The `TypeRef` arm resolves through the shared `resolved(ref, def)` fragment —
+-- byte-identical to the one `requires.sql` carries — which follows the
+-- reference's `ResolutionScope` chain: a reference is local only when its chain
+-- terminates at the `Module`. The anchor matches a top-level, module-scoped
+-- reference (`ResolutionScope_Module` non-null, `ResolutionScope_TypeRef` null)
+-- to a non-nested local `TypeDef` by (namespace, name); the recursive arm
+-- matches a nested reference (`ResolutionScope_TypeRef` non-null) to the local
+-- nested `TypeDef` under the enclosing `TypeDef` its enclosing reference already
+-- resolved to — by `TypeName` under that enclosing, never by namespace, which is
+-- empty for a nested type. A reference whose chain terminates at an
+-- `AssemblyRef` or `ModuleRef` never reaches the anchor, so an external
+-- `TypeRef`-only reference resolves to nothing and is the natural frontier. The
+-- caller binds the referenced `TypeRef` Id as `:ref`.
+--
+-- The `TypeDef` arm resolves a reference that already names a local definition
+-- by its exact `Id`, bound as `:def` — no chain to walk. The caller binds
+-- whichever of `:ref`/`:def` the reference's coded-index tag selects and leaves
+-- the other NULL, so exactly one arm matches (a NULL key matches no row).
+--
+-- Either arm joins the resolved local `TypeDef` to the `types` view, keeping
+-- only a type that resolves locally, and brings the `iid` in from the
+-- `interfaces` view for a referenced interface (NULL for a value type, which
+-- carries none). The `types` view's `kind` routes the row to the right template
+-- section (interface/struct/enum/delegate), so the row shape matches the
+-- `interfaces`/`requires` selections the walk emits through.
+WITH RECURSIVE resolved(ref, def) AS (
+  SELECT r.Id, d.Id
+  FROM
+    TypeRef r
+    JOIN TypeDef d
+      ON d.TypeNamespace = r.TypeNamespace
+      AND d.TypeName = r.TypeName
+  WHERE
+    r.ResolutionScope_TypeRef IS NULL
+    AND r.ResolutionScope_Module IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM NestedClass nc WHERE nc.NestedClass = d.Id
+    )
+  UNION
+  SELECT r.Id, d.Id
+  FROM
+    resolved e
+    JOIN TypeRef r ON r.ResolutionScope_TypeRef = e.ref
+    JOIN NestedClass nc ON nc.EnclosingClass = e.def
+    JOIN TypeDef d ON d.Id = nc.NestedClass AND d.TypeName = r.TypeName
+)
+SELECT
+  t.Id,
+  t.TypeNamespace,
+  t.TypeName,
+  i.iid,
+  t.kind
+FROM
+  resolved rv
+  JOIN types t ON t.Id = rv.def
+  LEFT JOIN interfaces i ON i.Id = t.Id
+WHERE
+  rv.ref = :ref
+UNION
+SELECT
+  t.Id,
+  t.TypeNamespace,
+  t.TypeName,
+  i.iid,
+  t.kind
+FROM
+  types t
+  LEFT JOIN interfaces i ON i.Id = t.Id
+WHERE
+  t.Id = :def

--- a/Sources/winmd-inspect/Resources/Render/requires.sql
+++ b/Sources/winmd-inspect/Resources/Render/requires.sql
@@ -54,7 +54,8 @@ SELECT
   n.Id,
   n.TypeNamespace,
   n.TypeName,
-  n.iid
+  n.iid,
+  'interface' AS kind
 FROM
   InterfaceImpl i
   JOIN resolved rv ON rv.ref = i.Interface_TypeRef
@@ -66,7 +67,8 @@ SELECT
   n.Id,
   n.TypeNamespace,
   n.TypeName,
-  n.iid
+  n.iid,
+  'interface' AS kind
 FROM
   InterfaceImpl i
   JOIN interfaces n ON n.Id = i.Interface_TypeDef

--- a/Sources/winmd-inspect/Resources/Templates/com.mustache
+++ b/Sources/winmd-inspect/Resources/Templates/com.mustache
@@ -1,4 +1,5 @@
 {{! language: swift }}
+{{#interface}}
 {{#generic}}
 // A WinRT parameterised interface has no static IID: its IID is a
 // per-instantiation PIID computed at runtime from the type
@@ -30,3 +31,95 @@ public protocol {{{name}}}{{#base}}: {{{.}}}{{/base}} {
 {{/methods}}
 }
 {{/generic}}
+{{/interface}}
+{{#struct}}
+// @frozen fixes the ABI layout, so the projected struct is the C/C++ record it
+// mirrors field for field — the transparent layout interop passes by value.
+@frozen public struct {{{name}}} {
+{{#fields}}
+    public var {{{name}}}: {{{type}}}
+{{/fields}}
+
+    // The synthesized memberwise initializer is internal even for a public
+    // struct, so an explicit public one lets a caller outside the generated
+    // module construct the value type to pass to a native API.
+    public init({{#fields}}{{{name}}}: {{{type}}}{{^last}}, {{/last}}{{/fields}}) {
+{{#fields}}
+        self.{{{name}}} = {{{name}}}
+{{/fields}}
+    }
+}
+{{/struct}}
+{{#enum}}
+{{#flags}}
+{{! A `[flags]` enum projects to an OptionSet the way ClangImporter imports an
+    NS_OPTIONS C enum: its members combine as a bitmask, which a native `enum`
+    case — a single value — cannot name. `RawValue` is the enum's `value__`
+    underlying type, so the set is the ABI-exact width of the C enum, and each
+    `@_transparent` member folds to its raw constant at the use site with no
+    static storage; a repeated raw value across members is fine here. }}
+@frozen public struct {{{name}}}: OptionSet {
+    public typealias RawValue = {{{underlying}}}
+    public let rawValue: RawValue
+    @inlinable public init(rawValue: RawValue) { self.rawValue = rawValue }
+{{#members}}
+    @_transparent public static var {{{name}}}: {{{owner}}} { {{{owner}}}(rawValue: {{{value}}}) }
+{{/members}}
+}
+{{/flags}}
+{{^flags}}
+// A regular enum projects to an explicitly-stored raw-value struct newtype, not
+// a native Swift enum: a native `enum E: {{{underlying}}}` does not carry the ABI
+// layout of its raw type — `@frozen` freezes the compact representation Swift
+// chooses, and the raw type is only a `RawRepresentable` conversion, so a
+// two-case `enum E: UInt32` is one byte, not four, and the signature would pass
+// the wrong width to native code. The newtype stores the `value__` underlying
+// type directly, so it is the ABI-exact width of the C enum; its members are
+// named constants and it holds any ABI value (an undeclared or aliased one)
+// where a native enum would be the wrong size and trap.
+@frozen public struct {{{name}}}: Hashable, Sendable {
+    public var rawValue: {{{underlying}}}
+    @inlinable public init(rawValue: {{{underlying}}}) { self.rawValue = rawValue }
+{{#members}}
+    @_transparent public static var {{{name}}}: {{{owner}}} { {{{owner}}}(rawValue: {{{value}}}) }
+{{/members}}
+}
+{{/flags}}
+{{/enum}}
+{{#delegate}}
+{{#generic}}
+// A parameterised WinRT delegate, like a parameterised interface, has no static
+// IID: its IID is a per-instantiation PIID computed at runtime from the type
+// arguments, so no `@com(interface:)` is emitted — the runtime projection
+// supplies it. Its generic parameters are declared as the protocol's primary
+// associated types so the `Invoke` signature spells them by name.
+internal protocol {{{abi}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}> {
+{{#generics}}
+    associatedtype {{{name}}}
+{{/generics}}
+    func Invoke({{#params}}_ {{{name}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}}
+}
+
+// The public wrapper a signature spells (`Handler<T>`): a parameterised delegate
+// name names this struct, not the internal ABI protocol, so the wrapper must be
+// declared for the reference to resolve. It holds the ABI existential and
+// forwards `Invoke`, the same shape the generic interface arm gives a
+// parameterised interface — a blank requirement parameter forwards through its
+// synthesized `local` name so the call passes it by name.
+public struct {{{name}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}> {
+    internal let base: any {{{abi}}}<{{#generics}}{{{name}}}{{^last}}, {{/last}}{{/generics}}>
+    public func Invoke({{#params}}_ {{{local}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}} {
+        base.Invoke({{#params}}{{{local}}}{{^last}}, {{/last}}{{/params}})
+    }
+}
+{{/generic}}
+{{^generic}}
+// A WinRT delegate is a COM interface — IUnknown plus a single `Invoke` — so
+// `@com` generates the IUnknown-based vtable from this Invoke-only protocol,
+// the same ABI-faithful shape an interface projects, not a Swift closure.
+@com(interface: "{{{iid}}}")
+public protocol {{{name}}} {
+    func Invoke({{#params}}_ {{{name}}}: {{{type}}}{{^last}}, {{/last}}{{/params}}){{#returns}} -> {{{.}}}{{/returns}}
+}
+{{/generic}}
+{{/delegate}}

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -316,6 +316,14 @@ internal struct Shell: ~Escapable {
   /// varies per execution, so only the parse is shared, changing no result.
   private let queries = Cache()
 
+  /// The namespace-qualification sets the render keys off — the ambiguous
+  /// `TypeName`s the decode spells qualified and the value-type `TypeDef` `Id`s
+  /// the emit wraps in a namespace `enum` — memoised for the shell's lifetime
+  /// (see `Storage.collisions()`). They are a pure function of the immutable
+  /// database, so unlike the per-render `queries` memo they are computed once on
+  /// first use and reused across every render.
+  private let ambiguities = Ambiguities()
+
   /// A batch decode bucketed by owning row `Id` — the `.render *` maps that
   /// replace a per-owner query (`roster` for an interface's methods,
   /// `signatures` for a method's parameters): each owner `Id` maps to the rows
@@ -378,6 +386,21 @@ internal struct Shell: ~Escapable {
     /// No render-query resource of the requested name resolved — neither a `-I`
     /// directory's `Render/<name>.sql` nor the bundled one.
     case query(String)
+    /// Two or more distinct local protocols (interfaces or delegates) of the
+    /// one simple `name`, borne by the listed `namespaces`, would emit as bare
+    /// top-level declarations — a duplicate, uncompilable clash. A protocol
+    /// cannot nest in a namespace `enum` the way a value type disambiguates, so
+    /// the render rejects the closure rather than emit two `public protocol
+    /// <name>`; the request must name one qualified.
+    case ambiguous(String, Array<String>)
+    /// A fabricated namespace `enum` container of `name` — a CLR namespace
+    /// segment of an ambiguous value type the render wraps — collides with an
+    /// emitted top-level declaration of that same `name`, two `public`
+    /// declarations Swift rejects as a redeclaration. Only a value type can be
+    /// namespace-wrapped to disambiguate, so a namespace segment that shadows
+    /// an emitted protocol or bare type has no fallback; the render rejects the
+    /// closure rather than emit the clash.
+    case collision(String)
   }
 
   // MARK: - Execute
@@ -479,6 +502,15 @@ internal struct Shell: ~Escapable {
     // where an override edited between renders was silently ignored while
     // templates and language specs reloaded, is dropped.
     queries.statements.removeAll()
+    // The flat render emits only the requested interface (or, for `*`, every
+    // interface) — never the value-type declarations a signature names, and
+    // never the fabricated namespace `enum` containers a closure wraps an
+    // ambiguous value type in. So it must not namespace-qualify a value-type
+    // reference: a qualified `A.Point` would name a container this render does
+    // not emit. Qualification is a closure-render concern (which both qualifies
+    // and emits the container); the flat render spells every value type bare,
+    // through empty qualification sets.
+    ambiguities.sets = ([], [])
     // The template names its own target language through a leading `{{! language:
     // <name> }}` directive; stripping it yields the body and loads the matching
     // spec, whose render UDF (`SANITIZE`) makes identifier escaping the
@@ -562,7 +594,7 @@ internal struct Shell: ~Escapable {
     for found in interfaces {
       sources.append(try emit(found, through: mustache, routines: routines,
                               in: dialect, language: language, search: search,
-                              inherits: inherits, roster: roster,
+                              nested: false, inherits: inherits, roster: roster,
                               signatures: signatures, sanitized: sanitized))
     }
     return sources.joined(separator: "\n")
@@ -588,6 +620,11 @@ internal struct Shell: ~Escapable {
     // clear it so each named query re-resolves its resource once, honouring an
     // override edited since the last render, then is reused within this one.
     queries.statements.removeAll()
+    // Each render fixes its own qualification sets: a closure restricts them to
+    // its reached declarations (below), so a set an earlier render memoised — a
+    // flat render's empty sets, or a different root's reached ones — must not
+    // leak into this one.
+    ambiguities.sets = nil
     var body = try self.template(named: template, search: search)
     let language = Shell.language(declaredIn: &body, search: search)
     let routines = language.routines.merging(session.functions)
@@ -596,16 +633,401 @@ internal struct Shell: ~Escapable {
     guard !roots.isEmpty else { throw RenderError.interface(root) }
 
     let mustache = try MustacheTemplate(string: body)
-    // The interfaces already emitted, keyed on their local `TypeDef` Id, so the
-    // mutually referential interface graph terminates and each renders once.
+    // The types already walked, keyed on their local `TypeDef` Id, so the
+    // mutually referential type graph terminates and each is visited once. The
+    // walk gathers each reachable type's row and records its spelled-reference
+    // edges, but defers rendering a body: the qualification sets a body is
+    // spelled through are not fixed until the reached set is known (after the
+    // prune), so emitting happens below, once, over the kept nodes.
     var visited = Set<Int>()
-    var sources = Array<String>()
+    var nodes = Array<Array<Value>>()
+    var edges = Dictionary<Int, Array<Int>>()
     for seed in roots {
-      try walk(seed, visited: &visited, into: &sources, through: mustache,
-               routines: routines, in: dialect, language: language,
-               search: search)
+      try walk(seed, visited: &visited, into: &nodes, edges: &edges,
+               routines: routines, in: dialect, search: search)
     }
-    return sources.joined(separator: "\n")
+    // Prune orphan nodes: keep only a type reachable from the seeds through
+    // declarations the closure actually renders. A frontier — a metadata-nested
+    // protocol, or a value type whose enclosing chain is not an emitted
+    // container — is not emittable, so its own dependencies do not propagate,
+    // and a type reached only through it is dropped rather than rendered as an
+    // unreferenced orphan (which can fault collision checks). The enclosing
+    // chain of a kept nested type is kept too, so its container survives.
+    let kept = try prune(nodes, edges: edges,
+                         seeds: roots.map { $0[0].integer })
+    // Fix the qualification sets over the reached declarations alone
+    // (`Storage.collisions(among:)`), so an unreachable same-named type neither
+    // wraps nor faults a reached value type. The closure emit and nest both
+    // read them through `qualifying()`, so a body is spelled with the same set
+    // that nests it, and the reached-only tally is shared by the two.
+    ambiguities.sets =
+        try session.storage.collisions(among: Set(kept.map { $0[0].integer }))
+    // Render each kept node's body now that the reached-only sets are fixed, in
+    // the post-order the walk gathered them, so a dependency precedes the type
+    // naming it and `nest` can fold the flat sequence into its containment
+    // tree.
+    var emissions = Array<Emission>()
+    for node in kept {
+      // A generic interface or delegate — its `TypeName` carries the CLR arity
+      // suffix — additionally declares an `internal protocol <name>ABI` beside
+      // its wrapper; its synthesized name is the arity-stripped name suffixed
+      // with `ABI` and escaped as the wrapper's own name is (`interface`), so
+      // the collision check can count it. A non-generic type synthesizes none.
+      let raw = node[2].text
+      let abi = (node[4].text == "interface" || node[4].text == "delegate")
+          && raw.contains("`")
+          ? language.escape(String(raw.prefix { $0 != "`" }) + "ABI")
+          : nil
+      emissions.append(Emission(id: node[0].integer,
+                                name: Shell.name(node, language),
+                                kind: node[4].text,
+                                abi: abi,
+                                body: try emit(node, through: mustache,
+                                               routines: routines, in: dialect,
+                                               language: language,
+                                               search: search)))
+    }
+    // A nested type is spelled fully qualified in every signature that names it
+    // (`Foo.Bar`), so its declaration must actually nest under its encloser for
+    // the two spellings to agree and for two same-named nested types under
+    // different enclosers not to collide as duplicate top-level declarations.
+    // Fold the flat post-order emission into real Swift nesting, wrapping only
+    // an ambiguous value type in its fabricated namespace `enum` containers.
+    return try nest(emissions, language: language,
+                    wrapping: qualifying().ids)
+  }
+
+  /// The namespace-qualification sets the render keys off for this render: the
+  /// ambiguous `TypeName`s the decode spells qualified, and the value-type
+  /// `Id`s the emit wraps in a namespace `enum`. The decode spelling and the
+  /// emit nesting share this one source, so a reference is spelled with the
+  /// same set that decides whether its container is emitted.
+  ///
+  /// Each render fixes the sets up front, before any emit: the closure render
+  /// to its reached declarations (`Storage.collisions(among:)`), the flat
+  /// render to the empty sets — it emits no value-type or container
+  /// declarations, so it qualifies nothing and spells every value type bare. An
+  /// unset memo therefore never reaches an emit; it defaults to the empty
+  /// (bare) sets rather than qualifying against a tally no declaration backs.
+  private borrowing func qualifying() -> (names: Set<String>, ids: Set<Int>) {
+    ambiguities.sets ?? ([], [])
+  }
+
+  /// Keeps only the emissions reachable from the `seeds` through the emitted
+  /// declarations' spelled references (`edges`), dropping the orphans a
+  /// discarded frontier — or a reference the output never spells (a static
+  /// field, a custom modifier) — leaves behind. An emission that cannot itself
+  /// be emitted (a metadata-nested protocol, or a value type whose enclosing
+  /// chain is not an emitted value-type container) is a frontier: it renders no
+  /// declaration, so its own references do not propagate and a type reached
+  /// only through it is dropped rather than rendered unreferenced (which can
+  /// fault collision checks). The enclosing chain of a kept nested type is kept
+  /// too, so the container that holds it survives.
+  private borrowing func prune(_ nodes: Array<Array<Value>>,
+                               edges: Dictionary<Int, Array<Int>>,
+                               seeds: Array<Int>) throws
+      -> Array<Array<Value>> {
+    var kind = Dictionary<Int, String>(minimumCapacity: nodes.count)
+    for node in nodes { kind[node[0].integer] = node[4].text }
+    // Whether the emission's declaration renders, so its references propagate:
+    // an interface or delegate only at top level (a protocol cannot nest), a
+    // value type only when every enclosing level is an emitted value-type
+    // container — the test `nest` applies before folding a type into the tree.
+    func emittable(_ id: Int) throws -> Bool {
+      guard let leaf = kind[id] else { return false }
+      let chain = try session.storage.nesting(of: id)
+      if leaf == "interface" || leaf == "delegate" { return chain.isEmpty }
+      return chain.allSatisfy {
+        kind[$0.id] == "struct" || kind[$0.id] == "enum"
+      }
+    }
+    var kept = Set<Int>()
+    var queue = seeds
+    while let node = queue.popLast() {
+      guard kept.insert(node).inserted else { continue }
+      for level in try session.storage.nesting(of: node) {
+        queue.append(level.id)
+      }
+      if try emittable(node) { queue.append(contentsOf: edges[node] ?? []) }
+    }
+    return nodes.filter { kept.contains($0[0].integer) }
+  }
+
+  /// Assembles the flat post-order `emissions` into nested Swift declarations —
+  /// an ambiguous value type wrapped under the namespace `enum`s its
+  /// fully-qualified spelling names, every value type nested under its enclosing
+  /// types, each nested protocol dropped — so a declaration's path matches the
+  /// spelling its signatures carry and two same-named types stay distinct.
+  ///
+  /// `ambiguous` is the set of value-type `Id`s the decode spells
+  /// namespace-qualified (`Storage.collisions()`): an ambiguous top-level value
+  /// type is spelled fully qualified — `Windows.Win32.Foundation.Point`,
+  /// `A.B.Outer.Inner` — so its declaration must nest that deep for the two to
+  /// agree, while an unambiguous one spells bare and is a plain root. The
+  /// CLR-namespace segments of an ambiguous type are fabricated as real Swift
+  /// `enum` namespaces above its enclosing chain: unlike a type encloser, a
+  /// namespace is not a real `TypeDef`, so fabricating an `enum` per segment is
+  /// sound here (a real Win32 namespace segment — `Windows`/`Win32`/… — is never
+  /// itself a projected type name; a collision with an emitted type of that name
+  /// is possible in principle but does not arise). The set shares one source
+  /// with the decode, so a nested ambiguous type and its enclosing chain wrap
+  /// together — the outermost encloser of any ambiguous type is itself in
+  /// `ambiguous` — keeping the emitted path and the spelled path in agreement.
+  /// A nested value type (`Foo.Bar`) nests under its immediate encloser, which
+  /// must be
+  /// a real emitted value-type container — an encloser this closure emitted as a
+  /// `struct`/`enum`, never a fabricated namespace `enum` (a fabricated encloser
+  /// would misrepresent an emitted `protocol`, which cannot hold a value type,
+  /// or shadow a runtime `class` the encloser names). Each value type's
+  /// enclosing chain (`storage.nesting(of:)`) is tested end to end: it nests
+  /// only when every level is an emitted value-type container, so `Foo.Bar.Baz`
+  /// nests only if both `Foo` and `Bar` are; a chain with any non-container
+  /// level — a `protocol`, an excluded runtime `class`, or a level not emitted —
+  /// makes it a dropped frontier the consumer defines.
+  ///
+  /// An interface or delegate emits as a Swift `protocol`, which cannot nest in
+  /// any container and is never namespace-qualified: only a top-level one (an
+  /// empty enclosing chain) is a legal root, spelled bare. A metadata-nested
+  /// protocol is a dropped frontier — a bare top-level declaration would neither
+  /// match its metadata-nested spelling nor tell two same-named nested protocols
+  /// apart — so it renders nothing, exactly as a value type with an unusable
+  /// enclosing chain does.
+  ///
+  /// The kept roots — the outermost namespace `enum`s and the top-level
+  /// protocols — render in the post-order the walk emitted them (a container at
+  /// its earliest-emitted descendant), so a dependency precedes the type naming
+  /// it and a top-level type keeps its position. A namespace `enum`'s members
+  /// keep that same earliest order; a real value-type container's nested types
+  /// render in name order for determinism.
+  private borrowing func nest(_ emissions: Array<Emission>,
+                              language: Language,
+                              wrapping ambiguous: Set<Int>) throws -> String {
+    // A node in the containment forest: a real emitted `TypeDef` (keyed by its
+    // local Id) or a fabricated CLR-namespace container (keyed by its raw dotted
+    // path, so every value type in that namespace shares the one container).
+    enum Node: Hashable {
+      case type(Int)
+      case space(String)
+    }
+    // The rendered body, declaration name, and emission position of each emitted
+    // type, keyed by its local `TypeDef` Id.
+    var bodies = Dictionary<Int, String>(minimumCapacity: emissions.count)
+    var declared = Dictionary<Int, String>(minimumCapacity: emissions.count)
+    var index = Dictionary<Int, Int>(minimumCapacity: emissions.count)
+    // The Ids emitted as value-type containers — a `struct` or `enum` — the only
+    // kinds a nested type may legally nest inside.
+    var container = Set<Int>()
+    // The synthesized ABI-protocol name of each generic interface/delegate — an
+    // `internal protocol <name>ABI` the body declares that its label does not
+    // name — so the per-scope collision check counts it alongside the labels.
+    var abi = Dictionary<Int, String>(minimumCapacity: emissions.count)
+    for (position, emission) in emissions.enumerated() {
+      bodies[emission.id] = emission.body
+      declared[emission.id] = emission.name
+      index[emission.id] = position
+      if emission.kind == "struct" || emission.kind == "enum" {
+        container.insert(emission.id)
+      }
+      if let name = emission.abi { abi[emission.id] = name }
+    }
+    // The containment forest: the roots (namespace `enum`s and top-level
+    // protocols), each node's direct children. A dropped frontier is recorded
+    // nowhere, so it never renders.
+    var roots = Array<Node>()
+    var children = Dictionary<Node, Array<Node>>()
+    // The namespace nodes already linked into the forest, so a shared namespace
+    // is fabricated once.
+    var linked = Set<Node>()
+    // Fabricates the namespace-container chain for `segments` (raw, outermost
+    // first), linking each level under the previous — the outermost a root — and
+    // returns the deepest node, the immediate parent of a top-level value type.
+    func space(_ segments: Array<Substring>) -> Node {
+      var path = ""
+      var parent: Node?
+      var node = Node.space("")
+      for segment in segments {
+        path = path.isEmpty ? String(segment) : path + "." + segment
+        node = .space(path)
+        if linked.insert(node).inserted {
+          if let parent {
+            children[parent, default: []].append(node)
+          } else {
+            roots.append(node)
+          }
+        }
+        parent = node
+      }
+      return node
+    }
+    for emission in emissions {
+      let chain = try session.storage.nesting(of: emission.id)
+      guard container.contains(emission.id) else {
+        // An interface or delegate emits as a `protocol`: a top-level one is a
+        // root, a metadata-nested one a dropped frontier.
+        if chain.isEmpty { roots.append(.type(emission.id)) }
+        continue
+      }
+      // A value type nests only when every enclosing level is an emitted
+      // value-type container; any other level makes it a dropped frontier.
+      guard chain.allSatisfy({ container.contains($0.id) }) else { continue }
+      if let inner = chain.last {
+        children[.type(inner.id), default: []].append(.type(emission.id))
+      } else if ambiguous.contains(emission.id) {
+        // An ambiguous top-level value type nests under its CLR-namespace
+        // `enum`s, matching the namespace-qualified spelling its references
+        // carry; an empty namespace (the global namespace) leaves it a plain
+        // root.
+        let raw = try session.storage.namespace(of: emission.id)
+        let segments = raw.split(separator: ".",
+                                 omittingEmptySubsequences: false)
+        if segments.isEmpty {
+          roots.append(.type(emission.id))
+        } else {
+          children[space(segments), default: []].append(.type(emission.id))
+        }
+      } else {
+        // An unambiguous top-level value type spells bare, so it needs no
+        // fabricated namespace container: it is a plain root.
+        roots.append(.type(emission.id))
+      }
+    }
+    // The declaration label of a node — a type's escaped name, or a namespace
+    // segment escaped the same way the decode escapes a namespace component, so
+    // the fabricated `enum` name matches the qualified spelling.
+    func label(_ node: Node) -> String {
+      switch node {
+      case let .type(id):
+        return declared[id] ?? ""
+      case let .space(path):
+        return language.escape(String(path.split(separator: ".").last ?? ""))
+      }
+    }
+    // Every scope in the forest — the top-level roots and each container's
+    // direct children — is one Swift declaration scope, so its members must
+    // bear distinct labels: a duplicate at any level is an uncompilable
+    // redeclaration, not only among the roots. Nesting can place a real value
+    // type and a fabricated namespace `enum` of the one name inside the same
+    // container (`enum A` holding both a real `B` and the `B` namespace of an
+    // `A.B.…` type), which a root-only check misses. The first clash in
+    // sorted-label order across all scopes faults, so the fault is
+    // deterministic.
+    var clash: (label: String, nodes: Array<Node>, abi: Bool)?
+    for scope in [roots] + Array(children.values) {
+      var byLabel = Dictionary<String, Array<Node>>()
+      // The synthesized ABI-protocol names declared in this scope, and how many
+      // generic types declare each (normally one), so an `internal protocol
+      // <name>ABI` counts as an occupant even though no node bears its label.
+      var abiCount = Dictionary<String, Int>()
+      for node in scope {
+        byLabel[label(node), default: []].append(node)
+        if case let .type(id) = node, let name = abi[id] {
+          abiCount[name, default: 0] += 1
+        }
+      }
+      for (name, nodes) in byLabel where nodes.count >= 2 {
+        if clash == nil || name < clash!.label { clash = (name, nodes, false) }
+      }
+      // A synthesized ABI-protocol name a real declaration (or another
+      // generic's ABI protocol) in the same scope also bears: an invalid
+      // redeclaration the emission labels alone do not surface.
+      for (name, count) in abiCount {
+        let total = (byLabel[name]?.count ?? 0) + count
+        if total >= 2, clash == nil || name < clash!.label {
+          clash = (name, byLabel[name] ?? [], true)
+        }
+      }
+    }
+    if let clash {
+      // A generic type's synthesized `<name>ABI` colliding with a declaration
+      // of that name is always a `collision`: the internal ABI protocol is not
+      // a namespace-qualifiable public one, so it never reads as `ambiguous`.
+      if clash.abi { throw RenderError.collision(clash.label) }
+      // Same-named top-level protocols — a `.type` node that is not an emitted
+      // value-type container, the one clash a namespace `enum` cannot
+      // disambiguate — yield `ambiguous`, named by their namespaces. Any other
+      // clash is a fabricated namespace container shadowing an emitted type
+      // (only a value type can be wrapped), a `collision`; a nested `.type` is
+      // always a value-type container, so a nested clash is never `ambiguous`.
+      let protocols = clash.nodes.allSatisfy { node in
+        if case let .type(id) = node { !container.contains(id) } else { false }
+      }
+      if protocols {
+        let namespaces = try clash.nodes.map { node -> String in
+          guard case let .type(id) = node else { return "" }
+          return try session.storage.namespace(of: id)
+        }
+        throw RenderError.ambiguous(clash.label, namespaces.sorted())
+      }
+      throw RenderError.collision(clash.label)
+    }
+    // The earliest emission position anywhere in a node's subtree, so a
+    // container sorts at its earliest-emitted descendant — a top-level type at
+    // its own position, a container at its earliest-emitted member. A fabricated
+    // namespace node has no position of its own.
+    func earliest(_ node: Node) -> Int {
+      var least = if case let .type(id) = node { index[id] ?? Int.max }
+                  else { Int.max }
+      for child in children[node] ?? [] { least = min(least, earliest(child)) }
+      return least
+    }
+    // The rendered text of a node: a type's body with its nested children folded
+    // in before its closing brace, or a fabricated `public enum` wrapping its
+    // members. A real container orders its children by name; a namespace `enum`
+    // keeps its members in emission (earliest) order, so it preserves the
+    // post-order a top-level value type held before it was wrapped.
+    func rendered(_ node: Node) -> String {
+      let kids = children[node] ?? []
+      switch node {
+      case let .type(id):
+        guard let body = bodies[id] else { return "" }
+        guard !kids.isEmpty else { return body }
+        let block = kids.sorted { label($0) < label($1) }
+            .map { Shell.indent(rendered($0)) }.joined(separator: "\n")
+        return Shell.inject(block, into: body)
+      case .space:
+        let block = kids.sorted { earliest($0) < earliest($1) }
+            .map { Shell.indent(rendered($0)) }.joined(separator: "\n")
+        return Shell.inject(block, into: "public enum \(label(node)) {\n}")
+      }
+    }
+    roots.sort { earliest($0) < earliest($1) }
+    return roots.map { rendered($0) }.joined(separator: "\n")
+  }
+
+  /// Indents every non-empty line of `text` by one four-space level — the step
+  /// a nested declaration is inset under its container. A blank line stays
+  /// blank so no line carries trailing whitespace.
+  private static func indent(_ text: String) -> String {
+    text.split(separator: "\n", omittingEmptySubsequences: false)
+        .map { $0.isEmpty ? "" : "    \($0)" }
+        .joined(separator: "\n")
+  }
+
+  /// Splices the nested-declaration `block` into `body` just before its real
+  /// closing brace, so a rendered container (a struct or enum) carries its
+  /// nested types inside its own body.
+  ///
+  /// The closer is located as the last line whose sole content is `}`
+  /// (indentation aside), not merely the body's last line: a custom or `-I`
+  /// container template may emit a footer after the brace — a trailing comment
+  /// or any text on its own line — which the body's last line would then be, so
+  /// splicing before that line would leave the child a sibling after the real
+  /// brace and spill it out of the container. Anchoring on the brace nests the
+  /// child inside and keeps a footer a line past the closer. Trailing blank
+  /// lines are dropped first, the same trailing-blank trim the bundled template
+  /// relied on, so a bundled struct or enum body — brace on its own last line —
+  /// injects byte-identically. A body with no brace-only line (an unusual
+  /// container) falls back to splicing before its last line.
+  private static func inject(_ block: String, into body: String) -> String {
+    var lines = body.split(separator: "\n", omittingEmptySubsequences: false)
+        .map(String.init)
+    while let last = lines.last, last.allSatisfy(\.isWhitespace) {
+      lines.removeLast()
+    }
+    guard !lines.isEmpty else { return body }
+    let closer = lines.lastIndex { $0.trimmed == "}" } ?? lines.count - 1
+    lines.insert(block, at: closer)
+    return lines.joined(separator: "\n")
   }
 
   /// Whether any render query or view the `.render *` batch shortcuts is
@@ -665,8 +1087,15 @@ internal struct Shell: ~Escapable {
 
   /// The seed rows for `name` — the interface `TypeDef` rows the render
   /// `interfaces` query scans — resolved to the full render row shape (`Id`,
-  /// namespace, name, `iid`), dropping an interface whose `GuidAttribute`
-  /// resolves nothing.
+  /// namespace, name, `iid`, and a literal `kind` of `interface`), dropping an
+  /// interface whose `GuidAttribute` resolves nothing.
+  ///
+  /// The `interfaces.sql` seed projects three columns (`Id`, namespace, name);
+  /// the `iid` is fetched here and the `interface` kind tag appended in Swift
+  /// (index 4), so the seed row carries the same kind-tagged shape the
+  /// `requires`/`references` closure selections carry — `emit` and `walk` both
+  /// dispatch on that `kind` — while the seed query keeps its three-column
+  /// contract, unchanged for a flat render or a `-I` override.
   ///
   /// The scan seeks the interface `TypeDef` rows by name (`interfaces.sql`), and
   /// the `iid` is fetched separately so a concrete seed does not materialise the
@@ -710,7 +1139,8 @@ internal struct Shell: ~Escapable {
       let iid = if let iids { iids[row[0].integer] }
                 else { try guid(of: row[0], routines, search: search) }
       guard let iid else { continue }
-      interfaces.append([row[0], row[1], row[2], .text(iid)])
+      interfaces.append([row[0], row[1], row[2], .text(iid),
+                         .text("interface")])
     }
     return interfaces
   }
@@ -889,57 +1319,313 @@ internal struct Shell: ~Escapable {
     return rows.first.map { $0[0].text }
   }
 
-  /// Emits the interface `found` and, first, the transitive closure of its plain
-  /// (`spec IS NULL`) base and required interfaces — a depth-first post-order
-  /// over the E1 edges, so a base precedes the interface refining it.
+  /// Emits the type `found` and, first, the transitive closure of every local
+  /// type it depends on — a depth-first post-order, so a dependency precedes the
+  /// type naming it. `found` is a kind-tagged row (`Id`, namespace, name, `iid`,
+  /// and a `kind` of `interface`/`struct`/`enum`/`delegate`), the shape the
+  /// `interfaces`, `requires`, and `references` selections share.
   ///
-  /// The `requires` query resolves each base and required interface to its local
-  /// interface `TypeDef` row keyed on namespace and name, so a base that resolves
-  /// to no local interface `TypeDef` — an external `TypeRef`-only frontier, or a
-  /// local type that is no interface — is not returned and the walk simply stops
-  /// there. The visited set (the local `TypeDef` Id) renders each interface once
-  /// and terminates a cycle; the bases are walked in a stable namespace-then-name
-  /// order so the emission is deterministic.
+  /// The adjacency depends on the node's kind. An interface first closes over
+  /// its plain (`spec IS NULL`) base and required interfaces — the E1 edges,
+  /// through the `requires` query, each resolved to its local interface `TypeDef`
+  /// row keyed on namespace and name — then over the value-type and delegate
+  /// types its methods name (E3/E7). A struct closes over its fields' types
+  /// (E6), a delegate over its `Invoke` signature (E7), and an enum is a leaf.
+  /// Each signature-named type resolves through the `references` query to a local
+  /// `types` row; a runtime `class` stays a frontier, and an external
+  /// `TypeRef`-only reference resolves to no row and simply drops. The visited
+  /// set (the local `TypeDef` Id) renders each type once across all kinds and
+  /// terminates a cycle; the neighbours are walked in a stable
+  /// namespace-then-name order so the emission is deterministic.
   private borrowing func walk(_ found: Array<Value>, visited: inout Set<Int>,
-                              into sources: inout Array<String>,
-                              through mustache: MustacheTemplate,
+                              into nodes: inout Array<Array<Value>>,
+                              edges: inout Dictionary<Int, Array<Int>>,
                               routines: Routines, in dialect: Dialect,
-                              language: Language,
                               search: Array<String>) throws {
     guard visited.insert(found[0].integer).inserted else { return }
-    let query = try statement(named: "requires")
-    let bases = try session.run(query, routines,
-                                bindings: ["parent": found[0]])
-    let ordered = bases.sorted {
-      ($0[1].text, $0[2].text) < ($1[1].text, $1[2].text)
+    // Frontier a reached dependency the language import already provides — a
+    // type whose Identity `(namespace, name)` is a key in the dialect's `known`
+    // bridge table (`HRESULT`, `BOOL`, `PWSTR`, …): emit no wrapper for it and
+    // do not walk its members, exactly as the layout-reject and nested-protocol
+    // frontiers do. A reference to it still spells through `dialect.known` (its
+    // bridged name), so the consumer's imported type satisfies the signature.
+    // The seeds are interfaces, which the `known` table never names, so only
+    // reached dependencies are frontiered here.
+    if dialect.known[Identity(namespace: found[1].text,
+                              name: found[2].text)] != nil {
+      return
     }
-    for base in ordered {
-      try walk(base, visited: &visited, into: &sources, through: mustache,
-               routines: routines, in: dialect, language: language,
-               search: search)
+    // Reject a value type whose ABI layout `@frozen` cannot reproduce — an
+    // explicit layout (a union or offset-placed fields), a non-default packing,
+    // or a declared class size (tail padding to a fixed extent) — rather than
+    // project a wrong-sized struct: emit nothing and do not walk its fields,
+    // leaving it a frontier the consumer defines. The `layout` query returns a
+    // row only for such a type; a naturally-laid struct returns none and renders
+    // normally. (`ClassLayout` is an optional table, resolved empty when absent,
+    // so a database with no laid-out type reads no packing or size row.)
+    if found[4].text == "struct",
+        try session.run(statement(named: "layout"), routines,
+                        bindings: ["parent": found[0]]).first != nil {
+      return
     }
-    sources.append(try emit(found, through: mustache, routines: routines,
-                            in: dialect, language: language, search: search))
+    // The types this node's rendered declaration spells: its base and required
+    // interfaces (E1) and its signature-named value/delegate types (E3/E6/E7).
+    // Recorded as its `edges` so a post-walk reachability prune can drop a type
+    // reachable only through a declaration the closure discards (a frontier) as
+    // an orphan that would render unreferenced and fault collision validation.
+    var neighbors = Array<Int>()
+    // An interface closes over its base and required interfaces first (E1),
+    // before the signature-named types, so an inherited surface precedes the
+    // refinement naming it.
+    if found[4].text == "interface" {
+      let query = try statement(named: "requires")
+      let bases = try session.run(query, routines,
+                                  bindings: ["parent": found[0]])
+      neighbors.append(contentsOf: bases.map { $0[0].integer })
+      for base in bases.sorted(by: Shell.precedes) {
+        try walk(base, visited: &visited, into: &nodes, edges: &edges,
+                 routines: routines, in: dialect, search: search)
+      }
+    }
+    // The value-type and delegate types the node's signatures name (E3/E6/E7),
+    // resolved to their local rows and walked before the terminal emit.
+    let referenced = try adjacency(of: found, routines, in: dialect,
+                                   search: search)
+    neighbors.append(contentsOf: referenced.map { $0[0].integer })
+    edges[found[0].integer] = neighbors
+    for neighbor in referenced.sorted(by: Shell.precedes) {
+      try walk(neighbor, visited: &visited, into: &nodes, edges: &edges,
+               routines: routines, in: dialect, search: search)
+    }
+    // A nested value type spells fully qualified through its enclosing chain
+    // (`Outer.Inner`), so its immediate enclosing value type must be emitted
+    // too — as the real `struct`/`enum` container `Inner` nests inside — even
+    // when no signature names `Outer` directly. Walk that encloser (its own
+    // walk climbs the rest of the chain); prune keeps it as a kept nested
+    // type's enclosing level, but only if its emission exists, so it is walked,
+    // not merely retained. A non-value encloser is left unwalked: a
+    // `protocol`/`class` cannot hold a value type, so `Inner` stays a frontier
+    // the prune drops.
+    if found[4].text == "struct" || found[4].text == "enum",
+        let outer = try session.storage.nesting(of: found[0].integer).last {
+      let plan =
+          try Shell.statement(Shell.query(named: "references", search: search))
+      let rows = try session.run(plan, routines,
+                                 bindings: ["ref": .null,
+                                            "def": .integer(outer.id)])
+      if let row = rows.first,
+          row[4].text == "struct" || row[4].text == "enum" {
+        try walk(row, visited: &visited, into: &nodes, edges: &edges,
+                 routines: routines, in: dialect, search: search)
+      }
+    }
+    // The walked row, deferred for a body render once the reached-only
+    // qualification sets are fixed; its local `TypeDef` Id, namespace, name,
+    // and kind let `prune` and `nest` classify it and fold it under a parent.
+    nodes.append(found)
   }
 
-  /// Renders the single interface `found` — its `Id`, namespace, name, and
-  /// `iid`, the row shape the `interfaces` and `requires` queries share —
-  /// through `mustache`, the per-interface body the flat render and the
-  /// `--closure` walk both run.
+  /// The local `types` rows the signatures of `found` name — the node's
+  /// signature-driven adjacency (E3/E6/E7). An interface contributes every type
+  /// its methods name, a struct every type its fields name, a delegate the types
+  /// its `Invoke` signature names; an enum contributes none. Each referenced
+  /// type resolves through the `references` query — by the exact `TypeRef`/
+  /// `TypeDef` row it was named through, not by name — to a local `types` row,
+  /// dropping a runtime `class` (which stays a frontier) and an external
+  /// `TypeRef`-only reference (which resolves to no row).
+  private borrowing func adjacency(of found: Array<Value>,
+                                   _ routines: Routines, in dialect: Dialect,
+                                   search: Array<String>) throws
+      -> Array<Array<Value>> {
+    // The referenced types, gathered from the node's method or field signatures
+    // per its kind — each a `Referent` carrying the coded-index row it was named
+    // through, so it resolves to a local definition by its exact Id.
+    var references = Set<Referent>()
+    switch found[4].text {
+    case "interface":
+      let plan =
+          try Shell.statement(Shell.query(named: "methods", search: search))
+      let rows = try session.run(plan, routines,
+                                 bindings: ["parent": found[0]])
+      for row in rows {
+        let method = row[0].integer
+        references.formUnion(session.storage.identities(method: method))
+      }
+    case "struct":
+      let plan =
+          try Shell.statement(Shell.query(named: "fields", search: search))
+      let rows = try session.run(plan, routines,
+                                 bindings: ["parent": found[0]])
+      // Only instance fields close over their types: a static or literal field
+      // (the `fdStatic` 0x10 bit) is dropped from the emitted declaration by
+      // `structure`, so walking its type would enqueue a type the struct never
+      // references — an orphan that renders anyway and can fault namespace or
+      // collision validation on a member that was omitted. The walk applies the
+      // same filter as the emit so the two agree on which fields count.
+      for row in rows where row[2].integer & 0x10 == 0 {
+        let field = row[0].integer
+        references.formUnion(session.storage.identities(field: field))
+      }
+    case "delegate":
+      let plan =
+          try Shell.statement(Shell.query(named: "invoke", search: search))
+      let rows = try session.run(plan, routines,
+                                 bindings: ["parent": found[0]])
+      for row in rows {
+        let method = row[0].integer
+        references.formUnion(session.storage.identities(method: method))
+      }
+    default:
+      return []
+    }
+    // Resolve each reference to its local row by the exact Id it names — a
+    // `TypeRef` through the shared scope-chain `resolved` CTE (bound `:ref`), a
+    // `TypeDef` by its Id directly (bound `:def`) — leaving the other key NULL so
+    // one arm matches. A runtime `class` (a reference type, outside the value
+    // closure) is dropped, as is a reference that resolves to no local row.
+    let plan =
+        try Shell.statement(Shell.query(named: "references", search: search))
+    var neighbors = Array<Array<Value>>()
+    for reference in references {
+      let (ref, def): (Value, Value) = switch reference.kind {
+      case .reference: (.integer(reference.row), .null)
+      case .definition: (.null, .integer(reference.row))
+      }
+      let rows = try session.run(plan, routines,
+                                 bindings: ["ref": ref, "def": def])
+      for row in rows where row[4].text != "class" {
+        // A nongeneric delegate projects an `@com` interface keyed on its static
+        // GUID, so one bearing no `GuidAttribute` — no static IID — is a
+        // frontier: dropped rather than emitted as a GUID-less `@com` shape. A
+        // generic (parameterised) delegate legitimately bears no static IID (a
+        // per-instantiation PIID), so it is kept and emitted through the generic
+        // `{{#generic}}` arm (which omits `@com`), the way a generic interface is
+        // kept below; it is told apart by its declared generic parameters, since
+        // `guid(of:)` returns nil for both, so the nongeneric gate precedes it.
+        if row[4].text == "delegate",
+            try declarations(of: row[0], routines, search: search).isEmpty,
+            try guid(of: row, routines, search: search) == nil { continue }
+        // A nongeneric interface with no `GuidAttribute` has no static IID: its
+        // `references` LEFT JOIN yields a NULL iid, which the template would
+        // spell as `@com(interface: "")` — unusable source. Drop it, the way the
+        // normal `interfaces` view (an INNER join on the GUID) excludes it. A
+        // generic interface legitimately bears no static IID (a per-instantiation
+        // PIID), so a NULL iid there is expected and the row is kept — its
+        // template branch omits `@com` — distinguished by its declared generic
+        // parameters, exactly as `guid(of:)` tells a parameterised delegate apart.
+        if row[4].text == "interface", row[3].text.isEmpty,
+            try declarations(of: row[0], routines, search: search).isEmpty {
+          continue
+        }
+        neighbors.append(row)
+      }
+    }
+    return neighbors
+  }
+
+  /// The static GUID the delegate `found` bears through its `GuidAttribute`,
+  /// decoded through the `guid` query the way the `interfaces` view spells an
+  /// interface's `iid`. A WinRT delegate is a COM interface — IUnknown plus a
+  /// single `Invoke` — so `@com` needs its IUnknown-derived IID.
   ///
-  /// Decoding the interface's declared generics, methods, and base is the same
-  /// work either path needs; wrapping it here is what lets the closure worklist
-  /// reuse the decode and emit rather than duplicate them.
+  /// `nil` marks a delegate the walk treats as a frontier: a parameterised
+  /// delegate computes its PIID per instantiation and bears no static GUID, and
+  /// a delegate carrying no `GuidAttribute` resolves nothing through the query.
+  /// Either way the render drops it rather than emitting a GUID-less `@com`
+  /// protocol.
+  private borrowing func guid(of found: Array<Value>, _ routines: Routines,
+                              search: Array<String>) throws -> String? {
+    guard try declarations(of: found[0], routines, search: search).isEmpty
+    else { return nil }
+    let plan = try Shell.statement(Shell.query(named: "guid", search: search))
+    let rows = try session.run(plan, routines, bindings: ["parent": found[0]])
+    guard let row = rows.first, row[0] != .null else { return nil }
+    return row[0].text
+  }
+
+  /// The stable namespace-then-name order the walk emits siblings in, so a
+  /// closure renders deterministically regardless of the order the adjacency
+  /// queries (or the referenced-identity set) yield rows. The local `Id` breaks
+  /// a namespace-and-name tie — two nested types share the empty namespace and
+  /// may share a bare name under different enclosers, so name alone is not a
+  /// total order and the emission (hence the nesting) would otherwise vary.
+  private static func precedes(_ lhs: Array<Value>,
+                               _ rhs: Array<Value>) -> Bool {
+    (lhs[1].text, lhs[2].text, lhs[0].integer)
+        < (rhs[1].text, rhs[2].text, rhs[0].integer)
+  }
+
+  /// Renders the single type `found` through `mustache`, the per-node body the
+  /// flat render and the `--closure` walk both run.
+  ///
+  /// `found` is a kind-tagged row; its `kind` selects the template section and
+  /// the context shape. An interface renders its `@com` protocol (or generic
+  /// wrapper), a struct its fields, an enum its native cases, a delegate its
+  /// `Invoke` signature — each under exactly one of the template's
+  /// `{{#interface}}`/`{{#struct}}`/`{{#enum}}`/`{{#delegate}}` sections, so one
+  /// template renders every kind. The interface context is unchanged, nested
+  /// under `interface` for the sectioned closure template. A flat render
+  /// (`nested` false) additionally exposes the interface's fields at the
+  /// template root, the documented pre-closure behaviour a bare `{{name}}`
+  /// template reads, so an inline or `-I` template written for the flat renderer
+  /// keeps working. Wrapping the decode here is what lets the closure walk reuse
+  /// it across kinds rather than duplicate it.
   private borrowing func emit(_ found: Array<Value>,
                               through mustache: MustacheTemplate,
                               routines: Routines, in dialect: Dialect,
                               language: Language,
-                              search: Array<String>,
+                              search: Array<String>, nested: Bool = true,
                               inherits: Dictionary<Int, String>? = nil,
                               roster: Buckets? = nil,
                               signatures: Buckets? = nil,
                               sanitized: Dictionary<String, String>? = nil)
       throws -> String {
+    let context: Dictionary<String, Any>
+    switch found[4].text {
+    case "struct":
+      context = ["struct": try structure(found, routines, in: dialect,
+                                         language: language, search: search)]
+    case "enum":
+      context = ["enum": try enumeration(found, routines, in: dialect,
+                                         language: language, search: search)]
+    case "delegate":
+      context = ["delegate": try delegation(found, routines, in: dialect,
+                                            language: language, search: search)]
+    default:
+      let projection = try interface(found, routines, in: dialect,
+                                     language: language, search: search,
+                                     inherits: inherits, roster: roster,
+                                     signatures: signatures,
+                                     sanitized: sanitized)
+      if nested {
+        context = ["interface": projection]
+      } else {
+        // The flat render only ever emits interfaces; expose the projection at
+        // the root (the documented top-level fields) and under `interface` (so
+        // the bundled sectioned template's `{{#interface}}` still renders). The
+        // closure walk emits mixed kinds, so it stays sectioned (`nested`).
+        var root = projection
+        root["interface"] = projection
+        context = root
+      }
+    }
+    return mustache.render(context)
+  }
+
+  /// The template context for the interface `found` — its `Id`, namespace, name,
+  /// and `iid` decoded into the declared generics, methods, and base the
+  /// `{{#interface}}` section reads. This is the interface half of `emit`, its
+  /// dictionary now the value of the context's `interface` key. The `.render *`
+  /// batch maps (`inherits`/`roster`/`signatures`/`sanitized`) thread through so
+  /// the wildcard batch reuses this decode; each is `nil` on the per-node path.
+  private borrowing func interface(_ found: Array<Value>, _ routines: Routines,
+                                   in dialect: Dialect, language: Language,
+                                   search: Array<String>,
+                                   inherits: Dictionary<Int, String>? = nil,
+                                   roster: Buckets? = nil,
+                                   signatures: Buckets? = nil,
+                                   sanitized: Dictionary<String, String>? = nil)
+      throws -> Dictionary<String, Any> {
     let id = found[0]
     // The interface's ordered declared generic-parameter names, through the
     // `generics` view bound by its `Id` — empty for a non-generic interface.
@@ -1022,11 +1708,207 @@ internal struct Shell: ~Escapable {
     // leaves its output byte-identical to today's.
     if let generics {
       context["generic"] = true
+      // The generic parameter names are keyword-escaped for the declaration —
+      // the primary-associated-type clause and each `associatedtype` — the way
+      // the decode escapes their uses in the `Invoke` signature, so a parameter
+      // whose metadata name is a Swift keyword declares and reads under the one
+      // escaped spelling. The raw `generics` still feed the decode, which
+      // escapes on use.
       context["generics"] = generics.enumerated().map { index, name in
-        ["name": name, "last": index == generics.count - 1]
+        ["name": language.escape(name), "last": index == generics.count - 1]
       }
     }
-    return mustache.render(context)
+    return context
+  }
+
+  /// The template context for the struct `found` — its keyword-escaped name and
+  /// its fields, each a `name` and the `type` spelled at render time from its
+  /// `FieldDef` signature (edge E6). The `fields` render query projects each
+  /// field's already-escaped name and its `Id`, which `decode(field:)` navigates
+  /// to the field's type in the target `Dialect`.
+  private borrowing func structure(_ found: Array<Value>, _ routines: Routines,
+                                   in dialect: Dialect, language: Language,
+                                   search: Array<String>) throws
+      -> Dictionary<String, Any> {
+    let plan = try Shell.statement(Shell.query(named: "fields", search: search))
+    let rows = try session.run(plan, routines, bindings: ["parent": found[0]])
+    // Only instance fields are the struct's ABI storage. A static or literal
+    // field (the `fdStatic` 0x10 bit of `FieldDef.Flags`) is not laid out in an
+    // instance, so emitting it as a stored `var` would add a nonexistent field
+    // and shift every following offset, corrupting a by-value native call. Enum
+    // members — also static literal fields — are rendered separately (`members`),
+    // so dropping the static fields here does not affect them.
+    let instances = rows.filter { $0[2].integer & 0x10 == 0 }
+    // Each field carries a `last` flag (computed over the retained instance
+    // fields) so the template's public memberwise initialiser can comma-separate
+    // its parameters — the synthesised memberwise init stays internal even for a
+    // public struct, so a cross-module caller could not otherwise construct it.
+    let names = qualifying().names
+    let fields =
+        instances.enumerated().map { index, row -> Dictionary<String, Any> in
+      let type = session.storage.decode(field: row[0].integer, in: dialect,
+                                        qualifying: names) ?? ""
+      return ["name": row[1].text, "type": type,
+              "last": index == instances.count - 1]
+    }
+    return ["name": Shell.name(found, language), "fields": fields]
+  }
+
+  /// The template context for the enum `found` — its keyword-escaped name, the
+  /// `underlying` raw-value type, a `flags` marking, and its members, each a
+  /// `name` and the integer `value` from the `Constant` table. The underlying
+  /// type is the `value__` field's decoded type (falling back to the dialect's
+  /// `i4` spelling when it does not decode).
+  ///
+  /// The projection mirrors how ClangImporter imports a C enum. A regular enum
+  /// becomes a native fixed-size Swift `enum` over the `underlying` type, so a
+  /// change to that width is a (correct) ABI break the projection surfaces. A
+  /// `[flags]` enum — one bearing a `System.FlagsAttribute`, detected through
+  /// the overridable `flags` query — becomes an `OptionSet` instead: a native
+  /// `enum` case is a single value and cannot name a bitmask combination
+  /// (`a | b` is no `case`), while the `[flags]` contract is exactly that its
+  /// members combine, so a set type is the faithful projection (the shape Clang
+  /// gives an `NS_OPTIONS` C enum). The `flags` key drives that branch in the
+  /// template.
+  ///
+  /// A Win32 enum aliases raw values — two member names for one value — which a
+  /// native `enum` cannot express (`case a = 5; case b = 5` does not compile),
+  /// so the native-enum members are deduplicated by value in declaration order:
+  /// the first member of each distinct value is a `case` (`alias` false), and
+  /// each later member sharing an already-seen value is an alias (`alias` true)
+  /// carrying the `canonical` name of the case it repeats, which the template
+  /// spells as a `static var` returning that case rather than a duplicate
+  /// `case`. An `OptionSet` has no such constraint — its members are `static
+  /// let`s, which tolerate a repeated raw value — so a `[flags]` enum keeps
+  /// every member as a plain member with no aliasing.
+  ///
+  /// The name is carried a second time under `owner`, the enum's own type for
+  /// the `Owner(rawValue: …)` an `OptionSet` member spells and the `.member` an
+  /// alias returns: inside the `{{#members}}` section `{{{name}}}` binds the
+  /// member's own name, so the enclosing type is looked up under a distinct key
+  /// the member context does not shadow.
+  private borrowing func enumeration(_ found: Array<Value>, _ routines: Routines,
+                                     in dialect: Dialect, language: Language,
+                                     search: Array<String>) throws
+      -> Dictionary<String, Any> {
+    let all = try Shell.statement(Shell.query(named: "fields", search: search))
+    let fields = try session.run(all, routines, bindings: ["parent": found[0]])
+    let names = qualifying().names
+    // The `value__` storage field is found by its raw metadata name (column 3),
+    // not the escaped `Name`: a `SANITIZE` override (an active language spec or
+    // session UDF) can respell `value__`, and matching the escaped spelling
+    // would then miss it and silently fall back to `i4`, emitting an enum
+    // backed by a wider type (a `UInt64`) with the wrong ABI representation.
+    let underlying = fields.first { $0[3].text == "value__" }
+        .flatMap { session.storage.decode(field: $0[0].integer, in: dialect,
+                                          qualifying: names) }
+        ?? (dialect.primitives["i4"] ?? "i4")
+    // A `[flags]` enum bears a `System.FlagsAttribute`; the overridable `flags`
+    // query returns a row for it and none for a plain enum. A fixture missing
+    // the attribute rows simply yields no row, so the enum reads as not flags.
+    let mark = try statement(named: "flags")
+    let flags =
+        !(try session.run(mark, routines, bindings: ["parent": found[0]])
+            .isEmpty)
+    let plan = try Shell.statement(Shell.query(named: "members", search: search))
+    let rows = try session.run(plan, routines, bindings: ["parent": found[0]])
+    let name = Shell.name(found, language)
+    let members = rows.map { row -> Dictionary<String, Any> in
+      // `value(field:)` already formats the constant signed or unsigned per
+      // its element type, so an unsigned 64-bit member with bit 63 set spells a
+      // positive `UInt64` decimal the generated raw value accepts. Both arms
+      // project each member as a `static let` on the stored newtype, so a
+      // repeated raw value (a Win32 alias) is simply two named constants — no
+      // deduplication is needed the way a native enum's `case`s would demand.
+      let value = session.storage.value(field: row[0].integer) ?? "0"
+      return ["name": row[1].text, "value": value]
+    }
+    return ["name": name, "owner": name, "underlying": underlying,
+            "flags": flags, "members": members]
+  }
+
+  /// The template context for the delegate `found` — its keyword-escaped name,
+  /// its static `iid`, the `params` its `Invoke` signature carries, and the
+  /// `returns` that signature yields (edge E7). A WinRT delegate is a COM
+  /// interface (IUnknown plus a single `Invoke`), so the projection is an
+  /// `@com(interface:)` protocol carrying just `Invoke` and `@com` generates the
+  /// IUnknown-based vtable from it — the same ABI-faithful shape an interface
+  /// projects.
+  ///
+  /// The `invoke` query selects the delegate's one `Invoke` method, whose
+  /// parameters and return decode exactly as an interface method's do — the
+  /// return set only when it is value-carrying (`returned(_:)` yields `nil` for
+  /// `void`), so `{{#returns}}` renders nothing for a `void` `Invoke`. The
+  /// walk enqueues only a delegate that bears a static GUID, so `guid(of:)`
+  /// resolves the same IID here.
+  private borrowing func delegation(_ found: Array<Value>, _ routines: Routines,
+                                    in dialect: Dialect, language: Language,
+                                    search: Array<String>) throws
+      -> Dictionary<String, Any> {
+    let plan = try Shell.statement(Shell.query(named: "invoke", search: search))
+    let invoke = try session.run(plan, routines, bindings: ["parent": found[0]])
+    // The delegate's own declared generic-parameter names (its `GenericParam`
+    // rows), so a `VAR` in its `Invoke` signature spells its declared name
+    // (`TSender`) rather than a positional placeholder (`T0`); `nil` for a
+    // non-generic delegate, which decodes exactly as before.
+    let names = try declarations(of: found[0], routines, search: search)
+    let generics: Array<String>? = names.isEmpty ? nil : names
+    var params = Array<Dictionary<String, Any>>()
+    var returns: String?
+    if let method = invoke.first {
+      let selection =
+          try Shell.statement(Shell.query(named: "params", search: search))
+      let raw = try session.run(selection, routines,
+                                bindings: ["parent": method[0]])
+      let kept = raw.filter { $0[2] != .integer(0) }
+      let qualified = qualifying().names
+      let types = kept.map {
+        session.storage.decode(parameter: $0[0].integer, generics: generics,
+                               for: dialect, qualifying: qualified) ?? ""
+      }
+      params = Shell.parameters(kept.map(\.[1].text), types: types)
+      if let spelled =
+          session.storage.decode(return: method[0].integer, generics: generics,
+                                 in: dialect, qualifying: qualified) {
+        returns = language.returned(spelled)
+      }
+    }
+    // A generic delegate strips its own name's CLR arity suffix (`Handler``2`)
+    // the way an interface does, and its `ABI` protocol name suffixes the
+    // stripped name before the escape (no Swift keyword ends in `ABI`).
+    let stripped = String(found[2].text.prefix { $0 != "`" })
+    var context: Dictionary<String, Any> = [
+      "name": language.escape(stripped),
+      "abi": language.escape(stripped + "ABI"),
+      "iid": try guid(of: found, routines, search: search) ?? "",
+      "params": params,
+    ]
+    // A value-carrying `Invoke` renders its `-> Type`; a `void` one omits it.
+    if let returns { context["returns"] = returns }
+    // A generic delegate carries its ordered clause and `generic` flag, so its
+    // template branch declares each `associatedtype` and omits `@com` (its IID
+    // is a per-instantiation PIID) exactly as a generic interface; a non-generic
+    // one carries neither, so its output is byte-identical to today's.
+    if let generics {
+      context["generic"] = true
+      // The generic parameter names are keyword-escaped for the declaration the
+      // way the decode escapes their uses, so a parameter whose name is a Swift
+      // keyword declares and reads under one escaped spelling. The raw
+      // `generics` still feed the decode, which escapes on use.
+      context["generics"] = generics.enumerated().map { index, name in
+        ["name": language.escape(name), "last": index == generics.count - 1]
+      }
+    }
+    return context
+  }
+
+  /// The keyword-escaped declaration name of the type `found` — its raw
+  /// `TypeName` stripped of any CLR arity suffix, then escaped through the
+  /// target language's keyword rule, the same order the interface's own name
+  /// uses so a value type named for a keyword still spells compilably.
+  private static func name(_ found: Array<Value>, _ language: Language)
+      -> String {
+    language.escape(String(found[2].text.prefix { $0 != "`" }))
   }
 
   /// The template method entries for the interface at `id`, in declaration
@@ -1067,6 +1949,7 @@ internal struct Shell: ~Escapable {
     }
     var methods = Array<Dictionary<String, Any>>()
     methods.reserveCapacity(rows.count)
+    let qualified = qualifying().names
     for method in rows {
       // The method's parameters: from the batch `signatures` map for `*`, else
       // a per-method `params` query. Both return the same rows in the same
@@ -1080,7 +1963,7 @@ internal struct Shell: ~Escapable {
       let kept = params.filter { $0[2] != .integer(0) }
       let types = kept.map {
         session.storage.decode(parameter: $0[0].integer, generics: generics,
-                               for: dialect) ?? ""
+                               for: dialect, qualifying: qualified) ?? ""
       }
       let parameters = Shell.parameters(kept.map { escaped($0[1].text) },
                                         types: types)
@@ -1089,7 +1972,8 @@ internal struct Shell: ~Escapable {
         "params": parameters,
       ]
       let returned = session.storage.decode(return: method[0].integer,
-                                            generics: generics, in: dialect)
+                                            generics: generics, in: dialect,
+                                            qualifying: qualified)
       if let returned, let clause = language.returned(returned) {
         entry["returns"] = clause
       }
@@ -1205,8 +2089,8 @@ internal struct Shell: ~Escapable {
   /// name (a `-I` directory's copy shadowing the bundle's), the same way the
   /// template is. A name no search directory and no bundle resolves is a
   /// packaging error, raised as `RenderError.query`.
-  private static func query(named name: String,
-                            search: Array<String>) throws -> String {
+  internal static func query(named name: String,
+                             search: Array<String>) throws -> String {
     guard let url = resource(name, "sql", kind: "Render", search: search)
     else { throw RenderError.query(name) }
     let data = try Data(contentsOf: url)
@@ -1335,6 +2219,38 @@ internal struct Shell: ~Escapable {
   }
 }
 
+/// One type the `--closure` walk emitted — its rendered body tagged with the
+/// local `TypeDef` `Id`, declaration name, and kind the nesting assembly folds
+/// it by. A nested type is grouped under its enclosing type through the `Id`;
+/// the name orders siblings within a container; the kind decides whether the
+/// type is a legal value-type container a child may nest inside. It holds only
+/// value types, borrowing no database storage, so a `~Escapable` `Shell` may
+/// collect it.
+private struct Emission {
+  /// The emitted type's local `TypeDef` `Id`.
+  let id: Int
+
+  /// The type's escaped declaration name — the sibling sort key within a
+  /// container.
+  let name: String
+
+  /// The type's render kind — `struct`/`enum`/`interface`/`delegate`. Only a
+  /// `struct` or `enum` renders as a value-type container a nested type may
+  /// legally nest inside; an `interface`/`delegate` renders as a Swift
+  /// `protocol`, which cannot contain a nested type.
+  let kind: String
+
+  /// The synthesized ABI-protocol name a generic interface or delegate declares
+  /// alongside its wrapper (`internal protocol <name>ABI`), `nil` for a
+  /// non-generic type. The declaration `name` does not name it, so the
+  /// collision check counts it too, lest a co-emitted metadata type of that
+  /// name become an invalid redeclaration.
+  let abi: String?
+
+  /// The rendered declaration text.
+  let body: String
+}
+
 /// A per-render memo of parsed render queries, keyed by name. A reference type
 /// so a `borrowing` render method populates it (and clears it at each render's
 /// start) through the reference; it holds only value-type `Statement`s,
@@ -1342,6 +2258,18 @@ internal struct Shell: ~Escapable {
 private final class Cache {
   /// The parsed render queries loaded so far, keyed by name.
   var statements: Dictionary<String, SQLEngine.Statement> = [:]
+}
+
+/// A shell-lifetime memo of the render's namespace-qualification sets
+/// (`Storage.collisions()`): the ambiguous `TypeName`s the decode spells
+/// qualified and the value-type `Id`s the emit wraps in a namespace `enum`. A
+/// reference type so a `borrowing` render method fills it through the reference;
+/// it holds only value-type sets, borrowing none of the database storage, so a
+/// `~Escapable` `Shell` may own it. The sets are a pure function of the
+/// immutable database, so they are computed once and never invalidated.
+private final class Ambiguities {
+  /// The computed sets, or `nil` until first use.
+  var sets: (names: Set<String>, ids: Set<Int>)?
 }
 
 /// Locates resource `<name>.<ext>` of the given `kind` (`Render`, `Queries`,

--- a/Tests/SQLEngineWinMDTests/WinMDDatabaseTests.swift
+++ b/Tests/SQLEngineWinMDTests/WinMDDatabaseTests.swift
@@ -110,13 +110,14 @@ struct WinMDDatabaseTests {
 
   @Test func `enumerates its base relations`() {
     // The store physically holds only `TypeDef`, yet `table(named:)` also
-    // resolves the optional tables — `TypeSpec` (ECMA-335 §II.22.39) and
-    // `NestedClass` (§II.22.32) — to an empty relation when they are absent, so
-    // `relations()` enumerates them too — the catalog contract that
-    // `relations()` names every base relation `table(named:)` resolves. Each is
-    // appended once, past the physical tables.
+    // resolves the optional tables — `TypeSpec` (ECMA-335 §II.22.39),
+    // `NestedClass` (§II.22.32), and `ClassLayout` (§II.22.8) — to an empty
+    // relation when they are absent, so `relations()` enumerates them too — the
+    // catalog contract that `relations()` names every base relation
+    // `table(named:)` resolves. Each is appended once, past the physical tables.
     WinMDDatabaseTests.with { database in
-      #expect(database.relations() == ["TypeDef", "TypeSpec", "NestedClass"])
+      #expect(database.relations()
+                  == ["TypeDef", "TypeSpec", "NestedClass", "ClassLayout"])
     }
   }
 }

--- a/Tests/WinMDSynthesisTests/DecodeTests.swift
+++ b/Tests/WinMDSynthesisTests/DecodeTests.swift
@@ -249,6 +249,23 @@ struct DecodeTests {
                 == "`protocol`<CInt>")
   }
 
+  @Test func `a nested generic base escapes its keyword leaf per component`() {
+    // A nested generic definition spells its base namespace-qualified by its
+    // enclosing dot-path (`Outer.protocol``1`): the arity suffix must be
+    // stripped from the leaf and each component escaped independently. Escaping
+    // the whole dotted `Outer.protocol` as one spares the keyword leaf (it is
+    // not itself a keyword), spelling the invalid `Outer.protocol<CInt>`; the
+    // per-component escape delimits the leaf, matching the non-generic path.
+    let base = TypeDefOrRef(rawValue: 1)
+    let resolver = Resolver([
+      base.rawValue: Identity(namespace: "NS", name: "Outer.protocol`1"),
+    ])
+    let instance = SignatureType.instance(.named(kind: .class, base),
+                                          [.primitive(.int4)])
+    #expect(instance.decode(with: resolver, dialect: dialect)
+                == "Outer.`protocol`<CInt>")
+  }
+
   @Test func `a generic argument keeps the parameter-name class-ID hint`() {
     let base = TypeDefOrRef(rawValue: 1)
     let guid = TypeDefOrRef(rawValue: 2)

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -613,6 +613,55 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test func `the render decode spells a struct field's type from its signature`() {
+    // A struct field's type is decoded at render time from its `FieldDef`
+    // signature (edge E6): the `corner` field (Id 4) is a `VALUETYPE` naming the
+    // local `Point`, decoding to `Point`, while the enum's `value__` underlying
+    // field (Id 1) is an `i4`, decoding to `CInt`.
+    MembersFixture.with { catalog in
+      #expect(catalog.decode(field: 4, in: .swift) == "Point")
+      #expect(catalog.decode(field: 1, in: .swift) == "CInt")
+    }
+  }
+
+  @Test func `a method's referenced identities collect its named signature types`() {
+    // `identities(method:)` returns every distinct type a method signature
+    // names, each an identity paired with the coded row it was named through and
+    // deduplicated by that row: `void Method(Guid, Guid)` names the one
+    // `System.Guid` reference twice, collapsing to a single `Reference`. A
+    // primitive-only signature (`void Method(i4, string)`) names none — the
+    // empty frontier.
+    GuidParamFixture.with { catalog in
+      #expect(Set(catalog.identities(method: 1).map(\.identity))
+                  == [Identity(namespace: "System", name: "Guid")])
+    }
+    DatabaseSQLTests.with { catalog in
+      #expect(catalog.identities(method: 1).isEmpty)
+    }
+  }
+
+  @Test func `a field's referenced identities collect its named signature type`() {
+    // `identities(field:)` returns the types a field signature names: the
+    // `corner` field (Id 4) names the local `Point` value type; the primitive
+    // `value__` field (Id 1) names none.
+    MembersFixture.with { catalog in
+      #expect(Set(catalog.identities(field: 4).map(\.identity))
+                  == [Identity(namespace: "NS", name: "Point")])
+      #expect(catalog.identities(field: 1).isEmpty)
+    }
+  }
+
+  @Test func `an enum member's constant value decodes from the Constant table`() {
+    // Each enum member field carries a `Constant` row whose `Value` blob holds
+    // its raw value: `Red` (Id 2) is 5 and `Green` (Id 3) is 7. The `value__`
+    // underlying field (Id 1) bears no constant, so it yields `nil`.
+    MembersFixture.with { catalog in
+      #expect(catalog.value(field: 2) == 5)
+      #expect(catalog.value(field: 3) == 7)
+      #expect(catalog.value(field: 1) == nil)
+    }
+  }
+
   @Test func `the bundled bases view yields the interface's derived bases`() throws {
     // `IMyInterface` is `TypeDef` Id 1; binding `:parent` to its Id
     // navigates `InterfaceImpl.Class = :parent`, and the view UNIONs both arms
@@ -1931,6 +1980,95 @@ private enum RootInterfaceFixture {
 
   private static let valid: UInt64 =
       (1 << 1) | (1 << 2) | (1 << 6) | (1 << 9) | (1 << 10) | (1 << 12)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A metadata fixture of a struct's and an enum's fields — the value-type
+/// signature edges the closure walk pulls in (E6) and the `Constant`-table
+/// member values a native enum projection needs. Three narrow (all-index
+/// 2-byte) tables packed back to back in table-number order — `TypeRef` (#1),
+/// `FieldDef` (#4), `Constant` (#11) — with no owning `TypeDef` linkage, since
+/// the storage helpers key on a `FieldDef` `Id` directly. A stored index `N`
+/// names the 0-based row `N - 1`; a `TypeDefOrRef`/`HasConstant` coded token is
+/// `(row << bits) | tag`.
+///
+///   TypeRef[0]:  ResolutionScope=0, TypeName="Point"(4), TypeNamespace="NS"(1)
+///                — the named value type the `corner` field references.
+///   FieldDef[0]: Name="value__"(10), Signature=blob[1] (an `i4`) — an enum's
+///                underlying storage field, its type spelling the raw-value type.
+///   FieldDef[1]: Name="Red"(18), Signature=blob[1] — an enum member; its raw
+///                value lives in the `Constant` table.
+///   FieldDef[2]: Name="Green"(22), Signature=blob[1] — a second enum member.
+///   FieldDef[3]: Name="corner"(28), Signature=blob[4] (a `VALUETYPE` naming
+///                `TypeRef` row 1, `Point`) — a struct field of a named value
+///                type.
+///   Constant[0]: Type=I4, Parent=HasConstant(FieldDef row 2)=(2<<2)|0=8,
+///                Value=blob[8] (the little-endian i4 `5`) — `Red`'s value.
+///   Constant[1]: Type=I4, Parent=HasConstant(FieldDef row 3)=(3<<2)|0=12,
+///                Value=blob[13] (the little-endian i4 `7`) — `Green`'s value.
+private enum MembersFixture {
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] — Point
+    0x00, 0x00, 0x04, 0x00, 0x01, 0x00,
+    // FieldDef[0] — value__
+    0x00, 0x00, 0x0a, 0x00, 0x01, 0x00,
+    // FieldDef[1] — Red
+    0x00, 0x00, 0x12, 0x00, 0x01, 0x00,
+    // FieldDef[2] — Green
+    0x00, 0x00, 0x16, 0x00, 0x01, 0x00,
+    // FieldDef[3] — corner
+    0x00, 0x00, 0x1c, 0x00, 0x04, 0x00,
+    // Constant[0] — Red = 5
+    0x08, 0x00, 0x08, 0x00, 0x08, 0x00,
+    // Constant[1] — Green = 7
+    0x08, 0x00, 0x0c, 0x00, 0x0d, 0x00,
+  ]
+
+  // "\0NS\0Point\0value__\0Red\0Green\0corner\0": NS@1, Point@4, value__@10,
+  // Red@18, Green@22, corner@28.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x4e, 0x53, 0x00,
+    0x50, 0x6f, 0x69, 0x6e, 0x74, 0x00,
+    0x76, 0x61, 0x6c, 0x75, 0x65, 0x5f, 0x5f, 0x00,
+    0x52, 0x65, 0x64, 0x00,
+    0x47, 0x72, 0x65, 0x65, 0x6e, 0x00,
+    0x63, 0x6f, 0x72, 0x6e, 0x65, 0x72, 0x00,
+  ]
+
+  // A `#Blob` heap: the reserved empty blob at 0, then the field signatures and
+  // the constant value blobs, each length-prefixed.
+  //   @1:  [0x02] FIELD(0x06) I4(0x08) — the `i4` field signature.
+  //   @4:  [0x03] FIELD(0x06) VALUETYPE(0x11) TypeRef#1(token 0x05) — `Point`.
+  //   @8:  [0x04] 05 00 00 00 — the little-endian i4 constant `5`.
+  //   @13: [0x04] 07 00 00 00 — the little-endian i4 constant `7`.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x02, 0x06, 0x08,
+    0x03, 0x06, 0x11, 0x05,
+    0x04, 0x05, 0x00, 0x00, 0x00,
+    0x04, 0x07, 0x00, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 4, range: 6 ..< 30,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 2, range: 30 ..< 42,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 = (1 << 1) | (1 << 4) | (1 << 11)
 
   /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
   static func with(_ body: (borrowing Storage) throws -> Void) rethrows {

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -653,13 +653,137 @@ struct DatabaseSQLTests {
 
   @Test func `an enum member's constant value decodes from the Constant table`() {
     // Each enum member field carries a `Constant` row whose `Value` blob holds
-    // its raw value: `Red` (Id 2) is 5 and `Green` (Id 3) is 7. The `value__`
-    // underlying field (Id 1) bears no constant, so it yields `nil`.
+    // its raw value, formatted signed or unsigned per its element type: `Red`
+    // (Id 2) is 5 and `Green` (Id 3) is 7. The `value__` underlying field (Id 1)
+    // bears no constant, so it yields `nil`.
     MembersFixture.with { catalog in
-      #expect(catalog.value(field: 2) == 5)
-      #expect(catalog.value(field: 3) == 7)
+      #expect(catalog.value(field: 2) == "5")
+      #expect(catalog.value(field: 3) == "7")
       #expect(catalog.value(field: 1) == nil)
     }
+  }
+
+  @Test func `an unsigned 64-bit enum constant with bit 63 set stays positive`() {
+    // A `UInt64`-backed enum member (element type `etUInt8`) whose value is
+    // `0x8000000000000000` — bit 63 set — equals `9223372036854775808` as a
+    // `UInt64`, but that same bit pattern read as `Int64` is `Int64.min`, a
+    // negative value. `value(field:)` must format it per the element's
+    // signedness so the generated `rawValue:` literal stays a positive `UInt64`
+    // decimal; pre-fix it funnelled every constant through `Int`, so a `UInt64`
+    // raw value would be initialised from a rejected negative literal.
+    UnsignedConstantFixture.with { catalog in
+      #expect(catalog.value(field: 1) == "9223372036854775808")
+    }
+  }
+
+  @Test func `a sorted Constant table seeks a field's value by binary search`() {
+    // `Constant.Parent` is the table's sort key, so when the database stores the
+    // table sorted `value(field:)` binary-searches the raw coded `Parent`
+    // column — the same quantity the rows are ordered by — instead of scanning.
+    // The fixture sorts three rows by ascending raw `Parent` (fields 2, 4, 6,
+    // encoding to 8, 16, 24), so each present field seeks its own row and a field
+    // with no row (1, 3, 5, 7 — a near-miss the lower bound brackets to a
+    // neighbouring row, or past the end) is rejected by the decoded-key recheck,
+    // yielding `nil`. The result matches the linear scan exactly — a pure speedup.
+    SortedConstantFixture.with { catalog in
+      #expect(catalog.value(field: 2) == "5")
+      #expect(catalog.value(field: 4) == "7")
+      #expect(catalog.value(field: 6) == "9")
+      #expect(catalog.value(field: 1) == nil)
+      #expect(catalog.value(field: 3) == nil)
+      #expect(catalog.value(field: 5) == nil)
+      #expect(catalog.value(field: 7) == nil)
+    }
+  }
+
+  @Test func `the bundled flags query detects a System FlagsAttribute`() throws {
+    // The overridable `flags` query returns a row for an enum `TypeDef` bearing a
+    // `System.FlagsAttribute` custom attribute and no row for one that does not —
+    // the `[flags]` marking `enumeration` reads to project an `OptionSet` rather
+    // than a native Swift `enum`. `Flagged` (`TypeDef` Id 1) bears the attribute
+    // through a `MemberRef` naming the `System.FlagsAttribute` `TypeRef` (the
+    // encoding real metadata uses); `Plain` (Id 2) bears none. This runs the real
+    // bundled `Render/flags.sql`, so it pins its (namespace, name) match and its
+    // three attribute-encoding arms. Born with the query: pre-change there is no
+    // `flags` query to load, and it correctly discriminates the two enums.
+    let flags = try Shell.query(named: "flags", search: [])
+    try FlagsFixture.with { catalog in
+      let flagged = try DatabaseSQLTests.run(flags, [:], catalog,
+                                             ["parent": .integer(1)])
+      #expect(!flagged.isEmpty)
+      let plain = try DatabaseSQLTests.run(flags, [:], catalog,
+                                           ["parent": .integer(2)])
+      #expect(plain.isEmpty)
+    }
+  }
+
+  @Test func `the bundled com template renders a flags enum as an OptionSet`() throws {
+    // A `[flags]` enum renders through the `{{#flags}}` arm of the real bundled
+    // `com` enum section: an `OptionSet` whose `RawValue` is the `value__`
+    // underlying type, each member a `@_transparent` accessor folding to its raw
+    // constant — the projection that faithfully models a bitmask, which a native
+    // `enum` case (a single value) cannot. The context is the one `enumeration`
+    // assembles for a `[flags]` enum: `flags` true, and members carrying no alias
+    // (the accessors tolerate a repeated raw value). Pre-change the enum section
+    // had only the struct-newtype arm, so this OptionSet shape is born with the
+    // `{{#flags}}` branch.
+    let body = try DatabaseSQLTests.template(named: "com")
+    let template = try MustacheTemplate(string: body)
+    let context: [String: Any] = [
+      "name": "FileAccess", "owner": "FileAccess",
+      "underlying": "CUnsignedInt", "flags": true,
+      "members": [
+        ["name": "read", "value": "1", "alias": false],
+        ["name": "write", "value": "2", "alias": false],
+      ],
+    ]
+    let rendered = template.render(["enum": context])
+    #expect(rendered.contains("@frozen public struct FileAccess: OptionSet {"))
+    #expect(rendered.contains("public typealias RawValue = CUnsignedInt"))
+    #expect(rendered.contains("public let rawValue: RawValue"))
+    #expect(rendered.contains(
+        "@inlinable public init(rawValue: RawValue) { self.rawValue = rawValue }"))
+    #expect(rendered.contains(
+        "@_transparent public static var read: FileAccess { FileAccess(rawValue: 1) }"))
+    #expect(rendered.contains(
+        "@_transparent public static var write: FileAccess { FileAccess(rawValue: 2) }"))
+    // No emitted `[flags]` explanation — the template comment is non-rendering.
+    #expect(!rendered.contains("[flags]"))
+    // Not a native enum: the OptionSet models the bitmask a `case` cannot.
+    #expect(!rendered.contains("enum FileAccess"))
+    #expect(!rendered.contains("case read"))
+  }
+
+  @Test func `the bundled com template renders a regular enum as a raw-value struct newtype`() throws {
+    // A regular enum renders through the `{{^flags}}` arm: an explicitly-stored
+    // raw-value struct newtype over its `value__` underlying type, its members
+    // named constants — not a native Swift `enum`, whose compact representation
+    // would not carry the raw type's ABI width (a two-case `enum E: UInt32` is
+    // one byte, not four). A repeated raw value (a Win32 alias) is simply two
+    // `@_transparent` accessors the stored newtype tolerates, where a native
+    // enum's `case`s could not. The context is the one `enumeration` assembles:
+    // `flags` false.
+    let body = try DatabaseSQLTests.template(named: "com")
+    let template = try MustacheTemplate(string: body)
+    let context: [String: Any] = [
+      "name": "Palette", "owner": "Palette", "underlying": "CInt",
+      "flags": false,
+      "members": [
+        ["name": "Red", "value": "5"],
+        ["name": "Green", "value": "5"],
+      ],
+    ]
+    let rendered = template.render(["enum": context])
+    #expect(rendered.contains(
+        "@frozen public struct Palette: Hashable, Sendable {"))
+    #expect(rendered.contains("public var rawValue: CInt"))
+    #expect(rendered.contains(
+        "@_transparent public static var Red: Palette { Palette(rawValue: 5) }"))
+    #expect(rendered.contains(
+        "@_transparent public static var Green: Palette { Palette(rawValue: 5) }"))
+    // Not a native enum (the wrong ABI width) nor the `[flags]` OptionSet.
+    #expect(!rendered.contains("enum Palette"))
+    #expect(!rendered.contains("OptionSet"))
   }
 
   @Test func `the bundled bases view yields the interface's derived bases`() throws {
@@ -973,9 +1097,12 @@ struct DatabaseSQLTests {
     // interface through it. The fixture's `IMyInterface` renders through a
     // minimal inline template (no language directive — the identity language
     // leaves the body verbatim), proving the inline template feeds the render.
+    // The render feeds a kind-tagged context, so the template reads an
+    // interface's fields under its `{{#interface}}` section.
     try DatabaseSQLTests.with { catalog in
       var shell = Shell(catalog)
-      try shell.execute(".template mine 'interface {{name}}'")
+      try shell.execute(
+          ".template mine '{{#interface}}interface {{name}}{{/interface}}'")
       let rendered = try shell.render("IMyInterface", template: "mine")
       #expect(rendered == "interface IMyInterface")
     }
@@ -1032,7 +1159,9 @@ struct DatabaseSQLTests {
         ],
       ],
     ]
-    #expect(template.render(context) == """
+    // The context is kind-tagged: an interface's fields nest under the
+    // `interface` key, the shape the template's `{{#interface}}` section reads.
+    #expect(template.render(["interface": context]) == """
       // A WinRT parameterised interface has no static IID: its IID is a
       // per-instantiation PIID computed at runtime from the type
       // arguments, so no `@com(interface:)` is emitted on the ABI protocol
@@ -1050,6 +1179,47 @@ struct DatabaseSQLTests {
       }
 
       """)
+  }
+
+  @Test func `the bundled com template renders a generic delegate as an ABI protocol`() throws {
+    // A generic delegate renders through the `{{#generic}}` arm of the REAL
+    // bundled `com` delegate section, mirroring the generic interface: an
+    // internal ABI protocol carrying its ordered type parameters as primary
+    // associated types (`<TSender, TResult>` naming an `associatedtype` each),
+    // with NO `@com(interface:)` (its IID is a runtime per-instantiation PIID),
+    // so the `Invoke` signature spelling `TSender`/`TResult` resolves. The
+    // context is the one `delegation` assembles for a generic delegate: the
+    // arity suffix stripped, the ordered `generics`, and the `Invoke` parameter
+    // types decoded to the declared names (not positional `T0` placeholders).
+    let body = try DatabaseSQLTests.template(named: "com")
+    let template = try MustacheTemplate(string: body)
+    let context: [String: Any] = [
+      "name": "TypedEventHandler",
+      "abi": "TypedEventHandlerABI",
+      "iid": "00000000-0000-0000-0000-000000000000",
+      "generic": true,
+      "generics": [["name": "TSender", "last": false],
+                   ["name": "TResult", "last": true]],
+      "params": [
+        ["name": "sender", "type": "TSender", "last": false],
+        ["name": "args", "type": "TResult", "last": true],
+      ],
+    ]
+    let rendered = template.render(["delegate": context])
+    // The generic arm: an ABI protocol with primary associated types, no `@com`.
+    #expect(rendered.contains(
+        "internal protocol TypedEventHandlerABI<TSender, TResult> {"))
+    #expect(rendered.contains("    associatedtype TSender"))
+    #expect(rendered.contains("    associatedtype TResult"))
+    #expect(rendered.contains(
+        "    func Invoke(_ sender: TSender, _ args: TResult)"))
+    // The non-generic arm's `@com public protocol TypedEventHandler` is absent
+    // (a parameterised delegate has no static IID) — pre-fix, the delegate
+    // section had only that arm, so a generic delegate wrongly emitted it with
+    // an empty IID. The generic arm's own comment mentions `@com`, so the
+    // assertion pins the actual declaration, not the word.
+    #expect(!rendered.contains("public protocol TypedEventHandler {"))
+    #expect(!rendered.contains("@com(interface: \"00000000"))
   }
 
   @Test func `a generic interface whose stripped name is a keyword renders escaped`() throws {
@@ -1220,7 +1390,9 @@ struct DatabaseSQLTests {
         ],
       ],
     ]
-    #expect(template.render(context) == """
+    // The context is kind-tagged: an interface's fields nest under the
+    // `interface` key, the shape the template's `{{#interface}}` section reads.
+    #expect(template.render(["interface": context]) == """
       // A WinRT parameterised interface has no static IID: its IID is a
       // per-instantiation PIID computed at runtime from the type
       // arguments, so no `@com(interface:)` is emitted on the ABI protocol
@@ -1992,7 +2164,7 @@ private enum RootInterfaceFixture {
 
 /// A metadata fixture of a struct's and an enum's fields — the value-type
 /// signature edges the closure walk pulls in (E6) and the `Constant`-table
-/// member values a native enum projection needs. Three narrow (all-index
+/// member values the enum newtype projection needs. Three narrow (all-index
 /// 2-byte) tables packed back to back in table-number order — `TypeRef` (#1),
 /// `FieldDef` (#4), `Constant` (#11) — with no owning `TypeDef` linkage, since
 /// the storage helpers key on a `FieldDef` `Id` directly. A stored index `N`
@@ -2075,6 +2247,168 @@ private enum MembersFixture {
     let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
                           strings: strings.span.bytes, blob: blob.span.bytes,
                           guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A metadata fixture pinning the `flags` query's `System.FlagsAttribute`
+/// detection: two enum `TypeDef`s, one bearing the attribute and one not, so the
+/// query's (namespace, name) match and its `CustomAttribute → MemberRef →
+/// TypeRef` walk are exercised on a real bearing type. Five narrow (all-index
+/// 2-byte) tables in table-number order — `TypeRef` (#1, 1 row), `TypeDef` (#2,
+/// 2 rows), `MethodDef` (#6, empty, present so the query's `MethodDef` arm
+/// resolves a relation), `MemberRef` (#10, 1 row), `CustomAttribute` (#12, 1
+/// row). A stored index `N` names the 0-based row `N - 1`; a coded token is
+/// `(row << bits) | tag`.
+///
+///   TypeRef[0]:  ResolutionScope=0, TypeName="FlagsAttribute"(8),
+///                TypeNamespace="System"(1) — the attribute the query matches.
+///   TypeDef[0]:  TypeName="Flagged"(26), TypeNamespace="NS"(23) — the enum that
+///                bears the attribute.
+///   TypeDef[1]:  TypeName="Plain"(34), TypeNamespace="NS"(23) — the enum that
+///                does not.
+///   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+///                `FlagsAttribute` constructor, naming the `TypeRef`.
+///   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+///                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11 — so
+///                `Flagged`, and not `Plain`, bears `System.FlagsAttribute`.
+private enum FlagsFixture {
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] — System.FlagsAttribute
+    0x00, 0x00, 0x08, 0x00, 0x01, 0x00,
+    // TypeDef[0] — Flagged
+    0x00, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x17, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[1] — Plain
+    0x00, 0x00, 0x00, 0x00, 0x22, 0x00, 0x17, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // MemberRef[0] — the FlagsAttribute ctor
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0] — Flagged's FlagsAttribute
+    0x23, 0x00, 0x0b, 0x00, 0x00, 0x00,
+  ]
+
+  // "\0System\0FlagsAttribute\0NS\0Flagged\0Plain\0": System@1, FlagsAttribute@8,
+  // NS@23, Flagged@26, Plain@34.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00,
+    0x46, 0x6c, 0x61, 0x67, 0x73, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75,
+    0x74, 0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x46, 0x6c, 0x61, 0x67, 0x67, 0x65, 0x64, 0x00,
+    0x50, 0x6c, 0x61, 0x69, 0x6e, 0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [0x00]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 34 ..< 40,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 40 ..< 46,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 10) | (1 << 12)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A metadata fixture with a single `Constant` row — an enum member whose value
+/// is an unsigned 8-byte integer (`etUInt8`) with bit 63 set — to pin the
+/// unsigned formatting of `value(field:)`. Only the `Constant` table (§II.22.9,
+/// table number 11) is present; `value(field:)` scans it by the `FieldDef`
+/// `Id` its `Parent` (`HasConstant`) names, so no other table is needed.
+private enum UnsignedConstantFixture {
+  //   Constant[0]: Type=etUInt8 (`0x0b`), Parent=HasConstant(FieldDef row 1) =
+  //                (1 << 2) | 0 = 4, Value=blob@1.
+  private static let bytes: Array<UInt8> = [
+    0x0b, 0x00, 0x04, 0x00, 0x01, 0x00,
+  ]
+
+  // A `#Blob` heap: the reserved empty blob at 0, then at 1 the length-prefixed
+  // 8-byte little-endian `0x8000000000000000` (bit 63 set).
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 = (1 << 11)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: empty.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A fixture exercising the sorted-index binary search of `value(field:)`.
+/// Only the `Constant` table (§II.22.9, table number 11) is present, and the
+/// `sorted` bitmask marks it sorted on its `Parent` key, so `value(field:)`
+/// seeks a field's row through `Storage.bound` on the raw coded `Parent` column
+/// rather than scanning. The three rows are ordered by ascending raw `Parent`
+/// (the sort the seek relies on): fields 2, 4, 6 encode to `HasConstant` raw
+/// cells 8, 16, 24 (tag 0, `(field << 2) | 0`), each an `etInt4` value.
+private enum SortedConstantFixture {
+  //   Constant[0]: Type=etInt4 (`0x08`), Parent=HasConstant(FieldDef row 2) =
+  //                (2 << 2) | 0 = 8, Value=blob@1 (5).
+  //   Constant[1]: Type=etInt4, Parent=(4 << 2) | 0 = 16, Value=blob@6 (7).
+  //   Constant[2]: Type=etInt4, Parent=(6 << 2) | 0 = 24, Value=blob@11 (9).
+  private static let bytes: Array<UInt8> = [
+    0x08, 0x00, 0x08, 0x00, 0x01, 0x00,
+    0x08, 0x00, 0x10, 0x00, 0x06, 0x00,
+    0x08, 0x00, 0x18, 0x00, 0x0b, 0x00,
+  ]
+
+  // A `#Blob` heap: the reserved empty blob at 0, then three length-prefixed
+  // 4-byte little-endian `etInt4` values 5, 7, 9 at offsets 1, 6, 11.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x04, 0x05, 0x00, 0x00, 0x00,
+    0x04, 0x07, 0x00, 0x00, 0x00,
+    0x04, 0x09, 0x00, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 3, range: 0 ..< 18,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 = (1 << 11)
+  private static let sorted: UInt64 = (1 << 11)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata, with
+  /// the `Constant` table marked sorted on its `Parent` key.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: empty.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: sorted)
     try body(storage)
   }
 }

--- a/Tests/winmd-inspectTests/RenderClosureTests.swift
+++ b/Tests/winmd-inspectTests/RenderClosureTests.swift
@@ -11,6 +11,11 @@ import SQLEngine
 @testable import WinMD
 import WinMDSynthesis
 
+import struct Foundation.Data
+import class Foundation.FileManager
+import struct Foundation.URL
+import struct Foundation.UUID
+
 /// Coverage of the `.render … --closure` transitive-closure walk (Stage 0: the
 /// plain base and required-interface edges). Rather than map a `.winmd` file,
 /// the fixture assembles two method-less COM interfaces in memory — `IBase` and
@@ -159,6 +164,557 @@ struct RenderClosureTests {
       #expect(closed.contains("public protocol IBase: IUnknown {"))
       #expect(closed.contains("public protocol IDerived: IBase {"))
     }
+  }
+
+  @Test func `--closure pulls in a struct a method returns, before the interface`() throws {
+    // `IRoot.Make` returns the local struct `Point` (edge E3, value arm). The
+    // closure decodes the method signature, resolves `Point` to its local
+    // `struct` `TypeDef`, and emits it before `IRoot`, the type naming it — the
+    // post-order the walk holds. The flat render of `IRoot` alone pulls nothing
+    // in.
+    try ClosureFixture.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      // `@frozen` fixes the ABI layout so the projected struct is the C/C++
+      // record it mirrors field for field.
+      #expect(closed.contains("@frozen public struct Point {"))
+      #expect(closed.contains("public var value: CInt"))
+      // A public memberwise initializer — the synthesized one is internal, so a
+      // caller outside the generated module could not otherwise construct it.
+      #expect(closed.contains("public init(value: CInt) {"))
+      #expect(closed.contains("self.value = value"))
+      let structure = try #require(closed.range(of: "public struct Point"))
+      let interface = try #require(closed.range(of: "public protocol IRoot"))
+      #expect(structure.lowerBound < interface.lowerBound)
+
+      let flat = try shell.render("IRoot", template: "com")
+      #expect(!flat.contains("public struct Point"))
+    }
+  }
+
+  @Test func `--closure omits a static field from struct storage`() throws {
+    // `Point`'s only field `value` is marked `fdStatic`. A static field is not
+    // laid out in an instance, so emitting it as a stored `public var` would add
+    // a nonexistent field and shift every offset, corrupting a by-value native
+    // call. The struct render must drop it — `Point` stays a struct but carries
+    // no `value` field and no `value` init parameter. Pre-fix, the fields loop
+    // emitted every `FieldDef` row as a stored `var`.
+    try ClosureFixture.withStaticPointField { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("@frozen public struct Point {"))
+      #expect(!closed.contains("public var value"))
+      #expect(!closed.contains("public init(value:"))
+    }
+  }
+
+  @Test func `--closure rejects an explicit-layout struct rather than misprojecting it`() throws {
+    // The same `IRoot.Make` returns `Point`, but `Point`'s `TypeDef` `Flags`
+    // now carry `tdExplicitLayout` (the `0x10` value of the `0x18` LayoutMask),
+    // marking it a union or offset-placed record. `@frozen` freezes the layout
+    // Swift chooses, not the declared one, so projecting it would give the wrong
+    // size and field offsets across the ABI. The closure must reject it — emit
+    // nothing for `Point` and not recurse its fields — leaving it a frontier the
+    // consumer defines, while `IRoot` itself still renders. Pre-fix, the walk
+    // emitted every resolved value type, so `Point` came out as an
+    // ABI-incompatible `@frozen` struct.
+    try ClosureFixture.withPointFlags(0x10) { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("public protocol IRoot"))
+      #expect(!closed.contains("struct Point"))
+    }
+  }
+
+  @Test func `--closure projects a regular enum a method names as a raw-value struct newtype`() throws {
+    // `IRoot.Paint(Color)` names the local enum `Color`, a regular (non-`[flags]`)
+    // enum. The closure projects it as an explicitly-stored raw-value struct
+    // newtype, not a native Swift `enum`: a native `enum Color: CInt` does not
+    // carry `CInt`'s ABI width — Swift freezes a compact representation, so a
+    // two-case enum is one byte, not four — so the newtype stores the `value__`
+    // underlying type directly (the ABI-exact width) and its members are
+    // `@_transparent` accessors folding to values read from the `Constant` table
+    // (`Red = 5`, `Green = 7`). The `OptionSet` is the separate `[flags]`
+    // projection.
+    try ClosureFixture.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains(
+          "@frozen public struct Color: Hashable, Sendable {"))
+      #expect(closed.contains("public var rawValue: CInt"))
+      #expect(closed.contains(
+          "@_transparent public static var Red: Color { Color(rawValue: 5) }"))
+      #expect(closed.contains(
+          "@_transparent public static var Green: Color { Color(rawValue: 7) }"))
+      // Not a native enum (the wrong ABI width) nor the `[flags]` OptionSet.
+      #expect(!closed.contains("enum Color"))
+      #expect(!closed.contains("Color: OptionSet"))
+    }
+  }
+
+  @Test func `--closure emits a duplicate enum raw value as two static constants`() throws {
+    // A Win32 enum aliases raw values — two member names for one value.
+    // `withDuplicateColorValue` makes `Green` share `Red`'s value 5. The stored
+    // struct newtype tolerates this: both are `@_transparent` accessors of the
+    // same raw value, no deduplication a native enum's `case`s would demand. Both
+    // members emit — the alias the C enum spelled, without a compile error.
+    try ClosureFixture.withDuplicateColorValue { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains(
+          "@_transparent public static var Red: Color { Color(rawValue: 5) }"))
+      #expect(closed.contains(
+          "@_transparent public static var Green: Color { Color(rawValue: 5) }"))
+    }
+  }
+
+  @Test func `--closure projects a delegate a method names as a com protocol`() throws {
+    // `IRoot.Listen(Handler)` names the local delegate `Handler`. A WinRT
+    // delegate is a COM interface (IUnknown plus a single `Invoke`), so the
+    // closure projects it as an `@com(interface:)` protocol carrying just
+    // `Invoke` — its own static IID decoded through the `guid` query — not a
+    // Swift closure typealias. `void Invoke(i4)` renders a void return (no
+    // arrow) over a single `CInt` parameter.
+    try ClosureFixture.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains(
+          "@com(interface: \"DEADBEEF-CAFE-BABE-F00D-1234567890AB\")"))
+      #expect(closed.contains("public protocol Handler {"))
+      #expect(closed.contains("func Invoke(_ : CInt)"))
+      // Not a closure typealias.
+      #expect(!closed.contains("typealias Handler"))
+    }
+  }
+
+  @Test func `--closure keeps a parameterized delegate a method names`() throws {
+    // `IRoot.Listen(Handler)` names `Handler`, now parameterized by a
+    // `GenericParam`. A generic delegate has no static IID — its IID is a
+    // per-instantiation PIID — so `guid(of:)` resolves nothing; yet the closure
+    // must keep it and emit its generic ABI-protocol arm (no `@com`), the way a
+    // generic interface is kept, rather than drop it as GUID-less. Pre-fix the
+    // delegate filter dropped every `guid(of:) == nil` delegate, so a
+    // parameterized one vanished and `IRoot` named a type never declared.
+    try ClosureFixture.withGenericHandler { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("public protocol IRoot"))
+      // Kept, emitted through the generic arm — an ABI protocol, no static IID.
+      #expect(closed.contains("internal protocol HandlerABI<T>"))
+      #expect(!closed.contains("@com(interface: \"\")"))
+      // The public wrapper a signature naming `Handler<T>` resolves to must be
+      // declared alongside the ABI protocol, the same shape a generic interface
+      // gives its wrapper — a `public struct Handler<T>` holding the ABI
+      // existential and forwarding `Invoke`. Without it the parameterised name a
+      // signature spells is undeclared and the closure does not compile.
+      #expect(closed.contains("public struct Handler<T>"))
+      #expect(closed.contains("internal let base: any HandlerABI<T>"))
+      #expect(closed.contains("base.Invoke("))
+    }
+  }
+
+  @Test func `--closure escapes a keyword-named generic parameter's declaration`() throws {
+    // `Handler`'s generic parameter is named `class`, a Swift keyword. Its
+    // primary-associated-type clause and `associatedtype` declaration — and the
+    // wrapper's clause — must escape it the way the decode escapes its uses in
+    // the `Invoke` signature, or the generated declaration is invalid Swift.
+    try ClosureFixture.withGenericHandler(named: "class") { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("internal protocol HandlerABI<`class`>"))
+      #expect(closed.contains("associatedtype `class`"))
+      #expect(closed.contains("public struct Handler<`class`>"))
+      // Not the raw keyword, which would not compile.
+      #expect(!closed.contains("associatedtype class\n"))
+    }
+  }
+
+  @Test func `--closure enqueues an interface a method names, emitting it`() throws {
+    // `IRoot.Chain(IOther)` names another local interface. A signature-named
+    // interface routes through the interface path — enqueued, then emitted
+    // through the `{{#interface}}` section, its own IID intact — before `IRoot`.
+    try ClosureFixture.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("public protocol IOther: IUnknown {"))
+      let other = try #require(closed.range(of: "public protocol IOther"))
+      let root = try #require(closed.range(of: "public protocol IRoot"))
+      #expect(other.lowerBound < root.lowerBound)
+    }
+  }
+
+  @Test func `the render decode spells a unique-named value type bare`() {
+    // Qualification is collision-only: a value type whose simple `TypeName` is
+    // borne by no other value type spells BARE, its namespace omitted. `Point`
+    // (a struct) and `Color` (an enum) are each the only value type of their
+    // name, so `IRoot.Make`'s return decodes to the bare `Point` and `Paint`'s
+    // `Color` parameter to the bare `Color` — not `NS.Point`/`NS.Color`. A
+    // protocol type is never qualified either, so `Chain`'s `IOther` interface
+    // parameter stays the bare `IOther`. (Pre-fix always-qualify wrongly spelled
+    // the unique `Point`/`Color` with their namespace; a genuine collision is
+    // covered by `RenderClosureNamespaceTests`.)
+    ClosureFixture.with { catalog in
+      #expect(catalog.decode(return: 1, in: .swift) == "Point")
+      // `Make` has no parameters, so the four `Param` rows are, in declaration
+      // order, `Paint`'s `Color` (1), `Listen`'s `Handler` (2), `Chain`'s
+      // `IOther` (3), and `Invoke`'s `i4` (4).
+      #expect(catalog.decode(parameter: 1, for: .swift) == "Color")
+      #expect(catalog.decode(parameter: 3, for: .swift) == "IOther")
+    }
+  }
+
+  @Test func `--closure emits a unique-named value type bare, with no namespace`() throws {
+    // The emit half of collision-only: an unambiguous top-level value type is a
+    // plain root, wrapped in no fabricated namespace `enum`, matching the bare
+    // spelling its references carry. `Point` and `Color` are each uniquely
+    // named, so the closure over `IRoot` emits them at the top level with no
+    // `public enum NS` container — unlike a genuine collision, which
+    // `RenderClosureNamespaceTests` wraps.
+    try ClosureFixture.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("@frozen public struct Point {"))
+      #expect(closed.contains("@frozen public struct Color: Hashable, Sendable {"))
+      #expect(!closed.contains("public enum NS"))
+      #expect(!closed.contains("NS.Point"))
+      #expect(!closed.contains("NS.Color"))
+    }
+  }
+
+  @Test func `--closure frontiers a reached type the language import provides`() throws {
+    // Change 1 — frontier a `known` dependency. A type whose Identity
+    // `(namespace, name)` is a key in the dialect's `known` bridge table is one
+    // the consumer already has from the language import, so the closure must
+    // emit no wrapper for it and not walk its members, exactly as the
+    // layout-reject and nested-protocol frontiers do — while a reference still
+    // spells through `dialect.known` (its bridged name). `IRoot.Make` returns
+    // the local struct `Point` (namespace `NS`); a `-I` `swift.lang` that adds
+    // `wellknown NS.Point PointBridge` makes `(NS, Point)` a `known` key, so
+    // the closure frontiers `Point` — no `struct Point` renders — yet `Make`
+    // still spells its return `PointBridge` from the bridge table. The unique
+    // enum `Color`, absent from `known`, still emits.
+    let bridge = "wellknown NS.Point PointBridge"
+    try RenderClosureTests.withLanguage(adding: bridge) { directory in
+      try ClosureFixture.with { catalog in
+        let shell = Shell(catalog, search: [directory])
+        let closed = try shell.render(closure: "IRoot", template: "com")
+        // The `known` struct is frontiered: no wrapper renders for it.
+        #expect(!closed.contains("public struct Point"))
+        // … yet a reference still spells its bridged name.
+        #expect(closed.contains("-> PointBridge"))
+        // The root interface, and a non-`known` value type it names, still emit.
+        #expect(closed.contains("public protocol IRoot"))
+        #expect(closed.contains("@frozen public struct Color: Hashable, Sendable {"))
+      }
+    }
+  }
+
+  @Test func `--closure drops a guid-less nongeneric interface a signature names`() throws {
+    // `IRoot.Chain(IOther)` still names `IOther`, but `IOther`'s `GuidAttribute`
+    // is removed, so it has no static IID and `references` yields a NULL iid.
+    // Emitting it would spell `@com(interface: "")` — unusable source — so the
+    // closure must drop it (the normal `interfaces` view's INNER GUID join
+    // excludes it too), leaving it a frontier while `IRoot` still renders.
+    // Pre-fix, only classes and guid-less delegates were filtered, so the
+    // guid-less interface was emitted with an empty `@com` interface id.
+    try ClosureFixture.withoutIOtherGuid { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("public protocol IRoot"))
+      #expect(!closed.contains("public protocol IOther"))
+      #expect(!closed.contains("@com(interface: \"\")"))
+    }
+  }
+
+  /// Runs `body` with the path of a temporary `-I` directory whose
+  /// `Languages/swift.lang` is the stock Swift spec with `extra` appended — so a
+  /// render of the bundled `com` template (which declares `language: swift`)
+  /// resolves the augmented spec (a search directory shadows the bundle), the
+  /// hook a `known`-frontier test uses to add a `wellknown` line. The directory
+  /// is removed afterwards.
+  static func withLanguage(adding extra: String,
+                           _ body: (String) throws -> Void) throws {
+    let manager = FileManager.default
+    let directory =
+        manager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let languages = directory.appendingPathComponent("Languages")
+    try manager.createDirectory(at: languages, withIntermediateDirectories: true)
+    defer { try? manager.removeItem(at: directory) }
+    let spec = RenderClosureTests.swiftLanguage + "\n" + extra + "\n"
+    try Data(spec.utf8)
+        .write(to: languages.appendingPathComponent("swift.lang"))
+    try body(directory.path)
+  }
+
+  /// The stock Swift language spec — the conventions the `com` render's decode
+  /// composes a spelling from — embedded so a test may augment it without
+  /// reading the package bundle. It mirrors `Resources/Languages/swift.lang`;
+  /// only the well-known projections a test appends differ.
+  private static let swiftLanguage = """
+    escape-prefix `
+    escape-suffix `
+    void Void
+    root IUnknown
+    type void Void
+    type bool CBool
+    type char Unicode.UTF16.CodeUnit
+    type i1 CChar
+    type u1 CUnsignedChar
+    type i2 CShort
+    type u2 CUnsignedShort
+    type i4 CInt
+    type u4 CUnsignedInt
+    type i8 CLongLong
+    type u8 CUnsignedLongLong
+    type f4 CFloat
+    type f8 CDouble
+    type iptr Int
+    type uptr UInt
+    type string HSTRING
+    type object UnsafeMutableRawPointer
+    type typedref UnsafeMutableRawPointer
+    pointer-mutable UnsafeMutablePointer
+    pointer-const UnsafePointer
+    rawpointer-mutable UnsafeMutableRawPointer
+    rawpointer-const UnsafeRawPointer
+    optional ?
+    generic-open <
+    generic-close >
+    var-type T
+    var-method M
+    opaque UnsafeMutableRawPointer
+    guid-iid IID
+    guid-clsid CLSID
+    wellknown Windows.Win32.Foundation.HRESULT HRESULT
+    wellknown Windows.Win32.Foundation.BOOL BOOL
+    """
+}
+
+/// A metadata fixture whose root interface `IRoot` names, across its method
+/// signatures, one of each closure-reachable value kind — a struct it returns,
+/// an enum and a delegate it takes, and another interface — so the `--closure`
+/// walk pulls each in through the E3/E6/E7 edges and renders it through its own
+/// template section. Ten tables packed back to back in table-number order; a
+/// stored index `N` names the 0-based row `N - 1`, and a `TypeDefOrRef` token is
+/// `(row << 2) | tag` (tag 0 `TypeDef`, tag 1 `TypeRef`).
+///
+///   TypeRef[0]: `Windows.Win32.Foundation.Metadata.GuidAttribute` — the IID
+///               attribute the `interfaces` view keys on.
+///   TypeRef[1..3]: `System.ValueType`/`System.Enum`/`System.MulticastDelegate`
+///               — the bases the `types` view classifies a struct/enum/delegate
+///               `TypeDef` by.
+///   TypeDef[0]: `IRoot` (interface, `GuidAttribute`) owning the four methods.
+///   TypeDef[1]: `Point` (struct, `Extends` ValueType) with one `i4` field.
+///   TypeDef[2]: `Color` (enum, `Extends` Enum) with `value__` and the members
+///               `Red`/`Green`, whose values live in the `Constant` table.
+///   TypeDef[3]: `Handler` (delegate, `Extends` MulticastDelegate, its own
+///               `GuidAttribute`) owning `Invoke` — a WinRT delegate is a COM
+///               interface, so it carries a static IID the `@com` projection
+///               reads.
+///   TypeDef[4]: `IOther` (interface, `GuidAttribute`) — the signature-named
+///               interface.
+///   CustomAttribute[0..2]: the `GuidAttribute` rows for `IRoot`, `Handler`,
+///               and `IOther`, in `Parent`-sorted order.
+///   MethodDef[0..3]: `IRoot`'s `Make` (returns `Point`), `Paint(Color)`,
+///               `Listen(Handler)`, `Chain(IOther)`.
+///   MethodDef[4]: `Handler`'s `Invoke(i4)`.
+private enum ClosureFixture {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x42, 0x00, 0x31, 0x00, 0x00, 0x00, 0x47, 0x00, 0x31, 0x00,
+    0x21, 0x00, 0x00, 0x00, 0x5c, 0x00, 0x59, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x62, 0x00, 0x59, 0x00, 0x09, 0x00,
+    0x01, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x68, 0x00, 0x59, 0x00,
+    0x0d, 0x00, 0x02, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6e, 0x00,
+    0x59, 0x00, 0x11, 0x00, 0x05, 0x00, 0x05, 0x00, 0x21, 0x00, 0x00, 0x00,
+    0x76, 0x00, 0x59, 0x00, 0x00, 0x00, 0x05, 0x00, 0x06, 0x00, 0x00, 0x00,
+    0x8f, 0x00, 0x1d, 0x00, 0x00, 0x00, 0x7d, 0x00, 0x1d, 0x00, 0x00, 0x00,
+    0x85, 0x00, 0x1d, 0x00, 0x00, 0x00, 0x89, 0x00, 0x1d, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x95, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9a, 0x00, 0x06, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xa0, 0x00,
+    0x0c, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xa7, 0x00, 0x12, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0xad, 0x00, 0x18, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x08, 0x00, 0x0c, 0x00, 0x35, 0x00, 0x08, 0x00, 0x10, 0x00,
+    0x3a, 0x00, 0x23, 0x00, 0x0b, 0x00, 0x20, 0x00, 0x83, 0x00, 0x0b, 0x00,
+    0x3f, 0x00, 0xa3, 0x00, 0x0b, 0x00, 0x20, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x45, 0x6e, 0x75, 0x6d, 0x00, 0x4d,
+    0x75, 0x6c, 0x74, 0x69, 0x63, 0x61, 0x73, 0x74, 0x44, 0x65, 0x6c, 0x65,
+    0x67, 0x61, 0x74, 0x65, 0x00, 0x4e, 0x53, 0x00, 0x49, 0x52, 0x6f, 0x6f,
+    0x74, 0x00, 0x50, 0x6f, 0x69, 0x6e, 0x74, 0x00, 0x43, 0x6f, 0x6c, 0x6f,
+    0x72, 0x00, 0x48, 0x61, 0x6e, 0x64, 0x6c, 0x65, 0x72, 0x00, 0x49, 0x4f,
+    0x74, 0x68, 0x65, 0x72, 0x00, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x5f, 0x5f,
+    0x00, 0x52, 0x65, 0x64, 0x00, 0x47, 0x72, 0x65, 0x65, 0x6e, 0x00, 0x76,
+    0x61, 0x6c, 0x75, 0x65, 0x00, 0x4d, 0x61, 0x6b, 0x65, 0x00, 0x50, 0x61,
+    0x69, 0x6e, 0x74, 0x00, 0x4c, 0x69, 0x73, 0x74, 0x65, 0x6e, 0x00, 0x43,
+    0x68, 0x61, 0x69, 0x6e, 0x00, 0x49, 0x6e, 0x76, 0x6f, 0x6b, 0x65, 0x00,
+  ]
+
+  // The `#Blob` heap: the empty blob, the five method signatures, the shared
+  // `i4` field signature, the 20-byte interface `GuidAttribute` value (blob@32),
+  // the two i4 constant values `5` and `7`, and the delegate's distinct 20-byte
+  // `GuidAttribute` value (blob@63, `DEADBEEF-CAFE-BABE-F00D-1234567890AB`).
+  private static let blob: Array<UInt8> = [
+    0x00, 0x04, 0x20, 0x00, 0x11, 0x08, 0x05, 0x20, 0x01, 0x01, 0x11, 0x0c,
+    0x05, 0x20, 0x01, 0x01, 0x12, 0x10, 0x05, 0x20, 0x01, 0x01, 0x12, 0x14,
+    0x04, 0x20, 0x01, 0x01, 0x08, 0x02, 0x06, 0x08, 0x14, 0x01, 0x00, 0x30,
+    0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11, 0xad, 0xe5, 0x00, 0xaa, 0x00,
+    0x44, 0x77, 0x3d, 0x00, 0x00, 0x04, 0x05, 0x00, 0x00, 0x00, 0x04, 0x07,
+    0x00, 0x00, 0x00, 0x14, 0x01, 0x00, 0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca,
+    0xbe, 0xba, 0xf0, 0x0d, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 4, range: 0 ..< 24,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 5, range: 24 ..< 94,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 4, range: 94 ..< 118,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 5, range: 118 ..< 188,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 4, range: 188 ..< 212,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 212 ..< 212,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 212 ..< 218,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 2, range: 218 ..< 230,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 3, range: 230 ..< 248,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 248 ..< 248,
+                wide: 0, stride: 2),
+    // An empty NestedClass, present as real metadata always is, so the
+    // `references` recursive `resolved` CTE resolves the relation (this fixture
+    // names its referenced types through top-level, module-scoped refs).
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 248 ..< 248,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  /// Runs `body` over the fixture with `Point`'s `TypeDef` `Flags` overwritten to
+  /// `flags` — used to mark the struct an explicit-layout (union) value type the
+  /// closure must reject. `Point` is `TypeDef` row 2; the `TypeDef` table opens
+  /// at byte 24 of the tables stream with stride 14, so row 2's `Flags` (its
+  /// leading 4-byte field) begins at byte 38.
+  static func withPointFlags(_ flags: UInt8,
+                             _ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    var bytes = ClosureFixture.bytes
+    bytes[38] = flags
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  /// Runs `body` with `Point`'s single field `value` marked `fdStatic` (the
+  /// `0x10` bit OR-ed into its `FieldDef.Flags`), so the struct render must drop
+  /// it — a static field is not instance storage. `value` is `FieldDef` row 1;
+  /// the `FieldDef` table opens at byte 94 of the tables stream with stride 6,
+  /// so its `Flags` (the leading 2-byte field) begins at byte 94.
+  static func withStaticPointField(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    var bytes = ClosureFixture.bytes
+    bytes[94] |= 0x10
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  /// Runs `body` over the fixture with `IOther`'s `GuidAttribute` removed, so the
+  /// signature-named interface resolves no static IID. `CustomAttribute` is the
+  /// 9th relation (index 8); its three rows are `IRoot`'s, `Handler`'s, and
+  /// `IOther`'s `GuidAttribute`s in `Parent`-sorted order, so dropping the table
+  /// to its first two rows (range `230 ..< 242`) removes `IOther`'s alone.
+  static func withoutIOtherGuid(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    var relations = ClosureFixture.relations
+    relations[8] = WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 2,
+                               range: 230 ..< 242, wide: 0, stride: 6)
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  /// Runs `body` over the fixture with `Handler` (`TypeDef` row 4) made
+  /// parameterized — a single `GenericParam` row (table 42, §II.22.20) owning
+  /// it, its parameter name `T` appended to the string heap. A generic delegate
+  /// bears no static IID (a per-instantiation PIID), so `guid(of:)` resolves
+  /// nothing; the closure must keep it as generic and emit its ABI-protocol arm,
+  /// not drop it as GUID-less. The `generics` view reads `GenericParam` by
+  /// `Owner_TypeDef`, so the row alone makes `declarations(Handler)` non-empty.
+  static func withGenericHandler(named name: String = "T",
+                                 _ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    var bytes = ClosureFixture.bytes
+    var strings = ClosureFixture.strings
+    var relations = ClosureFixture.relations
+    // The generic parameter's name (`T` by default), appended to the string
+    // heap; a keyword name exercises the declaration's identifier escaping.
+    let offset = strings.count
+    strings.append(contentsOf: Array(name.utf8))
+    strings.append(0)
+    // One `GenericParam` row (stride 8, narrow indexes): Number 0, Flags 0,
+    // Owner=TypeOrMethodDef(TypeDef row 4)=(4 << 1) | 0 = 8, Name at `offset`.
+    let start = bytes.count
+    bytes.append(contentsOf: [0x00, 0x00, 0x00, 0x00, 0x08, 0x00,
+                              UInt8(offset & 0xff), UInt8(offset >> 8)])
+    relations.append(WinMD.Table(Metadata.Tables.GenericParam.self, rows: 1,
+                                 range: start ..< bytes.count,
+                                 wide: 0, stride: 8))
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid | (1 << 42),
+                          sorted: 0)
+    try body(storage)
+  }
+
+  /// Runs `body` over the fixture with `Green`'s constant value overwritten from
+  /// 7 to 5, so `Color` has two members (`Red`, `Green`) sharing the raw value 5
+  /// — a Win32 enum alias; the stored struct newtype renders both as `static
+  /// let`s, a repeat a native Swift `enum`'s `case`s could not have expressed.
+  /// `Green`'s constant is the second of the two little-endian i4 values in the
+  /// `#Blob` heap: they follow the 20-byte interface `GuidAttribute` value at
+  /// `blob@32` (a 1-byte length prefix plus 20 bytes, so ending at index 52), so
+  /// `Red`'s value blob is `[0x04] 05 00 00 00` at index 53 and `Green`'s is
+  /// `[0x04] 07 00 00 00` at index 58 — its low value byte (`0x07`) at index 59,
+  /// which this overwrites to `0x05`.
+  static func withDuplicateColorValue(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    var blob = ClosureFixture.blob
+    blob[59] = 0x05
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
   }
 }
 
@@ -623,22 +1179,2476 @@ struct RenderClosureNestedConflationTests {
     try body(storage)
   }
 
-  @Test func `--closure resolves a nested base by its enclosing, not its bare name`() throws {
+  @Test func `--closure frontiers a nested interface base sharing a local name`() throws {
     // The nested `Widget` reference is scoped to the local `A`, so the
     // scope-chain walk resolves it to `A.Widget` — never `B.Widget`, which
-    // shares the bare name under a different enclosing. Only `A.Widget`'s IID
-    // is emitted; `B.Widget`'s is not, and exactly one `Widget` declaration
-    // renders (the name-only join would have conflated both).
+    // shares the bare name under a different enclosing. `A.Widget` is a
+    // metadata-nested interface, which projects as a Swift `protocol` that
+    // cannot legally nest in its `A` container; a bare top-level declaration
+    // would neither match the metadata-nested spelling nor tell the two
+    // same-named nested `Widget`s apart. So the closure frontiers it — the base
+    // is dropped from emission entirely (the consumer defines it) — while
+    // `IRoot` still names `Widget` in its inheritance clause. Pre-finding-A the
+    // walk emitted `A.Widget` as a top-level bare `public protocol Widget`.
     try RenderClosureNestedConflationTests.with { catalog in
       let shell = Shell(catalog)
       let closed = try shell.render(closure: "IRoot", template: "com")
+      // `IRoot` (a top-level interface) still emits and names its base bare.
       #expect(closed.contains("public protocol IRoot: Widget {"))
-      // `A.Widget` (the well-known GUID) resolved and emitted …
-      #expect(closed.contains("0C733A30-2A1C-11CE-ADE5-00AA0044773D"))
-      // … while `B.Widget` (the all-0x11 GUID) did not.
+      // The nested interface base is a dropped frontier: no `Widget`
+      // declaration renders, so neither same-named nested `Widget`'s IID
+      // appears — `A.Widget`'s well-known GUID nor `B.Widget`'s all-0x11 one.
+      #expect(!closed.contains("public protocol Widget"))
+      #expect(!closed.contains("0C733A30-2A1C-11CE-ADE5-00AA0044773D"))
       #expect(!closed.contains("11111111-1111-1111-1111-111111111111"))
-      let count = closed.components(separatedBy: "public protocol Widget").count
-      #expect(count == 2) // one split ⇒ exactly one occurrence
+    }
+  }
+}
+
+/// Coverage of the `references` TypeRef arm's scope-chain walk over a *nested*
+/// external reference named by a method signature (edge E3) — the references-side
+/// mirror of the requires-side nested-external test. The fixture assembles a root
+/// `IRoot` whose one method `Get` returns a nested `TypeRef` `Widget` whose
+/// immediate `ResolutionScope` is another `TypeRef` (`Outer`), whose own scope is
+/// an external `AssemblyRef`. Its chain terminates externally, so `resolved`
+/// never reaches its anchor and the reference drops. A local nested interface
+/// `Widget` (empty namespace, under a local `Host`) shares the bare name, so the
+/// pre-fix name-only join would have enqueued and emitted `public protocol
+/// Widget`; binding the referenced `TypeRef` row keeps that unrelated declaration
+/// out while `IRoot.Get` still names `Widget` in its signature.
+struct RenderReferencesNestedExternalTests {
+  // Nine tables packed back to back in table-number order — TypeRef (#1, 3
+  // rows), TypeDef (#2, 3 rows), MethodDef (#6, 1 row), Param (#8, empty),
+  // InterfaceImpl (#9, empty), MemberRef (#10, 1 row), CustomAttribute (#12, 2
+  // rows), AssemblyRef (#35, 1 row), NestedClass (#41, 1 row) — every index
+  // narrow (2-byte). ECMA-335 rows are 1-based; a coded index is
+  // `(row << bits) | tag`, and a signature's `TypeDefOrRef` is compressed the
+  // same way (tag 0 `TypeDef`, tag 1 `TypeRef`).
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeRef[1]:  ResolutionScope(AssemblyRef row 1)=(1<<2)|2=6,
+  //                TypeName="Outer"(63), TypeNamespace="NS"(49) — the external
+  //                enclosing reference.
+  //   TypeRef[2]:  ResolutionScope(TypeRef row 2)=(2<<2)|3=11,
+  //                TypeName="Widget"(69), TypeNamespace=empty(0) — nested under
+  //                `Outer`; the chain terminates at the `AssemblyRef`.
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IRoot"(52),
+  //                TypeNamespace="NS"(49), MethodList=1 — owns `Get`.
+  //   TypeDef[1]:  Flags=0 (a plain class), TypeName="Host"(58),
+  //                TypeNamespace="NS"(49), MethodList=2 — a local enclosing.
+  //   TypeDef[2]:  Flags=0x21, TypeName="Widget"(69), TypeNamespace=empty(0),
+  //                MethodList=2 — a local nested interface sharing the bare name.
+  //   MethodDef[0]: TypeName="Get"(76), Signature=blob[1] — `Widget Get()`, its
+  //                return the nested external `TypeRef` `Widget`
+  //                (`TypeDefOrRef`=(3<<2)|1=13).
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+  //                `GuidAttribute` ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[6] — `IRoot`'s IID.
+  //   CustomAttribute[1]: Parent=HasCustomAttribute(TypeDef row 3)=(3<<5)|3=99,
+  //                Type=11, Value=blob[6] — the local `Widget`'s IID.
+  //   AssemblyRef[0]: all-zero (an empty external assembly the chain scopes to).
+  //   NestedClass[0]: NestedClass=3 (TypeDef row 3, Widget), EnclosingClass=2
+  //                (TypeDef row 2, Host) — the local `Widget` is nested.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeRef[1] (external Outer ref)
+    0x06, 0x00, 0x3f, 0x00, 0x31, 0x00,
+    // TypeRef[2] (nested Widget ref under Outer)
+    0x0b, 0x00, 0x45, 0x00, 0x00, 0x00,
+    // TypeDef[0] (IRoot): Flags, Name, Namespace, Extends, FieldList, MethodList
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[1] (Host)
+    0x00, 0x00, 0x00, 0x00, 0x3a, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x02, 0x00,
+    // TypeDef[2] (local nested Widget)
+    0x21, 0x00, 0x00, 0x00, 0x45, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x02, 0x00,
+    // MethodDef[0] (Get): RVA, ImplFlags, Flags, Name, Signature, ParamList
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x4c, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x06, 0x00,
+    // CustomAttribute[1]
+    0x63, 0x00, 0x0b, 0x00, 0x06, 0x00,
+    // AssemblyRef[0]
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // NestedClass[0]
+    0x03, 0x00, 0x02, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IRoot\0Host\0Outer\0
+  //  Widget\0Get\0": GuidNamespace@1, GuidName@35, NS@49, IRoot@52, Host@58,
+  // Outer@63, Widget@69, Get@76.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x52, 0x6f, 0x6f, 0x74, 0x00,
+    0x48, 0x6f, 0x73, 0x74, 0x00,
+    0x4f, 0x75, 0x74, 0x65, 0x72, 0x00,
+    0x57, 0x69, 0x64, 0x67, 0x65, 0x74, 0x00,
+    0x47, 0x65, 0x74, 0x00,
+  ]
+
+  // The blob heap: offset 0 the empty blob; offset 1 the `Get` method signature
+  // (length 4: HASTHIS, 0 params, return `ELEMENT_TYPE_CLASS` naming the
+  // `TypeDefOrRef` 13 — the nested `Widget` reference); offset 6 the 20-byte
+  // `GuidAttribute` value (the well-known GUID), preceded by its length 0x14.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x04, 0x20, 0x00, 0x12, 0x0d,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 3, range: 0 ..< 18,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 3, range: 18 ..< 60,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 60 ..< 74,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 74 ..< 74,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 74 ..< 74,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 74 ..< 80,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 2, range: 80 ..< 92,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.AssemblyRef.self, rows: 1, range: 92 ..< 112,
+                wide: 0, stride: 20),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 1, range: 112 ..< 116,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 10)
+          | (1 << 12) | (1 << 35) | (1 << 41)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure drops a nested external type a signature names`() throws {
+    // `IRoot.Get` returns a nested `TypeRef` `Widget` whose immediate scope is
+    // another `TypeRef` (so the pre-fix immediate-scope gate would pass) but
+    // whose chain terminates at an `AssemblyRef`. Binding the referenced row
+    // resolves it through the scope-chain CTE to no local row, so the local
+    // nested `Widget` sharing the bare name is not enqueued: `Get` names
+    // `Widget` in its signature yet no `Widget` declaration is emitted.
+    try RenderReferencesNestedExternalTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("public protocol IRoot"))
+      // The edge is genuine (the method names the nested `Widget`), and a
+      // nested type spells fully qualified from its outermost encloser — the
+      // signature walks the reference's `ResolutionScope_TypeRef` chain to
+      // `Outer`, so the return reads `Outer.Widget`, not a bare `Widget` that
+      // would collide with any other nested `Widget`.
+      #expect(closed.contains("-> Outer.Widget"))
+      // … but the nested external ref is a frontier, so no `Widget` declaration.
+      #expect(!closed.contains("public protocol Widget"))
+    }
+  }
+}
+
+/// Coverage of the nested value-type name collision the closure render once
+/// emitted as duplicate top-level declarations. The fixture assembles a root
+/// `IRoot` whose methods return two enclosing structs `Foo` and `Baz`, each of
+/// which encloses a distinct nested struct sharing the bare `TypeName` `Bar` —
+/// `Foo.Bar` and `Baz.Bar`. A flat emission would spell both nested signatures
+/// `-> Bar` and emit two top-level `struct Bar`, an ambiguous, non-compiling
+/// clash. The render must instead nest each `Bar` under its enclosing struct —
+/// a real emitted value-type container, since a nested type may legally nest
+/// only inside an emitted `struct`/`enum`, never a fabricated namespace `enum`
+/// — and spell each return fully qualified, so the two `Bar`s are distinct
+/// declarations (`Foo.Bar` and `Baz.Bar`) and each signature names the right
+/// one. `Foo`/`Baz` are themselves reached (returned by `IRoot.GetC`/`GetD`) so
+/// the two children nest inside real emitted containers rather than fabricated
+/// ones.
+struct RenderClosureNestedValueCollisionTests {
+  // Nine tables packed back to back in table-number order — TypeRef (#1, 2
+  // rows), TypeDef (#2, 5 rows), FieldDef (#4, 2 rows), MethodDef (#6, 4 rows),
+  // Param (#8, empty), InterfaceImpl (#9, empty), MemberRef (#10, 1 row),
+  // CustomAttribute (#12, 1 row), NestedClass (#41, 2 rows) — every index narrow
+  // (2-byte). ECMA-335 rows are 1-based; a coded index is `(row << bits) | tag`,
+  // and a signature's `TypeDefOrRef` is compressed the same way (tag 0
+  // `TypeDef`).
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeRef[1]:  ResolutionScope=0, TypeName="ValueType"(56),
+  //                TypeNamespace="System"(49) — the base the `types` view
+  //                classifies a struct by.
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IRoot"(69),
+  //                TypeNamespace="NS"(66), FieldList=1, MethodList=1 — owns
+  //                `GetA`/`GetB`/`GetC`/`GetD`.
+  //   TypeDef[1]:  Flags=0, TypeName="Foo"(75), TypeNamespace="NS"(66),
+  //                Extends=ValueType (TypeDefOrRef=(2<<2)|1=9), FieldList=1,
+  //                MethodList=5 — a local enclosing struct, no fields of its own.
+  //   TypeDef[2]:  Flags=0, TypeName="Baz"(79), TypeNamespace="NS"(66),
+  //                Extends=9, FieldList=1, MethodList=5 — the other enclosing
+  //                struct.
+  //   TypeDef[3]:  Flags=0, TypeName="Bar"(83), TypeNamespace=empty(0),
+  //                Extends=9, FieldList=1, MethodList=5 — `Foo.Bar`, a nested
+  //                struct with one `i4` field.
+  //   TypeDef[4]:  Flags=0, TypeName="Bar"(83), TypeNamespace=empty(0),
+  //                Extends=9, FieldList=2, MethodList=5 — `Baz.Bar`, same bare
+  //                name under a different enclosing.
+  //   FieldDef[0]: Name="x"(87), Signature=blob[11] — `Foo.Bar`'s `i4` field.
+  //   FieldDef[1]: Name="x"(87), Signature=blob[11] — `Baz.Bar`'s `i4` field.
+  //   MethodDef[0]: Name="GetA"(89), Signature=blob[1] — `Foo.Bar GetA()`, its
+  //                return the nested `TypeDef` `Foo.Bar` (`TypeDefOrRef`
+  //                =(4<<2)|0=16).
+  //   MethodDef[1]: Name="GetB"(94), Signature=blob[6] — `Baz.Bar GetB()`, its
+  //                return the nested `TypeDef` `Baz.Bar` (`TypeDefOrRef`
+  //                =(5<<2)|0=20).
+  //   MethodDef[2]: Name="GetC"(99), Signature=blob[35] — `Foo GetC()`, its
+  //                return the enclosing `TypeDef` `Foo` (`TypeDefOrRef`
+  //                =(2<<2)|0=8), which pulls `Foo` into the closure.
+  //   MethodDef[3]: Name="GetD"(104), Signature=blob[40] — `Baz GetD()`, its
+  //                return the enclosing `TypeDef` `Baz` (`TypeDefOrRef`
+  //                =(3<<2)|0=12), which pulls `Baz` into the closure.
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+  //                `GuidAttribute` ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[14] — `IRoot`'s IID.
+  //   NestedClass[0]: NestedClass=4 (TypeDef row 4), EnclosingClass=2 (Foo).
+  //   NestedClass[1]: NestedClass=5 (TypeDef row 5), EnclosingClass=3 (Baz).
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeRef[1] (System.ValueType)
+    0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    // TypeDef[0] (IRoot): Flags, Name, Namespace, Extends, FieldList, MethodList
+    0x21, 0x00, 0x00, 0x00, 0x45, 0x00, 0x42, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[1] (Foo): sequential layout, Extends=ValueType(9), MethodList=5
+    0x08, 0x00, 0x00, 0x00, 0x4b, 0x00, 0x42, 0x00,
+    0x09, 0x00, 0x01, 0x00, 0x05, 0x00,
+    // TypeDef[2] (Baz): sequential layout, Extends=ValueType(9), MethodList=5
+    0x08, 0x00, 0x00, 0x00, 0x4f, 0x00, 0x42, 0x00,
+    0x09, 0x00, 0x01, 0x00, 0x05, 0x00,
+    // TypeDef[3] (Foo.Bar): sequential layout, MethodList=5
+    0x08, 0x00, 0x00, 0x00, 0x53, 0x00, 0x00, 0x00,
+    0x09, 0x00, 0x01, 0x00, 0x05, 0x00,
+    // TypeDef[4] (Baz.Bar): sequential layout, MethodList=5
+    0x08, 0x00, 0x00, 0x00, 0x53, 0x00, 0x00, 0x00,
+    0x09, 0x00, 0x02, 0x00, 0x05, 0x00,
+    // FieldDef[0] (Foo.Bar.x): Flags, Name, Signature
+    0x00, 0x00, 0x57, 0x00, 0x0b, 0x00,
+    // FieldDef[1] (Baz.Bar.x)
+    0x00, 0x00, 0x57, 0x00, 0x0b, 0x00,
+    // MethodDef[0] (GetA): RVA, ImplFlags, Flags, Name, Signature, ParamList
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x59, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // MethodDef[1] (GetB)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x5e, 0x00, 0x06, 0x00, 0x01, 0x00,
+    // MethodDef[2] (GetC): return `Foo` (blob[35])
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x63, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // MethodDef[3] (GetD): return `Baz` (blob[40])
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x68, 0x00, 0x28, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x0e, 0x00,
+    // NestedClass[0] (Foo.Bar under Foo)
+    0x04, 0x00, 0x02, 0x00,
+    // NestedClass[1] (Baz.Bar under Baz)
+    0x05, 0x00, 0x03, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0System\0ValueType\0NS\0
+  //  IRoot\0Foo\0Baz\0Bar\0x\0GetA\0GetB\0GetC\0GetD\0": GuidNamespace@1,
+  // GuidName@35, System@49, ValueType@56, NS@66, IRoot@69, Foo@75, Baz@79,
+  // Bar@83, x@87, GetA@89, GetB@94, GetC@99, GetD@104.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00,
+    0x56, 0x61, 0x6c, 0x75, 0x65, 0x54, 0x79, 0x70, 0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x52, 0x6f, 0x6f, 0x74, 0x00,
+    0x46, 0x6f, 0x6f, 0x00,
+    0x42, 0x61, 0x7a, 0x00,
+    0x42, 0x61, 0x72, 0x00,
+    0x78, 0x00,
+    0x47, 0x65, 0x74, 0x41, 0x00,
+    0x47, 0x65, 0x74, 0x42, 0x00,
+    0x47, 0x65, 0x74, 0x43, 0x00,
+    0x47, 0x65, 0x74, 0x44, 0x00,
+  ]
+
+  // The blob heap: offset 0 the empty blob; offset 1 the `GetA` signature
+  // (length 4: HASTHIS, 0 params, return `ELEMENT_TYPE_VALUETYPE` naming the
+  // `TypeDefOrRef` 16 — `Foo.Bar`); offset 6 the `GetB` signature (return
+  // `TypeDefOrRef` 20 — `Baz.Bar`); offset 11 the shared `i4` field signature
+  // (length 2: FIELD, `ELEMENT_TYPE_I4`); offset 14 the 20-byte `GuidAttribute`
+  // value (the well-known GUID), preceded by its length 0x14; offset 35 the
+  // `GetC` signature (return `TypeDefOrRef` 8 — the enclosing struct `Foo`);
+  // offset 40 the `GetD` signature (return `TypeDefOrRef` 12 — `Baz`). The two
+  // enclosing-struct signatures follow the GUID value so its offset 14 stays put.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x04, 0x20, 0x00, 0x11, 0x10,
+    0x04, 0x20, 0x00, 0x11, 0x14,
+    0x02, 0x06, 0x08,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+    0x04, 0x20, 0x00, 0x11, 0x08,
+    0x04, 0x20, 0x00, 0x11, 0x0c,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 5, range: 12 ..< 82,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 2, range: 82 ..< 94,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 4, range: 94 ..< 150,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 150 ..< 150,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 150 ..< 150,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 150 ..< 156,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 156 ..< 162,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 2, range: 162 ..< 170,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 12) | (1 << 41)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure nests two same-named value types under their enclosers`() throws {
+    // `IRoot.GetA` returns `Foo.Bar` and `IRoot.GetB` returns `Baz.Bar` — two
+    // distinct nested structs that share the bare name `Bar` — while `GetC`/
+    // `GetD` return their enclosing structs `Foo`/`Baz`, so both enclosers are
+    // reached and emitted as real value-type containers. The closure must nest
+    // each `Bar` inside its enclosing struct and spell each return by its
+    // enclosing dot-path, so the two declarations are distinct and each
+    // signature names the right one. The enclosing type already disambiguates
+    // the two `Bar`s (`Foo.Bar` vs `Baz.Bar`), so — collision-only — no
+    // namespace is fabricated: `Foo`/`Baz` are uniquely named, so they spell and
+    // emit bare, and their `Bar`s spell `Foo.Bar`/`Baz.Bar` rather than
+    // `NS.Foo.Bar`. Pre-fix, both spelled `-> Bar` and both emitted as a
+    // top-level `struct Bar`, an ambiguous non-compiling clash.
+    try RenderClosureNestedValueCollisionTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      // `Foo`/`Baz` are uniquely named top-level value types, so neither is
+      // wrapped in a fabricated namespace `enum` — the `NS` namespace stays off
+      // the spelling and the emit.
+      #expect(!closed.contains("public enum NS"))
+      #expect(!closed.contains("NS.Foo"))
+      #expect(!closed.contains("NS.Baz"))
+      // Each enclosing struct is a top-level `struct`, never a fabricated `enum`.
+      #expect(closed.contains("@frozen public struct Foo {"))
+      #expect(closed.contains("@frozen public struct Baz {"))
+      #expect(!closed.contains("public enum Foo"))
+      #expect(!closed.contains("public enum Baz"))
+      // The two `Bar` structs are actual nested declarations — never a top-level
+      // `struct Bar` — one under each enclosing struct.
+      #expect(closed.contains("@frozen public struct Bar {"))
+      #expect(closed.contains("public var x: CInt"))
+      #expect(!closed.contains("\n@frozen public struct Bar"))
+      // Exactly two `Bar` declarations, one per enclosing.
+      #expect(closed.components(separatedBy: "public struct Bar {").count == 3)
+      // Each method spells its nested return by its enclosing dot-path, so the
+      // two `Bar`s are told apart by their distinct enclosers.
+      #expect(closed.contains("-> Foo.Bar"))
+      #expect(closed.contains("-> Baz.Bar"))
+      #expect(closed.contains("-> Foo"))
+      #expect(closed.contains("-> Baz"))
+      // A container sorts at its earliest-emitted descendant, and the walk emits
+      // `Foo.Bar` before `Baz.Bar` (the local `Id` breaks the shared-name tie),
+      // so `Foo` precedes `Baz`, and both precede the interface naming them.
+      let foo = try #require(closed.range(of: "public struct Foo"))
+      let baz = try #require(closed.range(of: "public struct Baz"))
+      let root = try #require(closed.range(of: "public protocol IRoot"))
+      #expect(foo.lowerBound < baz.lowerBound)
+      #expect(baz.lowerBound < root.lowerBound)
+    }
+  }
+
+  @Test func `--closure nests a child before a custom template's footer`() throws {
+    // A custom `com` template whose struct section emits a footer after the
+    // closing brace — a trailing comment on its own line — must still nest a
+    // child value type inside the container, before the brace, not after the
+    // footer. `Foo` encloses the nested struct `Foo.Bar`, so the closure
+    // splices `Bar` before `Foo`'s `}` and keeps the footer a line past it.
+    // Pre-fix, `inject` treated the body's last line as the closer, so the
+    // footer looked like the brace and `Bar` spilled out past `Foo` as a
+    // sibling — uncompilable, since a signature still spells `Foo.Bar`.
+    try RenderClosureNestedValueCollisionTests.with { catalog in
+      var shell = Shell(catalog)
+      // A struct section that closes the brace on its own line, then a footer
+      // line after it — the shape that trips a last-line closer heuristic.
+      shell.templates["com"] = """
+        {{! language: swift }}
+        {{#interface}}
+        protocol {{{name}}} {}
+        {{/interface}}
+        {{#struct}}
+        struct {{{name}}} {
+        }
+        // end {{{name}}}
+        {{/struct}}
+        """
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      // `Bar` nests directly inside `Foo`, before `Foo`'s closing brace.
+      #expect(closed.contains("struct Foo {\n    struct Bar {"))
+      // The footer rides one line past the real closer, preserved.
+      #expect(closed.contains("}\n// end Foo"))
+      // `Bar` never spills out as a sibling after `Foo`'s brace.
+      #expect(!closed.contains("}\n    struct Bar {"))
+    }
+  }
+}
+
+/// Coverage of a value type reachable under an emitted nongeneric interface: a
+/// nested type may nest only inside a value-type container (an emitted `struct`
+/// or `enum`), never a Swift `protocol`. The fixture assembles a root interface
+/// `IOuter` (a `protocol` bearing a static IID) whose method returns a struct
+/// `IOuter.Inner` nested under it in the metadata. Splicing `Inner` into the
+/// protocol body would compile to `type 'Inner' cannot be nested in protocol
+/// 'IOuter'`, so the closure must leave `Inner` a frontier — dropped from the
+/// output, not injected into the protocol — while `IOuter` still renders as a
+/// `protocol` carrying only its `func` requirements.
+struct RenderClosureNestedInInterfaceTests {
+  // Nine tables in table-number order — TypeRef (#1, 2 rows), TypeDef (#2, 2
+  // rows), FieldDef (#4, 1 row), MethodDef (#6, 1 row), Param (#8, empty),
+  // InterfaceImpl (#9, empty), MemberRef (#10, 1 row), CustomAttribute (#12, 1
+  // row), NestedClass (#41, 1 row) — every index narrow (2-byte).
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeRef[1]:  ResolutionScope=0, TypeName="ValueType"(56),
+  //                TypeNamespace="System"(49) — the struct base.
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IOuter"(69),
+  //                TypeNamespace="NS"(66), FieldList=1, MethodList=1 — the root
+  //                interface, emitted as a `protocol`.
+  //   TypeDef[1]:  Flags=0, TypeName="Inner"(76), TypeNamespace=empty(0),
+  //                Extends=ValueType(9), FieldList=1, MethodList=2 — a struct
+  //                nested under `IOuter`.
+  //   FieldDef[0]: Name="x"(82), Signature=blob[6] — `Inner`'s `i4` field.
+  //   MethodDef[0]: Name="GetInner"(84), Signature=blob[1] — return the nested
+  //                `TypeDef` `Inner` (`TypeDefOrRef`=(2<<2)|0=8).
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=9 — the ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=11, Value=blob[9].
+  //   NestedClass[0]: NestedClass=2 (Inner), EnclosingClass=1 (IOuter).
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeRef[1] (System.ValueType)
+    0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    // TypeDef[0] (IOuter): interface, MethodList=1
+    0x21, 0x00, 0x00, 0x00, 0x45, 0x00, 0x42, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[1] (Inner): struct nested under IOuter, MethodList=2
+    0x00, 0x00, 0x00, 0x00, 0x4c, 0x00, 0x00, 0x00,
+    0x09, 0x00, 0x01, 0x00, 0x02, 0x00,
+    // FieldDef[0] (Inner.x)
+    0x00, 0x00, 0x52, 0x00, 0x06, 0x00,
+    // MethodDef[0] (GetInner): return Inner (blob[1])
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x54, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x09, 0x00,
+    // NestedClass[0] (Inner under IOuter)
+    0x02, 0x00, 0x01, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0System\0ValueType\0NS\0
+  //  IOuter\0Inner\0x\0GetInner\0": GuidNamespace@1, GuidName@35, System@49,
+  // ValueType@56, NS@66, IOuter@69, Inner@76, x@82, GetInner@84.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00,
+    0x56, 0x61, 0x6c, 0x75, 0x65, 0x54, 0x79, 0x70, 0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x00,
+    0x49, 0x6e, 0x6e, 0x65, 0x72, 0x00,
+    0x78, 0x00,
+    0x47, 0x65, 0x74, 0x49, 0x6e, 0x6e, 0x65, 0x72, 0x00,
+  ]
+
+  // Blob heap: offset 1 the `GetInner` signature (return `ELEMENT_TYPE_VALUETYPE`
+  // naming `TypeDefOrRef` 8 — `Inner`); offset 6 the `i4` field signature;
+  // offset 9 the 20-byte `GuidAttribute` value.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x04, 0x20, 0x00, 0x11, 0x08,
+    0x02, 0x06, 0x08,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 12 ..< 40,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 1, range: 40 ..< 46,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 46 ..< 60,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 60 ..< 60,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 60 ..< 60,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 60 ..< 66,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 66 ..< 72,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 1, range: 72 ..< 76,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 12) | (1 << 41)
+
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure does not nest a value type inside an emitted interface`() throws {
+    // `IOuter.GetInner` returns the struct `IOuter.Inner`, a value type nested
+    // under the interface in the metadata. A Swift `protocol` cannot contain a
+    // nested type, so the closure must not emit `Inner` inside `IOuter`'s body —
+    // it leaves `Inner` a dropped frontier and renders `IOuter` as a `protocol`
+    // holding only its `func` requirement. Pre-fix, the nesting assembly spliced
+    // `Inner` before the protocol's closing brace, producing source that fails to
+    // compile with `type 'Inner' cannot be nested in protocol 'IOuter'`.
+    try RenderClosureNestedInInterfaceTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IOuter", template: "com")
+      // `IOuter` renders as a protocol.
+      #expect(closed.contains("public protocol IOuter"))
+      // The nested value type is a dropped frontier: never emitted, never
+      // injected into the protocol body — no `struct`/`enum`/`@frozen` anywhere.
+      #expect(!closed.contains("struct Inner"))
+      #expect(!closed.contains("@frozen"))
+      #expect(!closed.contains("enum"))
+      // The protocol body holds only `func` requirements — every non-brace,
+      // non-attribute line inside it is a `func`, so no declaration can be nested
+      // where Swift would reject it.
+      for line in closed.split(separator: "\n") {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty { continue }
+        if trimmed.hasPrefix("//") { continue }
+        if trimmed.hasPrefix("@com") { continue }
+        if trimmed.hasPrefix("public protocol") { continue }
+        if trimmed == "}" { continue }
+        #expect(trimmed.hasPrefix("func "))
+      }
+    }
+  }
+}
+
+/// Coverage of a value type reachable under a local runtime class: a nested
+/// type may nest only inside an emitted value-type container, and a runtime
+/// class is a frontier the walk excludes, never emitted. The fixture assembles
+/// a root interface `IRoot` whose `GetInner` returns a struct `Outer.Inner`
+/// nested under the local class `Outer`, and whose `GetOuter` returns the class
+/// `Outer` itself. Fabricating a `public enum Outer` container to hold `Inner`
+/// would shadow the real class `Outer`, so `GetOuter`'s return would resolve to
+/// the namespace enum rather than the consumer's real class. The closure must
+/// leave `Inner` a dropped frontier and fabricate no `enum Outer`, so the real
+/// `Outer` a signature names stays the consumer's type, un-shadowed.
+struct RenderClosureNestedInClassTests {
+  // Nine tables in table-number order — TypeRef (#1, 2 rows), TypeDef (#2, 3
+  // rows), FieldDef (#4, 1 row), MethodDef (#6, 2 rows), Param (#8, empty),
+  // InterfaceImpl (#9, empty), MemberRef (#10, 1 row), CustomAttribute (#12, 1
+  // row), NestedClass (#41, 1 row) — every index narrow (2-byte).
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeRef[1]:  ResolutionScope=0, TypeName="ValueType"(56),
+  //                TypeNamespace="System"(49) — the struct base.
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IRoot"(69),
+  //                TypeNamespace="NS"(66), FieldList=1, MethodList=1 — owns
+  //                `GetInner`/`GetOuter`.
+  //   TypeDef[1]:  Flags=0, TypeName="Outer"(75), TypeNamespace="NS"(66),
+  //                Extends=0 (no base) → kind `class`, FieldList=1, MethodList=3
+  //                — a runtime class the walk excludes from the value closure.
+  //   TypeDef[2]:  Flags=0, TypeName="Inner"(81), TypeNamespace=empty(0),
+  //                Extends=ValueType(9), FieldList=1, MethodList=3 — a struct
+  //                nested under `Outer`.
+  //   FieldDef[0]: Name="x"(87), Signature=blob[11] — `Inner`'s `i4` field.
+  //   MethodDef[0]: Name="GetInner"(89), Signature=blob[1] — return the nested
+  //                `TypeDef` `Inner` (`ELEMENT_TYPE_VALUETYPE`, `TypeDefOrRef`
+  //                =(3<<2)|0=12).
+  //   MethodDef[1]: Name="GetOuter"(98), Signature=blob[6] — return the class
+  //                `Outer` (`ELEMENT_TYPE_CLASS`, `TypeDefOrRef`=(2<<2)|0=8).
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=9 — the ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=11, Value=blob[14].
+  //   NestedClass[0]: NestedClass=3 (Inner), EnclosingClass=2 (Outer).
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeRef[1] (System.ValueType)
+    0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    // TypeDef[0] (IRoot): interface, MethodList=1
+    0x21, 0x00, 0x00, 0x00, 0x45, 0x00, 0x42, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[1] (Outer): runtime class (Extends=0), MethodList=3
+    0x00, 0x00, 0x00, 0x00, 0x4b, 0x00, 0x42, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x03, 0x00,
+    // TypeDef[2] (Inner): struct nested under Outer, MethodList=3
+    0x00, 0x00, 0x00, 0x00, 0x51, 0x00, 0x00, 0x00,
+    0x09, 0x00, 0x01, 0x00, 0x03, 0x00,
+    // FieldDef[0] (Inner.x)
+    0x00, 0x00, 0x57, 0x00, 0x0b, 0x00,
+    // MethodDef[0] (GetInner): return Inner (blob[1])
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x59, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // MethodDef[1] (GetOuter): return Outer (blob[6])
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x62, 0x00, 0x06, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x0e, 0x00,
+    // NestedClass[0] (Inner under Outer)
+    0x03, 0x00, 0x02, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0System\0ValueType\0NS\0
+  //  IRoot\0Outer\0Inner\0x\0GetInner\0GetOuter\0": GuidNamespace@1, GuidName@35,
+  // System@49, ValueType@56, NS@66, IRoot@69, Outer@75, Inner@81, x@87,
+  // GetInner@89, GetOuter@98.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00,
+    0x56, 0x61, 0x6c, 0x75, 0x65, 0x54, 0x79, 0x70, 0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x52, 0x6f, 0x6f, 0x74, 0x00,
+    0x4f, 0x75, 0x74, 0x65, 0x72, 0x00,
+    0x49, 0x6e, 0x6e, 0x65, 0x72, 0x00,
+    0x78, 0x00,
+    0x47, 0x65, 0x74, 0x49, 0x6e, 0x6e, 0x65, 0x72, 0x00,
+    0x47, 0x65, 0x74, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x00,
+  ]
+
+  // Blob heap: offset 1 the `GetInner` signature (return `ELEMENT_TYPE_VALUETYPE`
+  // naming `TypeDefOrRef` 12 — `Inner`); offset 6 the `GetOuter` signature
+  // (return `ELEMENT_TYPE_CLASS` naming `TypeDefOrRef` 8 — the class `Outer`);
+  // offset 11 the `i4` field signature; offset 14 the 20-byte `GuidAttribute`
+  // value.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x04, 0x20, 0x00, 0x11, 0x0c,
+    0x04, 0x20, 0x00, 0x12, 0x08,
+    0x02, 0x06, 0x08,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 3, range: 12 ..< 54,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 1, range: 54 ..< 60,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 2, range: 60 ..< 88,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 88 ..< 88,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 88 ..< 88,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 88 ..< 94,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 94 ..< 100,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 1, range: 100 ..< 104,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 12) | (1 << 41)
+
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure fabricates no container for a value type nested in a class`() throws {
+    // `IRoot.GetInner` returns `Outer.Inner`, a struct nested under the local
+    // runtime class `Outer`; `IRoot.GetOuter` returns `Outer` itself. `Outer` is
+    // a class — a frontier the walk excludes, never emitted — so the closure must
+    // fabricate no `public enum Outer` to hold `Inner`: that enum would shadow
+    // the real class `Outer` a signature names, redirecting `GetOuter`'s return
+    // to the namespace enum. `Inner` is a dropped frontier, and `Outer` stays the
+    // consumer's real type. Pre-fix, the nesting assembly materialised a
+    // `public enum Outer` container around `Inner`, shadowing the class.
+    try RenderClosureNestedInClassTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("public protocol IRoot"))
+      // No fabricated namespace container shadows the real class.
+      #expect(!closed.contains("public enum Outer"))
+      #expect(!closed.contains("enum Outer"))
+      // The nested value type is a dropped frontier: never emitted.
+      #expect(!closed.contains("struct Inner"))
+      #expect(!closed.contains("@frozen"))
+      // A method still names the real class `Outer`, un-shadowed.
+      #expect(closed.contains("Outer"))
+    }
+  }
+}
+
+/// Coverage of Finding B: two top-level value types that share the bare
+/// `TypeName` `Point` in different CLR namespaces must both emit, each under a
+/// fabricated namespace `enum` container, distinct and non-colliding, and each
+/// signature must spell them fully namespace-qualified. The fixture assembles a
+/// root `IRoot` whose three methods return `A.Point` (namespace `A`), `B.Point`
+/// (namespace `B`), and `C.D.Point` (a dotted namespace `C.D`), each a local
+/// struct (`Extends System.ValueType`) with one `i4` field. Pre-fix all three
+/// spelled the bare `Point` and emitted a single ambiguous top-level `struct
+/// Point`; the namespaces disambiguate them.
+struct RenderClosureNamespaceTests {
+  // Nine tables in table-number order — TypeRef (#1, 2 rows), TypeDef (#2, 4
+  // rows), FieldDef (#4, 3 rows), MethodDef (#6, 3 rows), Param (#8, empty),
+  // MemberRef (#10, 1 row), CustomAttribute (#12, 1 row), TypeSpec (#27, empty),
+  // NestedClass (#41, empty) — every index narrow (2-byte). ECMA-335 rows are
+  // 1-based; a `TypeDefOrRef` is `(row << 2) | tag` (tag 0 `TypeDef`, 1
+  // `TypeRef`).
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeRef[1]:  ResolutionScope=0, TypeName="ValueType"(56),
+  //                TypeNamespace="System"(49) — the struct base.
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IRoot"(74),
+  //                TypeNamespace=empty(0), MethodList=1 — the root, owns
+  //                `GetA`/`GetB`/`GetC`.
+  //   TypeDef[1]:  Flags=0, TypeName="Point"(80), TypeNamespace="A"(66),
+  //                Extends=ValueType((2<<2)|1=9), FieldList=1, MethodList=4.
+  //   TypeDef[2]:  Flags=0, TypeName="Point"(80), TypeNamespace="B"(68),
+  //                Extends=9, FieldList=2, MethodList=4.
+  //   TypeDef[3]:  Flags=0, TypeName="Point"(80), TypeNamespace="C.D"(70),
+  //                Extends=9, FieldList=3, MethodList=4.
+  //   FieldDef[0..2]: each `x`(86) with the shared `i4` signature (blob@16).
+  //   MethodDef[0]: "GetA"(88), Signature=blob@1 — return `A.Point` (VALUETYPE
+  //                `TypeDefOrRef`=(2<<2)|0=8).
+  //   MethodDef[1]: "GetB"(93), Signature=blob@6 — return `B.Point` (=(3<<2)=12).
+  //   MethodDef[2]: "GetC"(98), Signature=blob@11 — return `C.D.Point`
+  //                (=(4<<2)=16).
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob@19 — `IRoot`'s well-known IID.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeRef[1] (System.ValueType)
+    0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    // TypeDef[0] (IRoot): Flags, Name, Namespace, Extends, FieldList, MethodList
+    0x21, 0x00, 0x00, 0x00, 0x4a, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[1] (A.Point): sequential layout
+    0x08, 0x00, 0x00, 0x00, 0x50, 0x00, 0x42, 0x00,
+    0x09, 0x00, 0x01, 0x00, 0x04, 0x00,
+    // TypeDef[2] (B.Point): sequential layout
+    0x08, 0x00, 0x00, 0x00, 0x50, 0x00, 0x44, 0x00,
+    0x09, 0x00, 0x02, 0x00, 0x04, 0x00,
+    // TypeDef[3] (C.D.Point): sequential layout
+    0x08, 0x00, 0x00, 0x00, 0x50, 0x00, 0x46, 0x00,
+    0x09, 0x00, 0x03, 0x00, 0x04, 0x00,
+    // FieldDef[0] (A.Point.x)
+    0x00, 0x00, 0x56, 0x00, 0x10, 0x00,
+    // FieldDef[1] (B.Point.x)
+    0x00, 0x00, 0x56, 0x00, 0x10, 0x00,
+    // FieldDef[2] (C.D.Point.x)
+    0x00, 0x00, 0x56, 0x00, 0x10, 0x00,
+    // MethodDef[0] (GetA): RVA, ImplFlags, Flags, Name, Signature, ParamList
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x58, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // MethodDef[1] (GetB)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x5d, 0x00, 0x06, 0x00, 0x01, 0x00,
+    // MethodDef[2] (GetC)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x62, 0x00, 0x0b, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x13, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0System\0ValueType\0A\0
+  //  B\0C.D\0IRoot\0Point\0x\0GetA\0GetB\0GetC\0": GuidNamespace@1, GuidName@35,
+  // System@49, ValueType@56, A@66, B@68, C.D@70, IRoot@74, Point@80, x@86,
+  // GetA@88, GetB@93, GetC@98.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00,
+    0x56, 0x61, 0x6c, 0x75, 0x65, 0x54, 0x79, 0x70, 0x65, 0x00,
+    0x41, 0x00,
+    0x42, 0x00,
+    0x43, 0x2e, 0x44, 0x00,
+    0x49, 0x52, 0x6f, 0x6f, 0x74, 0x00,
+    0x50, 0x6f, 0x69, 0x6e, 0x74, 0x00,
+    0x78, 0x00,
+    0x47, 0x65, 0x74, 0x41, 0x00,
+    0x47, 0x65, 0x74, 0x42, 0x00,
+    0x47, 0x65, 0x74, 0x43, 0x00,
+  ]
+
+  // The blob heap: offset 0 the empty blob; offset 1/6/11 the three method
+  // signatures (each length 4: HASTHIS, 0 params, return `ELEMENT_TYPE_VALUETYPE`
+  // naming the `TypeDefOrRef` 8/12/16 — `A.Point`/`B.Point`/`C.D.Point`); offset
+  // 16 the shared `i4` field signature; offset 19 the 20-byte well-known
+  // `GuidAttribute` value.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x04, 0x20, 0x00, 0x11, 0x08,
+    0x04, 0x20, 0x00, 0x11, 0x0c,
+    0x04, 0x20, 0x00, 0x11, 0x10,
+    0x02, 0x06, 0x08,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 4, range: 12 ..< 68,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 3, range: 68 ..< 86,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 3, range: 86 ..< 128,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 128 ..< 128,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 128 ..< 128,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 128 ..< 134,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 134 ..< 140,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 140 ..< 140,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 140 ..< 140,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure preserves the namespace of same-named value types`() throws {
+    // `IRoot.GetA`/`GetB`/`GetC` return `A.Point`, `B.Point`, and `C.D.Point` —
+    // three local structs sharing the bare name `Point` across three CLR
+    // namespaces. The closure must wrap each in fabricated `public enum`
+    // namespace containers (`enum C { enum D { … } }` for the dotted one) and
+    // spell each return fully qualified, so the three declarations are distinct
+    // and each signature names the right one.
+    try RenderClosureNamespaceTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      // A namespace `enum` per distinct segment; the dotted `C.D` nests `D`
+      // inside `C`.
+      #expect(closed.contains("public enum A {"))
+      #expect(closed.contains("public enum B {"))
+      #expect(closed.contains("public enum C {"))
+      #expect(closed.contains("public enum D {"))
+      // The three same-named structs each nest under their namespace — three
+      // `Point` declarations, never one ambiguous top-level `struct Point`.
+      #expect(closed.components(separatedBy: "public struct Point {").count == 4)
+      #expect(!closed.contains("\n@frozen public struct Point"))
+      // Each return is spelled fully namespace-qualified, the dotted one down
+      // both segments.
+      #expect(closed.contains("-> A.Point"))
+      #expect(closed.contains("-> B.Point"))
+      #expect(closed.contains("-> C.D.Point"))
+      // The root interface itself still emits, top-level and unqualified.
+      #expect(closed.contains("public protocol IRoot"))
+    }
+  }
+}
+
+/// Coverage of Finding A: a metadata-nested interface reached by a signature is
+/// a dropped frontier — a `@com` protocol cannot legally nest, and a bare
+/// top-level declaration would neither match its metadata-nested spelling nor
+/// tell two same-named nested interfaces apart — while a top-level interface a
+/// signature names still emits, bare. The fixture assembles a root `IRoot`
+/// whose methods name two nested interfaces `Host.IChild` and `Peer.IChild`
+/// (each a `tdInterface` `TypeDef` under a local class, each with its own
+/// `GuidAttribute`) that share the bare name `IChild`, and a top-level interface
+/// `ITop`. The closure must emit `IRoot` and `ITop` and frontier both `IChild`s,
+/// so no `protocol IChild` renders (and never two). Pre-finding-A the walk
+/// emitted each nested interface as a top-level bare `protocol IChild`, a
+/// duplicate, ambiguous clash.
+struct RenderClosureNestedProtocolTests {
+  // Nine tables in table-number order — TypeRef (#1, 1 row), TypeDef (#2, 6
+  // rows), MethodDef (#6, 3 rows), Param (#8, empty), InterfaceImpl (#9, empty),
+  // MemberRef (#10, 1 row), CustomAttribute (#12, 4 rows), TypeSpec (#27,
+  // empty), NestedClass (#41, 2 rows) — every index narrow (2-byte). ECMA-335
+  // rows are 1-based; a `TypeDefOrRef` is `(row << 2) | tag` (tag 0 `TypeDef`).
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IRoot"(52),
+  //                TypeNamespace="NS"(49), MethodList=1 — owns `A`/`B`/`C`.
+  //   TypeDef[1]:  Flags=0 (class), TypeName="Host"(58), TypeNamespace="NS"(49)
+  //                — a local encloser, not itself reached.
+  //   TypeDef[2]:  Flags=0, TypeName="Peer"(63), TypeNamespace="NS"(49) — the
+  //                other encloser.
+  //   TypeDef[3]:  Flags=0x21, TypeName="ITop"(68), TypeNamespace="NS"(49) — a
+  //                top-level interface a signature names, so it emits bare.
+  //   TypeDef[4]:  Flags=0x21, TypeName="IChild"(73), TypeNamespace=empty(0) —
+  //                `Host.IChild`, a nested interface.
+  //   TypeDef[5]:  Flags=0x21, TypeName="IChild"(73), TypeNamespace=empty(0) —
+  //                `Peer.IChild`, the same bare name under a different encloser.
+  //   MethodDef[0]: "A"(80), Signature=blob@1 — return `ELEMENT_TYPE_CLASS`
+  //                naming `Host.IChild` (`TypeDefOrRef`=(5<<2)|0=20).
+  //   MethodDef[1]: "B"(82), Signature=blob@6 — return `Peer.IChild` (=(6<<2)=24).
+  //   MethodDef[2]: "C"(84), Signature=blob@11 — return `ITop` (=(4<<2)=16).
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the ctor.
+  //   CustomAttribute[0..3]: the `GuidAttribute`s for `IRoot` (well-known),
+  //                `ITop` (all-0x22), `Host.IChild` (all-0x11), and `Peer.IChild`
+  //                (all-0x33), keyed by their `Parent` `TypeDef`.
+  //   NestedClass[0]: NestedClass=5 (Host.IChild), EnclosingClass=2 (Host).
+  //   NestedClass[1]: NestedClass=6 (Peer.IChild), EnclosingClass=3 (Peer).
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeDef[0] (IRoot): Flags, Name, Namespace, Extends, FieldList, MethodList
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[1] (Host): class
+    0x00, 0x00, 0x00, 0x00, 0x3a, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x04, 0x00,
+    // TypeDef[2] (Peer): class
+    0x00, 0x00, 0x00, 0x00, 0x3f, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x04, 0x00,
+    // TypeDef[3] (ITop): interface
+    0x21, 0x00, 0x00, 0x00, 0x44, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x04, 0x00,
+    // TypeDef[4] (Host.IChild): interface, empty namespace
+    0x21, 0x00, 0x00, 0x00, 0x49, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x04, 0x00,
+    // TypeDef[5] (Peer.IChild): interface, empty namespace
+    0x21, 0x00, 0x00, 0x00, 0x49, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x04, 0x00,
+    // MethodDef[0] (A): RVA, ImplFlags, Flags, Name, Signature, ParamList
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x50, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // MethodDef[1] (B)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x52, 0x00, 0x06, 0x00, 0x01, 0x00,
+    // MethodDef[2] (C)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x54, 0x00, 0x0b, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0] (IRoot)
+    0x23, 0x00, 0x0b, 0x00, 0x10, 0x00,
+    // CustomAttribute[1] (ITop)
+    0x83, 0x00, 0x0b, 0x00, 0x25, 0x00,
+    // CustomAttribute[2] (Host.IChild)
+    0xa3, 0x00, 0x0b, 0x00, 0x3a, 0x00,
+    // CustomAttribute[3] (Peer.IChild)
+    0xc3, 0x00, 0x0b, 0x00, 0x4f, 0x00,
+    // NestedClass[0] (Host.IChild under Host)
+    0x05, 0x00, 0x02, 0x00,
+    // NestedClass[1] (Peer.IChild under Peer)
+    0x06, 0x00, 0x03, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IRoot\0Host\0Peer\0
+  //  ITop\0IChild\0A\0B\0C\0": GuidNamespace@1, GuidName@35, NS@49, IRoot@52,
+  // Host@58, Peer@63, ITop@68, IChild@73, A@80, B@82, C@84.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x52, 0x6f, 0x6f, 0x74, 0x00,
+    0x48, 0x6f, 0x73, 0x74, 0x00,
+    0x50, 0x65, 0x65, 0x72, 0x00,
+    0x49, 0x54, 0x6f, 0x70, 0x00,
+    0x49, 0x43, 0x68, 0x69, 0x6c, 0x64, 0x00,
+    0x41, 0x00,
+    0x42, 0x00,
+    0x43, 0x00,
+  ]
+
+  // The blob heap: offset 0 the empty blob; offset 1/6/11 the three method
+  // signatures (each length 4: HASTHIS, 0 params, return `ELEMENT_TYPE_CLASS`
+  // naming the `TypeDefOrRef` 20/24/16 — `Host.IChild`/`Peer.IChild`/`ITop`);
+  // offset 16/37/58/79 four 20-byte `GuidAttribute` values (`IRoot`'s well-known
+  // GUID, then all-0x22 `ITop`, all-0x11 `Host.IChild`, all-0x33 `Peer.IChild`),
+  // each preceded by its length 0x14.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x04, 0x20, 0x00, 0x12, 0x14,
+    0x04, 0x20, 0x00, 0x12, 0x18,
+    0x04, 0x20, 0x00, 0x12, 0x10,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+    0x14, 0x01, 0x00, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x00, 0x00,
+    0x14, 0x01, 0x00, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x00, 0x00,
+    0x14, 0x01, 0x00, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33,
+    0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 6, range: 6 ..< 90,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 3, range: 90 ..< 132,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 132 ..< 132,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 132 ..< 132,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 132 ..< 138,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 4, range: 138 ..< 162,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 162 ..< 162,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 2, range: 162 ..< 170,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 10)
+          | (1 << 12) | (1 << 27) | (1 << 41)
+
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure frontiers nested interfaces a signature names, keeps a top-level one`() throws {
+    // `IRoot.A`/`B` name the nested interfaces `Host.IChild`/`Peer.IChild` and
+    // `IRoot.C` the top-level `ITop`. The closure emits `IRoot` and `ITop` and
+    // frontiers both nested `IChild`s: a nested `@com` protocol cannot legally
+    // nest, and a bare top-level declaration would be a duplicate, so neither
+    // renders. Pre-finding-A each nested interface emitted as a top-level bare
+    // `public protocol IChild`, an ambiguous clash.
+    try RenderClosureNestedProtocolTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      // The top-level interfaces emit, bare and unqualified.
+      #expect(closed.contains("public protocol IRoot"))
+      #expect(closed.contains("public protocol ITop"))
+      // Both nested interfaces are dropped frontiers — no `IChild` declaration
+      // renders at all, so the two same-named nested protocols never collide.
+      #expect(!closed.contains("public protocol IChild"))
+      #expect(!closed.contains("11111111-1111-1111-1111-111111111111"))
+      #expect(!closed.contains("33333333-3333-3333-3333-333333333333"))
+      // `ITop`'s own IID does render — a top-level interface is projected whole.
+      #expect(closed.contains("22222222-2222-2222-2222-222222222222"))
+    }
+  }
+}
+
+/// Coverage of Finding 4: two same-named top-level protocols emit as duplicate,
+/// uncompilable `public protocol` declarations, and a protocol cannot nest in a
+/// namespace `enum` the way a value type disambiguates — so the render rejects
+/// the closure rather than emit them. The fixture assembles two top-level
+/// interfaces `A.IFoo` and `B.IFoo`, each a `tdInterface` `TypeDef` bearing its
+/// own `GuidAttribute`, sharing the bare name `IFoo` across two CLR namespaces.
+/// A `--closure` over the simple name `IFoo` seeds both (the ambiguous root),
+/// so the walk emits two top-level `IFoo` protocols and `nest` — which sees
+/// every emitted protocol — must throw `RenderError.ambiguous` naming the two
+/// namespaces. A signature reaching two same-named protocols mid-closure faults
+/// through the identical detection point.
+struct RenderClosureAmbiguousProtocolTests {
+  // Ten tables in table-number order — TypeRef (#1, 1 row), TypeDef (#2, 2
+  // rows), FieldDef (#4, empty), MethodDef (#6, empty), Param (#8, empty),
+  // InterfaceImpl (#9, empty), MemberRef (#10, 1 row), CustomAttribute (#12, 2
+  // rows), TypeSpec (#27, empty), NestedClass (#41, empty) — every index narrow
+  // (2-byte). ECMA-335 rows are 1-based; a coded index is `(row << bits) | tag`.
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IFoo"(53),
+  //                TypeNamespace="A"(49) — the first same-named interface.
+  //   TypeDef[1]:  Flags=0x21, TypeName="IFoo"(53), TypeNamespace="B"(51) — the
+  //                second, same bare name under a different namespace.
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob@1 — `A.IFoo`'s IID (the well-known GUID).
+  //   CustomAttribute[1]: Parent=HasCustomAttribute(TypeDef row 2)=(2<<5)|3=67,
+  //                Type=11, Value=blob@22 — `B.IFoo`'s IID (all-0x11), distinct.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeDef[0] (A.IFoo): Flags, Name, Namespace, Extends, FieldList, MethodList
+    0x21, 0x00, 0x00, 0x00, 0x35, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // TypeDef[1] (B.IFoo)
+    0x21, 0x00, 0x00, 0x00, 0x35, 0x00, 0x33, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x01, 0x00,
+    // CustomAttribute[1]
+    0x43, 0x00, 0x0b, 0x00, 0x16, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0A\0B\0IFoo\0":
+  // GuidNamespace@1, GuidName@35, A@49, B@51, IFoo@53.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x41, 0x00,
+    0x42, 0x00,
+    0x49, 0x46, 0x6f, 0x6f, 0x00,
+  ]
+
+  // The blob heap: offset 0 the empty blob; offset 1 the well-known 20-byte
+  // `GuidAttribute` value (`0C733A30-…`, `A.IFoo`); offset 22 the all-0x11 value
+  // (`B.IFoo`), so the two IIDs are distinct.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+    0x14, 0x01, 0x00, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 34 ..< 40,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 2, range: 40 ..< 52,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 52 ..< 52,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 52 ..< 52,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure rejects an ambiguous top-level protocol`() throws {
+    // `A.IFoo` and `B.IFoo` share the bare name `IFoo`, so a closure over the
+    // simple name `IFoo` seeds both. A protocol cannot nest in a namespace
+    // `enum`, so the two would emit as duplicate top-level `public protocol
+    // IFoo` — the render rejects it instead, naming the two namespaces sorted.
+    RenderClosureAmbiguousProtocolTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(throws: Shell.RenderError.ambiguous("IFoo", ["A", "B"])) {
+        _ = try shell.render(closure: "IFoo", template: "com")
+      }
+    }
+  }
+}
+
+/// A value type and an interface bearing the one simple name in different
+/// namespaces — `A.Shape` (a struct) and `B.Shape` (an interface). The flat
+/// Win32 surface never lands a value-type name on a same-named protocol, so this
+/// hand-built pair pins the cross-kind collision the closure must resolve: the
+/// value type is namespace-qualified and wrapped, the protocol stays bare.
+@Suite struct RenderCrossKindCollisionTests {
+  // Two tables — one `TypeRef` (`System.ValueType`, the struct's base) and two
+  // `TypeDef`s — packed back to back. `TypeDef[0]` is the struct `A.Shape`
+  // (sequential layout, `Extends` the `ValueType` ref); `TypeDef[1]` is the
+  // interface `B.Shape` (the `tdInterface` `0x20` flag, no base). A `TypeDefOrRef`
+  // token is `(row << 2) | tag`, tag 0 a `TypeDef`, so `A.Shape` is `4` and
+  // `B.Shape` is `8`.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (System.ValueType): Scope=0, Name=1, Namespace=11
+    0x00, 0x00, 0x01, 0x00, 0x0b, 0x00,
+    // TypeDef[0] (A.Shape): sequential(8), Name=18, Namespace=24,
+    //   Extends=ValueType(5), FieldList=1, MethodList=1
+    0x08, 0x00, 0x00, 0x00, 0x12, 0x00, 0x18, 0x00, 0x05, 0x00, 0x01, 0x00,
+    0x01, 0x00,
+    // TypeDef[1] (B.Shape): interface(0x20), Name=18, Namespace=26,
+    //   Extends=0, FieldList=1, MethodList=1
+    0x20, 0x00, 0x00, 0x00, 0x12, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00,                                                       // ""
+    0x56, 0x61, 0x6c, 0x75, 0x65, 0x54, 0x79, 0x70, 0x65, 0x00, // ValueType@1
+    0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00,                   // System@11
+    0x53, 0x68, 0x61, 0x70, 0x65, 0x00,                         // Shape@18
+    0x41, 0x00,                                                 // A@24
+    0x42, 0x00,                                                 // B@26
+  ]
+
+  private static let blob = Array<UInt8>([0x00])
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34,
+                wide: 0, stride: 14),
+    // An empty `NestedClass`, so `enclosing` resolves the relation and reads
+    // both types as top-level.
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 = (1 << 1) | (1 << 2) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `a value type colliding with a same-named protocol wraps while the protocol stays bare`() throws {
+    try RenderCrossKindCollisionTests.with { storage in
+      let (names, ids) = try storage.collisions()
+      // `Shape` is ambiguous across kinds — a struct and an interface bear it —
+      // so the value type must be disambiguated even though it is the only
+      // *value* type of the name (the value-type-only tally missed this).
+      #expect(names.contains("Shape"))
+      // Only the value type is wrapped and qualified: the struct's Id (1) is in
+      // `ids`, the interface's Id (2) is not, since a protocol cannot nest in a
+      // fabricated namespace `enum` and stays a bare top-level declaration.
+      #expect(ids.contains(1))
+      #expect(!ids.contains(2))
+      // The struct reference spells namespace-qualified (`A.Shape`); the
+      // interface reference, though it shares the ambiguous name, resolves to a
+      // protocol — not a value type — so it stays bare rather than spelling the
+      // phantom `B.Shape` no declaration is emitted for.
+      #expect(try storage.spelling(of: TypeDefOrRef(rawValue: 4),
+                                   qualifying: names) == "A.Shape")
+      #expect(try storage.spelling(of: TypeDefOrRef(rawValue: 8),
+                                   qualifying: names) == nil)
+    }
+  }
+}
+
+/// A non-generic value type `A.Foo` and a generic interface `B.Foo` (its `TypeName`
+/// the CLR spelling `Foo` + arity suffix) — projected, both are the one Swift name
+/// `Foo`, so they collide even though their raw metadata names differ. The tally
+/// must strip the arity suffix, the same normalization the emission applies, or
+/// the value type is left an unwrapped bare `struct Foo` clashing with the generic
+/// interface's `struct Foo` wrapper.
+@Suite struct RenderGenericArityCollisionTests {
+  // `TypeRef[0]` is `System.ValueType`; `TypeDef[0]` the struct `A.Foo`
+  // (sequential, Extends the ValueType ref); `TypeDef[1]` the interface `B.Foo`
+  // whose `TypeName` carries the arity suffix. Tokens: `A.Foo` is `4`, the
+  // interface `8`.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (System.ValueType): Scope=0, Name=1, Namespace=11
+    0x00, 0x00, 0x01, 0x00, 0x0b, 0x00,
+    // TypeDef[0] (A.Foo): sequential(8), Name=18, Namespace=28,
+    //   Extends=ValueType(5), FieldList=1, MethodList=1
+    0x08, 0x00, 0x00, 0x00, 0x12, 0x00, 0x1c, 0x00, 0x05, 0x00, 0x01, 0x00,
+    0x01, 0x00,
+    // TypeDef[1] (B.Foo`1): interface(0x20), Name=22, Namespace=30,
+    //   Extends=0, FieldList=1, MethodList=1
+    0x20, 0x00, 0x00, 0x00, 0x16, 0x00, 0x1e, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00,                                                       // ""
+    0x56, 0x61, 0x6c, 0x75, 0x65, 0x54, 0x79, 0x70, 0x65, 0x00, // ValueType@1
+    0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00,                   // System@11
+    0x46, 0x6f, 0x6f, 0x00,                                     // Foo@18
+    0x46, 0x6f, 0x6f, 0x60, 0x31, 0x00,                         // Foo`1@22
+    0x41, 0x00,                                                 // A@28
+    0x42, 0x00,                                                 // B@30
+  ]
+
+  private static let blob = Array<UInt8>([0x00])
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 = (1 << 1) | (1 << 2) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `a value type and a generic type collide on their arity-stripped name`() throws {
+    try RenderGenericArityCollisionTests.with { storage in
+      let (names, ids) = try storage.collisions()
+      // The tally keys off the projected name: `Foo` and `Foo` + arity are the
+      // one `Foo`, so the name is ambiguous and the value type is wrapped. The
+      // raw names (`Foo` versus `Foo` + arity) would read as distinct and leave
+      // the struct an unwrapped bare root.
+      #expect(names.contains("Foo"))
+      #expect(ids.contains(1))
+      #expect(!ids.contains(2))
+      // The struct qualifies to `A.Foo`; the generic interface, sharing the
+      // stripped name but resolving to a protocol, stays bare.
+      #expect(try storage.spelling(of: TypeDefOrRef(rawValue: 4),
+                                   qualifying: names) == "A.Foo")
+      #expect(try storage.spelling(of: TypeDefOrRef(rawValue: 8),
+                                   qualifying: names) == nil)
+    }
+  }
+}
+
+@Suite struct RenderSameNamespaceArityCollisionTests {
+  // The arity collision within one namespace: `TypeDef[0]` is the value type
+  // `A.Foo` (sequential, Extends `System.ValueType`); `TypeDef[1]` the generic
+  // interface `A.Foo` + arity, sharing the namespace `A`. The projected name
+  // strips the arity, so both project to the one `A.Foo` identity — the case
+  // the separate-namespace fixture above cannot reach. Only the value type's
+  // raw identity may qualify; the protocol reference, whose raw name keeps the
+  // arity suffix, must stay bare rather than borrow the value type's `A.Foo`
+  // wrap.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (System.ValueType): Scope=0, Name=1, Namespace=11
+    0x00, 0x00, 0x01, 0x00, 0x0b, 0x00,
+    // TypeDef[0] (A.Foo): sequential(8), Name=18, Namespace=28,
+    //   Extends=ValueType(5), FieldList=1, MethodList=1
+    0x08, 0x00, 0x00, 0x00, 0x12, 0x00, 0x1c, 0x00, 0x05, 0x00, 0x01, 0x00,
+    0x01, 0x00,
+    // TypeDef[1] (A.Foo`1): interface(0x20), Name=22, Namespace=28,
+    //   Extends=0, FieldList=1, MethodList=1
+    0x20, 0x00, 0x00, 0x00, 0x16, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00,                                                       // ""
+    0x56, 0x61, 0x6c, 0x75, 0x65, 0x54, 0x79, 0x70, 0x65, 0x00, // ValueType@1
+    0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00,                   // System@11
+    0x46, 0x6f, 0x6f, 0x00,                                     // Foo@18
+    0x46, 0x6f, 0x6f, 0x60, 0x31, 0x00,                         // Foo`1@22
+    0x41, 0x00,                                                 // A@28
+  ]
+
+  private static let blob = Array<UInt8>([0x00])
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 = (1 << 1) | (1 << 2) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `a same-namespace value type and generic type collide on arity`() throws {
+    try RenderSameNamespaceArityCollisionTests.with { storage in
+      let (names, ids) = try storage.collisions()
+      // The projected name is ambiguous, so the value type wraps; the identity
+      // keys off the *raw* name, so only `A.Foo` (raw `Foo`) enters, not the
+      // protocol's `A.Foo` + arity.
+      #expect(names.contains("Foo"))
+      #expect(names.contains("A.Foo"))
+      #expect(!names.contains("A.Foo`1"))
+      #expect(ids.contains(1))
+      #expect(!ids.contains(2))
+      // The struct qualifies to `A.Foo`; the same-namespace generic interface,
+      // sharing the arity-stripped name but resolving to a protocol whose raw
+      // name carries the suffix, stays bare — it must not borrow the wrap.
+      #expect(try storage.spelling(of: TypeDefOrRef(rawValue: 4),
+                                   qualifying: names) == "A.Foo")
+      #expect(try storage.spelling(of: TypeDefOrRef(rawValue: 8),
+                                   qualifying: names) == nil)
+    }
+  }
+}
+
+/// A closure whose fabricated namespace container shadows an emitted type. The
+/// root interface `R.A` (simple name `A`) returns `A.Point`, whose instance
+/// field is a `B.Point`, so the closure reaches both value types and `Point` is
+/// ambiguous *among the reached declarations* — the collision the reached-only
+/// tally counts. The render wraps `A.Point` under a fabricated `enum A`, which
+/// collides with the bare `protocol A` the root itself emits. Only a value type
+/// can be namespace-wrapped, so the namespace segment has no fallback and the
+/// render must fault rather than emit `enum A` beside `protocol A`. (The field
+/// reaching `B.Point` is what keeps the ambiguity reachable: an unreachable
+/// `B.Point` would leave `Point` unique and the closure bare and valid — the
+/// case `RenderUnreachableCollisionTests` pins.)
+@Suite struct RenderNamespaceShadowTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x21, 0x00, 0x00, 0x00, 0x44, 0x00, 0x42, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x46, 0x00, 0x44, 0x00, 0x09, 0x00,
+    0x01, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x46, 0x00, 0x4c, 0x00,
+    0x09, 0x00, 0x02, 0x00, 0x02, 0x00, 0x00, 0x00, 0x59, 0x00, 0x0c, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc6, 0x05, 0x54, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x09, 0x00, 0x4e, 0x00, 0x06, 0x00, 0x23, 0x00, 0x0b, 0x00,
+    0x10, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x52, 0x00, 0x41, 0x00, 0x50, 0x6f,
+    0x69, 0x6e, 0x74, 0x00, 0x42, 0x00, 0x2e, 0x63, 0x74, 0x6f, 0x72, 0x00,
+    0x4d, 0x61, 0x6b, 0x65, 0x00, 0x6f, 0x72, 0x69, 0x67, 0x69, 0x6e, 0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [
+    0x00, 0x04, 0x20, 0x00, 0x11, 0x08, 0x05, 0x20, 0x02, 0x01, 0x08, 0x0f,
+    0x03, 0x06, 0x11, 0x0c, 0x14, 0x01, 0x00, 0xef, 0xbe, 0xad, 0xde, 0xfe,
+    0xca, 0xbe, 0xba, 0xf0, 0x0d, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0x00,
+    0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  // The tables the render's views touch, ascending by table number; the empty
+  // ones carry no rows but must be present so a view resolves the relation.
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 3, range: 12 ..< 54,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 1, range: 54 ..< 60,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 60 ..< 74,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 74 ..< 74,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 74 ..< 74,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 74 ..< 80,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 0, range: 80 ..< 80,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 80 ..< 86,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 86 ..< 86,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 86 ..< 86,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `a fabricated namespace container shadowing an emitted type faults`() {
+    RenderNamespaceShadowTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(throws: Shell.RenderError.collision("A")) {
+        _ = try shell.render(closure: "A", template: "com")
+      }
+    }
+  }
+}
+
+/// A closure whose nesting places a real type and a fabricated namespace
+/// container of the one name inside the same container. `IRoot` returns `A.B` (a
+/// value type ambiguous with `D.B`) and `A.B.Point` (ambiguous with `C.Point`).
+/// `A.B` carries an instance field of `D.B` and `A.B.Point` a field of
+/// `C.Point`, so the closure reaches all four and both names are ambiguous
+/// *among the reached declarations*. The render wraps `A.B` as a real `B` under
+/// `enum A` and wraps `A.B.Point` under a fabricated `enum A.enum B` — two
+/// children named `B` inside `enum A`. A root-only claims check passes (the
+/// roots are just `enum A`); the clash is a level down, so the emit must
+/// validate every container's children, not only the roots.
+@Suite struct RenderNestedShadowTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x21, 0x00, 0x00, 0x00, 0x44, 0x00, 0x42, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x4c, 0x00, 0x4a, 0x00, 0x09, 0x00,
+    0x01, 0x00, 0x03, 0x00, 0x08, 0x00, 0x00, 0x00, 0x52, 0x00, 0x4e, 0x00,
+    0x09, 0x00, 0x02, 0x00, 0x03, 0x00, 0x08, 0x00, 0x00, 0x00, 0x4c, 0x00,
+    0x58, 0x00, 0x09, 0x00, 0x03, 0x00, 0x03, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x52, 0x00, 0x5a, 0x00, 0x09, 0x00, 0x03, 0x00, 0x03, 0x00, 0x00, 0x00,
+    0x6b, 0x00, 0x11, 0x00, 0x00, 0x00, 0x6f, 0x00, 0x15, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xc6, 0x05, 0x62, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc6, 0x05, 0x67, 0x00, 0x06, 0x00,
+    0x01, 0x00, 0x09, 0x00, 0x5c, 0x00, 0x0b, 0x00, 0x23, 0x00, 0x0b, 0x00,
+    0x19, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x52, 0x00, 0x49, 0x52, 0x6f, 0x6f,
+    0x74, 0x00, 0x41, 0x00, 0x42, 0x00, 0x41, 0x2e, 0x42, 0x00, 0x50, 0x6f,
+    0x69, 0x6e, 0x74, 0x00, 0x44, 0x00, 0x43, 0x00, 0x2e, 0x63, 0x74, 0x6f,
+    0x72, 0x00, 0x4d, 0x61, 0x6b, 0x65, 0x00, 0x47, 0x65, 0x74, 0x00, 0x6c,
+    0x6f, 0x77, 0x00, 0x74, 0x69, 0x70, 0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [
+    0x00, 0x04, 0x20, 0x00, 0x11, 0x08, 0x04, 0x20, 0x00, 0x11, 0x0c, 0x05,
+    0x20, 0x02, 0x01, 0x08, 0x0f, 0x03, 0x06, 0x11, 0x10, 0x03, 0x06, 0x11,
+    0x14, 0x14, 0x01, 0x00, 0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xbe, 0xba,
+    0xf0, 0x0d, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 5, range: 12 ..< 82,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 2, range: 82 ..< 94,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 2, range: 94 ..< 122,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 122 ..< 122,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 122 ..< 122,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 122 ..< 128,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 0, range: 128 ..< 128,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 128 ..< 134,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 134 ..< 134,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 134 ..< 134,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `a namespace container shadowing a type inside another container faults`() {
+    RenderNestedShadowTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(throws: Shell.RenderError.collision("B")) {
+        _ = try shell.render(closure: "IRoot", template: "com")
+      }
+    }
+  }
+}
+
+/// A closure that reaches a value type only through its metadata-nested member.
+/// `R.IRoot.Make` returns `Outer.Inner` (`Inner` nested in `Outer` via
+/// `NestedClass`), and no signature names `Outer` directly. The walk must walk
+/// and emit `Outer` — the real `struct` container `Inner` nests inside — rather
+/// than only try to retain a nonexistent `Outer` emission during the prune,
+/// which would drop `Inner` while its signature still spells `Outer.Inner`.
+@Suite struct RenderEnclosingValueTypeTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x21, 0x00, 0x00, 0x00, 0x44, 0x00, 0x42, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x4c, 0x00, 0x4a, 0x00, 0x09, 0x00,
+    0x01, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x52, 0x00, 0x00, 0x00,
+    0x09, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xc6, 0x05, 0x5e, 0x00, 0x01, 0x00, 0x01, 0x00, 0x09, 0x00, 0x58, 0x00,
+    0x06, 0x00, 0x23, 0x00, 0x0b, 0x00, 0x0c, 0x00, 0x03, 0x00, 0x02, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x52, 0x00, 0x49, 0x52, 0x6f, 0x6f,
+    0x74, 0x00, 0x4e, 0x00, 0x4f, 0x75, 0x74, 0x65, 0x72, 0x00, 0x49, 0x6e,
+    0x6e, 0x65, 0x72, 0x00, 0x2e, 0x63, 0x74, 0x6f, 0x72, 0x00, 0x4d, 0x61,
+    0x6b, 0x65, 0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [
+    0x00, 0x04, 0x20, 0x00, 0x11, 0x0c, 0x05, 0x20, 0x02, 0x01, 0x08, 0x0f,
+    0x14, 0x01, 0x00, 0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xbe, 0xba, 0xf0,
+    0x0d, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 3, range: 12 ..< 54,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 0, range: 54 ..< 54,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 54 ..< 68,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 68 ..< 68,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 68 ..< 68,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 68 ..< 74,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 0, range: 74 ..< 74,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 74 ..< 80,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 80 ..< 80,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 1, range: 80 ..< 84,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `an enclosing value type reached only through a nested member emits`() throws {
+    try RenderEnclosingValueTypeTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      // `Outer` is emitted as the real value-type container even though only
+      // `Outer.Inner` is named, and `Inner` nests inside it rather than being
+      // dropped; the signature's `Outer.Inner` spelling then resolves.
+      #expect(closed.contains("@frozen public struct Outer {"))
+      #expect(closed.contains("@frozen public struct Inner {"))
+      #expect(closed.contains("Outer.Inner"))
+    }
+  }
+}
+
+/// A closure whose sole reached `Point` is unique: an unreachable same-named
+/// type must not make it ambiguous. `R.A.Make` returns `A.Point`; `B.Point`
+/// exists but nothing reaches it, so `Point` stays bare — no fabricated
+/// `enum A` shadowing `protocol A` — and the closure renders. Counting the
+/// ambiguity over the whole assembly (rather than the reached declarations)
+/// would wrongly wrap `A.Point` and fault; this is the pre-rework shape of the
+/// shadow fixture.
+@Suite struct RenderUnreachableCollisionTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x21, 0x00, 0x00, 0x00, 0x44, 0x00, 0x42, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x46, 0x00, 0x44, 0x00, 0x09, 0x00,
+    0x01, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x46, 0x00, 0x4c, 0x00,
+    0x09, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xc6, 0x05, 0x54, 0x00, 0x01, 0x00, 0x01, 0x00, 0x09, 0x00, 0x4e, 0x00,
+    0x06, 0x00, 0x23, 0x00, 0x0b, 0x00, 0x0c, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x52, 0x00, 0x41, 0x00, 0x50, 0x6f,
+    0x69, 0x6e, 0x74, 0x00, 0x42, 0x00, 0x2e, 0x63, 0x74, 0x6f, 0x72, 0x00,
+    0x4d, 0x61, 0x6b, 0x65, 0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [
+    0x00, 0x04, 0x20, 0x00, 0x11, 0x08, 0x05, 0x20, 0x02, 0x01, 0x08, 0x0f,
+    0x14, 0x01, 0x00, 0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xbe, 0xba, 0xf0,
+    0x0d, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 3, range: 12 ..< 54,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 0, range: 54 ..< 54,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 54 ..< 68,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 68 ..< 68,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 68 ..< 68,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 68 ..< 74,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 0, range: 74 ..< 74,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 74 ..< 80,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 80 ..< 80,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 80 ..< 80,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `an unreachable same-named type does not qualify a reached value type`() throws {
+    try RenderUnreachableCollisionTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "A", template: "com")
+      // `Point` is unique among the reached {A.Point}, so it stays bare: no
+      // fabricated `enum A` to shadow `protocol A`, and the return spells bare.
+      #expect(closed.contains("public protocol A"))
+      #expect(closed.contains("@frozen public struct Point {"))
+      #expect(!closed.contains("enum A"))
+      #expect(!closed.contains("A.Point"))
+    }
+  }
+
+  @Test func `a flat render does not qualify a value type it does not emit`() throws {
+    try RenderUnreachableCollisionTests.with { catalog in
+      let shell = Shell(catalog)
+      let flat = try shell.render("A", template: "com")
+      // `Point` is ambiguous across the whole assembly (`A.Point`/`B.Point`),
+      // but the flat render emits only `protocol A` — no value type, no
+      // fabricated `enum A` — so it must spell the return bare, not `A.Point`,
+      // which would name a container this render never emits.
+      #expect(flat.contains("public protocol A"))
+      #expect(!flat.contains("A.Point"))
+      #expect(!flat.contains("enum A"))
+      #expect(!flat.contains("struct Point"))
+    }
+  }
+}
+
+/// A closure whose generic type's synthesized ABI protocol collides with a
+/// co-emitted metadata type. `R.IRoot.Use` takes a generic delegate `Foo<T>`
+/// (reached via its plain param ref, made generic by a `GenericParam` row — so
+/// its arm declares an `internal protocol FooABI<T>` beside the wrapper) and a
+/// value type `FooABI`. The two top-level `FooABI` declarations collide, but
+/// the emission label the scan sees is only the value type's; unless the check
+/// also counts the generic's synthesized ABI name, it accepts a scope the
+/// generated Swift rejects as an invalid redeclaration.
+@Suite struct RenderGenericABICollisionTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x42, 0x00, 0x31, 0x00, 0x21, 0x00, 0x00, 0x00, 0x56, 0x00,
+    0x54, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x5e, 0x00, 0x5c, 0x00, 0x0d, 0x00, 0x01, 0x00, 0x02, 0x00, 0x08, 0x00,
+    0x00, 0x00, 0x64, 0x00, 0x5c, 0x00, 0x09, 0x00, 0x01, 0x00, 0x03, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc6, 0x05, 0x71, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc6, 0x05, 0x75, 0x00,
+    0x09, 0x00, 0x01, 0x00, 0x09, 0x00, 0x6b, 0x00, 0x0d, 0x00, 0x23, 0x00,
+    0x0b, 0x00, 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x7c, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x63,
+    0x61, 0x73, 0x74, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x00,
+    0x52, 0x00, 0x49, 0x52, 0x6f, 0x6f, 0x74, 0x00, 0x4e, 0x00, 0x46, 0x6f,
+    0x6f, 0x60, 0x31, 0x00, 0x46, 0x6f, 0x6f, 0x41, 0x42, 0x49, 0x00, 0x2e,
+    0x63, 0x74, 0x6f, 0x72, 0x00, 0x55, 0x73, 0x65, 0x00, 0x49, 0x6e, 0x76,
+    0x6f, 0x6b, 0x65, 0x00, 0x54, 0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [
+    0x00, 0x07, 0x20, 0x02, 0x01, 0x12, 0x08, 0x11, 0x0c, 0x03, 0x20, 0x00,
+    0x01, 0x05, 0x20, 0x02, 0x01, 0x08, 0x0f, 0x14, 0x01, 0x00, 0xef, 0xbe,
+    0xad, 0xde, 0xfe, 0xca, 0xbe, 0xba, 0xf0, 0x0d, 0x12, 0x34, 0x56, 0x78,
+    0x90, 0xab, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 3, range: 0 ..< 18,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 3, range: 18 ..< 60,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 0, range: 60 ..< 60,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 2, range: 60 ..< 88,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 88 ..< 88,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 88 ..< 88,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 88 ..< 94,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 0, range: 94 ..< 94,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 94 ..< 100,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 100 ..< 100,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 100 ..< 100,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.GenericParam.self, rows: 1, range: 100 ..< 108,
+                wide: 0, stride: 8),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+          | (1 << 42)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `a generic type's synthesized ABI name collides with a metadata type`() {
+    RenderGenericABICollisionTests.with { catalog in
+      let shell = Shell(catalog)
+      // `Foo<T>` declares `internal protocol FooABI<T>`; the value type
+      // `FooABI` declares `struct FooABI`. The two clash on `FooABI`, a name
+      // only the value type wears as an emission label.
+      #expect(throws: Shell.RenderError.collision("FooABI")) {
+        _ = try shell.render(closure: "IRoot", template: "com")
+      }
+    }
+  }
+}
+
+/// A closure whose reached struct has a static field naming another local type.
+/// `IRoot` returns `S`, whose only field `f` is static (the `fdStatic` bit) and
+/// typed `T`. `structure` drops the static field from the emitted declaration,
+/// so the walk must drop it from the dependency scan too: otherwise `T` is
+/// pulled into the closure and emitted though nothing references it — an orphan
+/// that renders anyway and can fault validation on an omitted member.
+@Suite struct RenderStaticFieldDependencyTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x21, 0x00, 0x00, 0x00, 0x44, 0x00, 0x42, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x4a, 0x00, 0x42, 0x00, 0x09, 0x00,
+    0x01, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x4c, 0x00, 0x42, 0x00,
+    0x09, 0x00, 0x02, 0x00, 0x02, 0x00, 0x16, 0x00, 0x4e, 0x00, 0x06, 0x00,
+    0x06, 0x00, 0x50, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xc6, 0x05, 0x58, 0x00, 0x01, 0x00, 0x01, 0x00, 0x09, 0x00, 0x52, 0x00,
+    0x0d, 0x00, 0x23, 0x00, 0x0b, 0x00, 0x13, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x4e, 0x00, 0x49, 0x52, 0x6f, 0x6f,
+    0x74, 0x00, 0x53, 0x00, 0x54, 0x00, 0x66, 0x00, 0x67, 0x00, 0x2e, 0x63,
+    0x74, 0x6f, 0x72, 0x00, 0x4d, 0x61, 0x6b, 0x65, 0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [
+    0x00, 0x04, 0x20, 0x00, 0x11, 0x08, 0x03, 0x06, 0x11, 0x0c, 0x02, 0x06,
+    0x08, 0x05, 0x20, 0x02, 0x01, 0x08, 0x0f, 0x14, 0x01, 0x00, 0xef, 0xbe,
+    0xad, 0xde, 0xfe, 0xca, 0xbe, 0xba, 0xf0, 0x0d, 0x12, 0x34, 0x56, 0x78,
+    0x90, 0xab, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 3, range: 12 ..< 54,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 2, range: 54 ..< 66,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 66 ..< 80,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 80 ..< 80,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 80 ..< 80,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 80 ..< 86,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 0, range: 86 ..< 86,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 86 ..< 92,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 92 ..< 92,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 92 ..< 92,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure skips a static field's type when collecting dependencies`() throws {
+    try RenderStaticFieldDependencyTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      // `S` emits (its static field dropped, so no stored properties).
+      #expect(closed.contains("public struct S {"))
+      // `T`, named only by `S`'s dropped static field, is not pulled in.
+      #expect(!closed.contains("struct T"))
+    }
+  }
+}
+
+/// A closure whose reached enum is backed by a non-`i4` width (`u8`), rendered
+/// with a session `SANITIZE` that respells `value__`. The enum's underlying type
+/// is the `value__` field's decoded type, found by the field's raw metadata name
+/// — not its escaped spelling, which the override changes — so the enum keeps its
+/// `UInt64` ABI width rather than silently falling back to `i4`.
+@Suite struct RenderEnumUnderlyingSanitizeTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x21, 0x00, 0x00, 0x00, 0x3f, 0x00, 0x3d, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x45, 0x00, 0x3d, 0x00, 0x09, 0x00,
+    0x01, 0x00, 0x02, 0x00, 0x06, 0x00, 0x47, 0x00, 0x06, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xc6, 0x05, 0x55, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x09, 0x00, 0x4f, 0x00, 0x09, 0x00, 0x23, 0x00, 0x0b, 0x00, 0x0f, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x45, 0x6e, 0x75, 0x6d,
+    0x00, 0x4e, 0x00, 0x49, 0x52, 0x6f, 0x6f, 0x74, 0x00, 0x45, 0x00, 0x76,
+    0x61, 0x6c, 0x75, 0x65, 0x5f, 0x5f, 0x00, 0x2e, 0x63, 0x74, 0x6f, 0x72,
+    0x00, 0x4d, 0x61, 0x6b, 0x65, 0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [
+    0x00, 0x04, 0x20, 0x00, 0x11, 0x08, 0x02, 0x06, 0x0b, 0x05, 0x20, 0x02,
+    0x01, 0x08, 0x0f, 0x14, 0x01, 0x00, 0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca,
+    0xbe, 0xba, 0xf0, 0x0d, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 12 ..< 40,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 1, range: 40 ..< 46,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 46 ..< 60,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 60 ..< 60,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 60 ..< 60,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 60 ..< 66,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 0, range: 66 ..< 66,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 66 ..< 72,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 72 ..< 72,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 72 ..< 72,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure identifies enum storage before a SANITIZE override respells it`() throws {
+    try RenderEnumUnderlyingSanitizeTests.with { catalog in
+      var shell = Shell(catalog)
+      // A session `SANITIZE` that respells only `value__`, overlaying the
+      // language spec's escaping the way an `-I` spec would.
+      _ = try shell.session.run(
+          "CREATE FUNCTION SANITIZE(n TEXT) RETURNS TEXT "
+              + "AS (CASE WHEN n = 'value__' THEN 'renamed' ELSE n END)")
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      // The enum keeps its `u8` (`UInt64`) width, found by the raw `value__`
+      // name; matching the respelled name would miss it and fall back to `i4`.
+      #expect(closed.contains("public var rawValue: CUnsignedLongLong"))
+      #expect(!closed.contains("public var rawValue: CInt"))
+    }
+  }
+}
+
+/// A closure that reaches a frontier whose own dependencies must not orphan.
+/// `IRoot` returns `V`, a value type nested under the runtime class `Cl` — so its
+/// enclosing chain is not an emitted value-type container and `nest` discards it
+/// as a frontier. `V`'s field names `W`, reached only through the discarded `V`,
+/// so `W` must be pruned rather than rendered as an unreferenced orphan.
+@Suite struct RenderFrontierDependencyTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x21, 0x00, 0x00, 0x00, 0x44, 0x00, 0x42, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4a, 0x00, 0x42, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x4d, 0x00, 0x00, 0x00,
+    0x09, 0x00, 0x01, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x4f, 0x00,
+    0x42, 0x00, 0x09, 0x00, 0x02, 0x00, 0x02, 0x00, 0x06, 0x00, 0x51, 0x00,
+    0x06, 0x00, 0x06, 0x00, 0x53, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0xc6, 0x05, 0x5b, 0x00, 0x01, 0x00, 0x01, 0x00, 0x09, 0x00,
+    0x55, 0x00, 0x0d, 0x00, 0x23, 0x00, 0x0b, 0x00, 0x13, 0x00, 0x03, 0x00,
+    0x02, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x4e, 0x00, 0x49, 0x52, 0x6f, 0x6f,
+    0x74, 0x00, 0x43, 0x6c, 0x00, 0x56, 0x00, 0x57, 0x00, 0x66, 0x00, 0x67,
+    0x00, 0x2e, 0x63, 0x74, 0x6f, 0x72, 0x00, 0x4d, 0x61, 0x6b, 0x65, 0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [
+    0x00, 0x04, 0x20, 0x00, 0x11, 0x0c, 0x03, 0x06, 0x11, 0x10, 0x02, 0x06,
+    0x08, 0x05, 0x20, 0x02, 0x01, 0x08, 0x0f, 0x14, 0x01, 0x00, 0xef, 0xbe,
+    0xad, 0xde, 0xfe, 0xca, 0xbe, 0xba, 0xf0, 0x0d, 0x12, 0x34, 0x56, 0x78,
+    0x90, 0xab, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 4, range: 12 ..< 68,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 2, range: 68 ..< 80,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 80 ..< 94,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 94 ..< 94,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 94 ..< 94,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 94 ..< 100,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 0, range: 100 ..< 100,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1,
+                range: 100 ..< 106, wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 106 ..< 106,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 1, range: 106 ..< 110,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure prunes a discarded frontier's exclusive dependency`() throws {
+    try RenderFrontierDependencyTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("public protocol IRoot"))
+      // `V` nests under the runtime class `Cl`, so it is a dropped frontier.
+      #expect(!closed.contains("struct V"))
+      // `W`, named only by the discarded `V`'s field, is pruned — not rendered
+      // as an unreferenced orphan.
+      #expect(!closed.contains("struct W"))
+    }
+  }
+}
+
+/// A closure whose method parameter carries a custom modifier naming a local
+/// type. `IRoot.Method`'s parameter is `modopt(Mod) i4`; the generated Swift
+/// signature spells only `CInt` (a non-`IsConst` modifier is ignored), so `Mod`
+/// must stay out of the walk's referents — kept in the resolver for the decode's
+/// `IsConst` check but never enqueued — or it emits as an orphan declaration.
+@Suite struct RenderCustomModifierTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x21, 0x00, 0x00, 0x00, 0x44, 0x00, 0x42, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x4a, 0x00, 0x42, 0x00, 0x09, 0x00,
+    0x01, 0x00, 0x02, 0x00, 0x06, 0x00, 0x4e, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xc6, 0x05, 0x58, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x50, 0x00, 0x09, 0x00, 0x52, 0x00, 0x0b, 0x00,
+    0x23, 0x00, 0x0b, 0x00, 0x11, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x4e, 0x00, 0x49, 0x52, 0x6f, 0x6f,
+    0x74, 0x00, 0x4d, 0x6f, 0x64, 0x00, 0x66, 0x00, 0x70, 0x00, 0x2e, 0x63,
+    0x74, 0x6f, 0x72, 0x00, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [
+    0x00, 0x06, 0x20, 0x01, 0x01, 0x20, 0x08, 0x08, 0x02, 0x06, 0x08, 0x05,
+    0x20, 0x02, 0x01, 0x08, 0x0f, 0x14, 0x01, 0x00, 0xef, 0xbe, 0xad, 0xde,
+    0xfe, 0xca, 0xbe, 0xba, 0xf0, 0x0d, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab,
+    0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 12 ..< 40,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 1, range: 40 ..< 46,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 46 ..< 60,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 1, range: 60 ..< 66,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 66 ..< 66,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 66 ..< 72,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 0, range: 72 ..< 72,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 72 ..< 78,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 78 ..< 78,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 78 ..< 78,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure omits a custom-modifier type from the dependency walk`() throws {
+    try RenderCustomModifierTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      // The parameter spells only `CInt`; the modifier is ignored.
+      #expect(closed.contains("func Method(_ p: CInt)"))
+      // `Mod`, named only as a custom modifier, is not enqueued or emitted.
+      #expect(!closed.contains("struct Mod"))
+    }
+  }
+}
+
+/// A closure where one type is used both as an ordinary parameter and as a
+/// custom modifier in the same method. `IRoot.Method(a: Mod, b: modopt(Mod) i4)`
+/// spells `Mod` for `a`, so `Mod` must still be enqueued and emitted — the
+/// modifier filter must drop only a token used *solely* as a modifier, not
+/// subtract every token ever seen as one.
+@Suite struct RenderModifierAlsoOrdinaryTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00, 0x00, 0x00, 0x38, 0x00, 0x31, 0x00,
+    0x21, 0x00, 0x00, 0x00, 0x44, 0x00, 0x42, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x4a, 0x00, 0x42, 0x00, 0x09, 0x00,
+    0x01, 0x00, 0x02, 0x00, 0x06, 0x00, 0x4e, 0x00, 0x0a, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xc6, 0x05, 0x5a, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x50, 0x00, 0x00, 0x00, 0x02, 0x00, 0x52, 0x00,
+    0x09, 0x00, 0x54, 0x00, 0x0d, 0x00, 0x23, 0x00, 0x0b, 0x00, 0x13, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e,
+    0x33, 0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f,
+    0x6e, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00, 0x47,
+    0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x65,
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x4e, 0x00, 0x49, 0x52, 0x6f, 0x6f,
+    0x74, 0x00, 0x4d, 0x6f, 0x64, 0x00, 0x66, 0x00, 0x61, 0x00, 0x62, 0x00,
+    0x2e, 0x63, 0x74, 0x6f, 0x72, 0x00, 0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64,
+    0x00,
+  ]
+
+  private static let blob: Array<UInt8> = [
+    0x00, 0x08, 0x20, 0x02, 0x01, 0x11, 0x08, 0x20, 0x08, 0x08, 0x02, 0x06,
+    0x08, 0x05, 0x20, 0x02, 0x01, 0x08, 0x0f, 0x14, 0x01, 0x00, 0xef, 0xbe,
+    0xad, 0xde, 0xfe, 0xca, 0xbe, 0xba, 0xf0, 0x0d, 0x12, 0x34, 0x56, 0x78,
+    0x90, 0xab, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 12 ..< 40,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 1, range: 40 ..< 46,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 1, range: 46 ..< 60,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 2, range: 60 ..< 72,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 72 ..< 72,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 72 ..< 78,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 0, range: 78 ..< 78,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 78 ..< 84,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 0, range: 84 ..< 84,
+                wide: 0, stride: 2),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 84 ..< 84,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 4) | (1 << 6) | (1 << 8) | (1 << 9)
+          | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 27) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure keeps a type used as both an ordinary parameter and a modifier`() throws {
+    try RenderModifierAlsoOrdinaryTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      // `a` spells `Mod`, `b`'s modifier is ignored so it spells `CInt`.
+      #expect(closed.contains("func Method(_ a: Mod, _ b: CInt)"))
+      // `Mod` is enqueued (its ordinary use), so its declaration emits.
+      #expect(closed.contains("public struct Mod {"))
+    }
+  }
+}
+
+/// A local, ambiguous value type's identity must not qualify an external
+/// reference of the same `(namespace, name)`. `A.Point` and `B.Point` are local
+/// value types, so `A.Point` is ambiguous; an `AssemblyRef`-scoped external
+/// `A.Point` shares that identity but is nonlocal, so it must spell bare (the
+/// consumer supplies it), not bind the local `A.Point` wrapper.
+@Suite struct RenderExternalReferenceQualifyTests {
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x08, 0x00, 0x01, 0x00, 0x06, 0x00, 0x12, 0x00, 0x18, 0x00,
+    0x08, 0x00, 0x00, 0x00, 0x12, 0x00, 0x18, 0x00, 0x05, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x12, 0x00, 0x1a, 0x00, 0x05, 0x00,
+    0x01, 0x00, 0x01, 0x00,
+  ]
+
+  private static let strings: Array<UInt8> = [
+    0x00, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x00, 0x56, 0x61, 0x6c, 0x75,
+    0x65, 0x54, 0x79, 0x70, 0x65, 0x00, 0x50, 0x6f, 0x69, 0x6e, 0x74, 0x00,
+    0x41, 0x00, 0x42, 0x00,
+  ]
+
+  private static let blob = Array<UInt8>([0x00])
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 12 ..< 40,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 0, range: 40 ..< 40,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 = (1 << 1) | (1 << 2) | (1 << 41)
+
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `a qualifying identity does not qualify an external same-named reference`() throws {
+    try RenderExternalReferenceQualifyTests.with { storage in
+      let (names, _) = try storage.collisions()
+      #expect(names.contains("A.Point"))
+      // The local `A.Point` (a `TypeDef`, token 4) qualifies to its namespace
+      // path; the external `AssemblyRef`-scoped `A.Point` (a `TypeRef`, token 9)
+      // shares the identity but is nonlocal, so it spells bare (nil).
+      #expect(try storage.spelling(of: TypeDefOrRef(rawValue: 4),
+                                   qualifying: names) == "A.Point")
+      #expect(try storage.spelling(of: TypeDefOrRef(rawValue: 9),
+                                   qualifying: names) == nil)
     }
   }
 }

--- a/Tests/winmd-inspectTests/RenderOverrideTests.swift
+++ b/Tests/winmd-inspectTests/RenderOverrideTests.swift
@@ -574,6 +574,38 @@ struct RenderCacheTests {
   }
 }
 
+/// Coverage of the flat renderer's top-level template context. The closure work
+/// nests each per-kind projection under a `kind` key (`interface`/`struct`/…)
+/// so one sectioned template renders every kind. That must not regress the flat
+/// renderer, documented as unchanged: an inline or `-I` template written for it
+/// — reading top-level fields such as `{{name}}` — kept working. The fix exposes
+/// the interface projection at the template root for a flat render (`nested`
+/// false), while still binding it under `interface` so the bundled sectioned
+/// template renders too; the closure walk stays sectioned. Pre-fix, a flat
+/// render supplied only the `interface` key, so a top-level `{{name}}` resolved
+/// to the empty string.
+struct RenderFlatTemplateTests {
+  @Test func `a flat render exposes interface fields at the template root`() throws {
+    try RenderOverrideTests.withDirectory { directory in
+      let manager = FileManager.default
+      let templates = URL(fileURLWithPath: "\(directory)/Templates")
+      try manager.createDirectory(at: templates,
+                                  withIntermediateDirectories: true)
+      // A template written for the flat renderer, reading top-level fields.
+      let flat = "{{! language: swift }}\ninterface {{name}}: {{iid}}"
+      try Data(flat.utf8)
+          .write(to: templates.appendingPathComponent("flat.mustache"))
+      try RenderOverrideTests.with { catalog in
+        let shell = Shell(catalog, search: [directory])
+        let rendered = try shell.render("IDerived", template: "flat")
+        // The top-level `{{name}}` resolves to the interface's name, not "" —
+        // the documented flat behaviour the closure nesting must preserve.
+        #expect(rendered.hasPrefix("interface IDerived: "))
+      }
+    }
+  }
+}
+
 /// Coverage of the `.render *` empty-seed guard: a metadata file whose `TypeDef`
 /// rows are all non-interface produces no seed, so `.render *` emits nothing.
 /// The batch shortcuts must not fire in that case — `guids` expands the

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -419,13 +419,15 @@ struct ShellTests {
 
   @Test func `the bundled views are the COM-interface and type views`() {
     // The parse-and-register path a `CREATE VIEW` reuses; the bundled views
-    // register under their case-folded names — the five COM-interface views,
-    // `signatures` (which decodes a method's return through the `SIGNATURE`
-    // UDF), and the type-classification keystone `identities`/`types`.
+    // register under their case-folded names — the COM-interface views (an
+    // interface's `methods`, a method's `params`, an interface's `bases` and
+    // `generics`, and a struct's or enum's `fields`), `signatures` (which
+    // decodes a method's return through the `SIGNATURE` UDF), and the
+    // type-classification keystone `identities`/`types`.
     let views = Session.bundled()
     #expect(Set(views.keys) == ["interfaces", "methods", "params", "bases",
-                                "generics", "signatures", "identities",
-                                "types"])
+                                "generics", "fields", "signatures",
+                                "identities", "types"])
   }
 
   @Test func `a streamed CREATE VIEW statement parses and registers a view`() throws {


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the WinMD SQL engine and synthesis layer, focusing on improved type resolution, more robust SQL views, and better handling of type spelling and references. The changes add new APIs for field decoding and reference tracking, refine how type names are escaped and qualified, and introduce a new SQL view for fields.

**Key changes include:**

### New APIs and Features

* Added new methods to `WinMD.Storage` for decoding field types, extracting referenced type identities from both methods and fields, and retrieving constant values for fields (supporting enum raw values). These methods enable more precise closure walks and type analysis.
* Introduced the `Referent` struct, which pairs a referenced type’s identity with the exact coded-index token used in signatures, supporting more accurate local resolution and closure walks.

### Improvements to Type Spelling and Qualification

* Updated type name rendering to escape each dotted component individually, ensuring that keywords in any path segment are properly escaped, and that generic type names strip CLR arity suffixes only from the leaf component. [[1]](diffhunk://#diff-aee6cca485fee9a87b0ca5fceac7fed0e75e37985d9296779223130f89b6c4f1L429-R452) [[2]](diffhunk://#diff-aee6cca485fee9a87b0ca5fceac7fed0e75e37985d9296779223130f89b6c4f1L470-R503)
* Extended the `Resolver` to pre-resolve and store namespace-qualified spellings for ambiguous value types, and to expose these spellings for use during decoding. [[1]](diffhunk://#diff-3db2057f05d11bbc75daa76b97642011c6b3333b9282e314fe4c907716664afbR104-R122) [[2]](diffhunk://#diff-3db2057f05d11bbc75daa76b97642011c6b3333b9282e314fe4c907716664afbL66-R188)

### SQL View Enhancements

* Added a new SQL view `fields` in `fields.sql`, allowing queries for fields by their parent `TypeDef`.
* Included `ClassLayout` as an optional table in the WinMD SQL catalog, ensuring it is synthesized and available for queries when not physically present.

These changes collectively improve the expressiveness, accuracy, and usability of the WinMD decoding and SQL query layers, especially for advanced scenarios like closure walks, enum handling, and type disambiguation.