### PR TITLE
winmd-inspect: render an interface's base-interface closure

### DIFF
--- a/Sources/SQLEngineWinMD/Database+SQL.swift
+++ b/Sources/SQLEngineWinMD/Database+SQL.swift
@@ -54,6 +54,20 @@ public import WinMD
 // MARK: - Catalog
 
 extension WinMD.Storage: SQLEngine.Catalog {
+  /// The optional tables the bundled queries reference — tables ECMA-335 lets a
+  /// database omit from the tables stream (`TypeSpec` §II.22.39 when nothing is
+  /// generic-instantiated, `NestedClass` §II.22.32 when nothing nests) that a
+  /// bundled view or the closure walk still names. `table(named:)` resolves an
+  /// absent one to an empty relation and `relations()` enumerates it, so a
+  /// `SELECT … FROM` such a table reads no rows rather than faulting on a
+  /// missing relation. Only these are synthesised — not the whole table
+  /// registry — so `INFORMATION_SCHEMA` still enumerates exactly the
+  /// physically-present tables plus the referenced optionals.
+  private static var optionals: Array<(name: String, schema: TableSchema.Type)> {
+    [(name: "TypeSpec", schema: Metadata.Tables.TypeSpec.self),
+     (name: "NestedClass", schema: Metadata.Tables.NestedClass.self)]
+  }
+
   /// The relation named `name`, resolved case-insensitively against the open
   /// tables' schema names.
   ///
@@ -68,41 +82,38 @@ extension WinMD.Storage: SQLEngine.Catalog {
         return WinMDRelation(self, tables[index])
       }
     }
-    // `TypeSpec` (ECMA-335 §II.22.39) is an optional table — a database with no
-    // generic instantiation omits it from the tables stream — yet the bundled
-    // `identities`/`bases` views union a `TypeSpec` arm. Resolve an absent
-    // `TypeSpec` to an empty relation so such a view reads no rows rather than
-    // faulting on a missing relation.
-    if name.caseInsensitiveCompare("TypeSpec") == .orderedSame {
-      return WinMDRelation(self, .empty(Metadata.Tables.TypeSpec.self))
+    // An optional table (see `optionals`) the tables stream omits resolves to
+    // an empty relation, so a bundled view or the closure walk that names it
+    // reads no rows rather than faulting on a missing relation.
+    for entry in WinMD.Storage.optionals
+        where name.caseInsensitiveCompare(entry.name) == .orderedSame {
+      return WinMDRelation(self, .empty(entry.schema))
     }
     return nil
   }
 
   /// The schema names of every base relation — the `INFORMATION_SCHEMA`
   /// overlay's base-relation enumeration, mapped from the database's open
-  /// tables, plus the synthetic `TypeSpec` when the physical table is absent.
+  /// tables, plus each synthetic optional (see `optionals`) whose physical
+  /// table is absent.
   ///
-  /// `table(named:)` resolves an absent `TypeSpec` (ECMA-335 §II.22.39, an
-  /// optional table) to an empty relation, so the enumeration must name it too:
-  /// `relations()` must list every base relation `table(named:)` resolves, or
-  /// `INFORMATION_SCHEMA` would omit a `TypeSpec` a `SELECT … FROM TypeSpec`
-  /// still reads. A database with a generic instantiation has the table
-  /// physically and needs no synthetic entry — appended only when absent, so
-  /// the name is never duplicated.
+  /// `table(named:)` resolves an absent optional table to an empty relation, so
+  /// the enumeration must name it too: `relations()` must list every base
+  /// relation `table(named:)` resolves, or `INFORMATION_SCHEMA` would omit a
+  /// table a `SELECT … FROM` it still reads. A database that has the physical
+  /// table needs no synthetic entry — a name is appended only when absent, so it
+  /// is never duplicated.
   public borrowing func relations() -> Array<String> {
     var names = Array<String>()
-    names.reserveCapacity(tables.count + 1)
-    var spec = false
+    names.reserveCapacity(tables.count + WinMD.Storage.optionals.count)
     for index in 0 ..< tables.count {
       names.append("\(tables[index].description)")
-      if tables[index].description.caseInsensitiveCompare("TypeSpec")
-          == .orderedSame {
-        spec = true
-      }
     }
-    if !spec {
-      names.append("TypeSpec")
+    for entry in WinMD.Storage.optionals
+        where !names.contains(where: {
+          $0.caseInsensitiveCompare(entry.name) == .orderedSame
+        }) {
+      names.append(entry.name)
     }
     return names
   }

--- a/Sources/winmd-inspect/Resources/Render/requires.sql
+++ b/Sources/winmd-inspect/Resources/Render/requires.sql
@@ -1,0 +1,74 @@
+-- The parent interface's plain (non-generic) base and required interfaces,
+-- resolved to their local interface rows (`Id`, namespace, name, and `iid`)
+-- for the closure walk to enqueue. An `InterfaceImpl` names a base either
+-- through a `TypeDef` (a local definition) or a `TypeRef` (a reference, local
+-- or external), and each arm resolves that edge to a local interface by
+-- identity.
+--
+-- The `TypeDef` arm joins the exact `Interface_TypeDef` Id to the `interfaces`
+-- view, never remapping it back by name, so two same-named nested definitions
+-- never conflate onto one row.
+--
+-- The `TypeRef` arm resolves a reference to a local `TypeDef` through the
+-- shared `resolved(ref, def)` fragment, which follows the reference's scope
+-- chain and its nesting. A `TypeRef` is local only when its `ResolutionScope`
+-- chain terminates at the `Module`: `resolved`'s anchor matches a top-level
+-- reference (`ResolutionScope_Module` non-null, `ResolutionScope_TypeRef`
+-- null) to a non-nested local `TypeDef` by (namespace, name); its recursive arm
+-- matches a nested reference (`ResolutionScope_TypeRef` non-null) to the local
+-- nested `TypeDef` under the enclosing `TypeDef` its enclosing reference
+-- already resolved to — by `TypeName` under that enclosing, never by namespace
+-- (a nested type's namespace is empty). A nested reference whose chain
+-- terminates at an `AssemblyRef` or `ModuleRef` never reaches the anchor, so an
+-- external reference that merely shares a local interface's name is the natural
+-- frontier and drops, and two same-named nested definitions resolve by their
+-- distinct enclosings rather than conflating. A reference that resolves to no
+-- local interface (an external ref, or a local type that is no interface)
+-- likewise drops, the closure following only genuine local edges.
+--
+-- The row shape matches the `interfaces` selection so the walk emits each
+-- through the same per-interface body. A generic (`TypeSpec`) base is omitted,
+-- the deferral the plain `bases` projection makes.
+WITH RECURSIVE resolved(ref, def) AS (
+  SELECT r.Id, d.Id
+  FROM
+    TypeRef r
+    JOIN TypeDef d
+      ON d.TypeNamespace = r.TypeNamespace
+      AND d.TypeName = r.TypeName
+  WHERE
+    r.ResolutionScope_TypeRef IS NULL
+    AND r.ResolutionScope_Module IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM NestedClass nc WHERE nc.NestedClass = d.Id
+    )
+  UNION
+  SELECT r.Id, d.Id
+  FROM
+    resolved e
+    JOIN TypeRef r ON r.ResolutionScope_TypeRef = e.ref
+    JOIN NestedClass nc ON nc.EnclosingClass = e.def
+    JOIN TypeDef d ON d.Id = nc.NestedClass AND d.TypeName = r.TypeName
+)
+SELECT
+  n.Id,
+  n.TypeNamespace,
+  n.TypeName,
+  n.iid
+FROM
+  InterfaceImpl i
+  JOIN resolved rv ON rv.ref = i.Interface_TypeRef
+  JOIN interfaces n ON n.Id = rv.def
+WHERE
+  i.Class = :parent
+UNION
+SELECT
+  n.Id,
+  n.TypeNamespace,
+  n.TypeName,
+  n.iid
+FROM
+  InterfaceImpl i
+  JOIN interfaces n ON n.Id = i.Interface_TypeDef
+WHERE
+  i.Class = :parent

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -171,8 +171,14 @@ internal struct Bind: Metacommand {
   }
 }
 
-/// `.render <interface> <template>` — render a COM interface (or `*` for every
-/// interface) through a bundled Mustache template.
+/// `.render <interface> <template> [--closure]` — render a COM interface (or
+/// `*` for every interface) through a bundled Mustache template.
+///
+/// Without `--closure` the render is the interface's own surface, exactly as
+/// before. With `--closure` and a concrete interface, the render is that
+/// interface plus the transitive closure of its plain (`spec IS NULL`) base and
+/// required interfaces (the E1 edges). `*` keeps meaning the flat enumeration of
+/// every interface, so `--closure` with `*` is the same flat enumeration.
 internal struct Render: Metacommand {
   internal static let spelling = ".render"
 
@@ -182,22 +188,38 @@ internal struct Render: Metacommand {
   /// The template to render it through.
   internal let template: String
 
+  /// Whether to render the interface's transitive base/required-interface
+  /// closure (the `--closure` flag) rather than the interface alone. Ignored for
+  /// `*`, which stays the flat enumeration of every interface.
+  internal let closure: Bool
+
   internal init(_ arguments: Substring) {
     let fields = arguments.split(whereSeparator: \.isWhitespace)
-    if fields.count == 2 {
-      interface = String(fields[0])
-      template = String(fields[1])
+    // The `--closure` flag may appear in any position; the two remaining
+    // whitespace fields are still the interface and template, so a missing
+    // operand leaves them empty and `execute` rejects the command.
+    let operands = fields.filter { $0 != "--closure" }
+    if operands.count == 2 {
+      interface = String(operands[0])
+      template = String(operands[1])
     } else {
       interface = ""
       template = ""
     }
+    closure = fields.contains { $0 == "--closure" }
   }
 
   internal func execute(against shell: inout Shell) throws {
     if interface.isEmpty || template.isEmpty {
       throw Shell.MetaError.unknown(Render.spelling)
     }
-    print(try shell.render(interface, template: template))
+    // A concrete interface under `--closure` renders its base closure; `*`
+    // stays the flat enumeration even when the flag is present.
+    if closure && interface != "*" {
+      print(try shell.render(closure: interface, template: template))
+    } else {
+      print(try shell.render(interface, template: template))
+    }
   }
 }
 
@@ -310,6 +332,7 @@ internal struct Shell: ~Escapable {
     .schema <query>         print a query's result columns without running it
     .read <path>            run a file of `;`-separated SQL statements
     .render <iface> <tmpl>  render an interface (or `*`) through a template
+    .render … --closure     also render the interface's base-interface closure
     .bind <name> <value>    bind a `:name` parameter (no value clears it)
     .template <name> '…'    define an inline Mustache template (multiline
                             single-quoted; `''` for a literal quote; declare
@@ -459,7 +482,7 @@ internal struct Shell: ~Escapable {
     // (`WHERE TypeName = :name OR '*' = :name`). Choosing which rows to emit is
     // the query's job, so render just iterates whatever it returns.
     let selection =
-        try Shell.select(Shell.query(named: "interfaces", search: search))
+        try Shell.statement(Shell.query(named: "interfaces", search: search))
     let interfaces = try session.run(selection, routines,
                                      bindings: ["name": .text(interface)])
     guard interface == "*" || !interfaces.isEmpty else {
@@ -470,87 +493,175 @@ internal struct Shell: ~Escapable {
     var sources = Array<String>()
     sources.reserveCapacity(interfaces.count)
     for found in interfaces {
-      let id = found[0]
-      // The interface's ordered declared generic-parameter names, through the
-      // `generics` view bound by its `Id` — empty for a non-generic interface.
-      // A generic interface declares at least one; its own name then carries a
-      // CLR arity suffix, stripped below. The names thread into the
-      // method/parameter/return decode so a `VAR` spells its declared name
-      // (`Element`) rather than a positional placeholder (`T0`).
-      let names = try declarations(of: id, routines, search: search)
-      // The names supplied to decode when the interface is generic; `nil`
-      // otherwise, so a non-generic interface decodes exactly as before.
-      let generics: Array<String>? = names.isEmpty ? nil : names
-      // The interface's own methods, decoded with its generic names so a `VAR`
-      // spells its declared name. A generic interface that HAS a base renders
-      // only its own surface here; forwarding a base's inherited methods onto
-      // the wrapper is a follow-up.
-      let methods = try self.methods(of: id, routines, search: search,
-                                     generics: generics, in: dialect,
-                                     language: language)
-      // The interface's named base, via the `bases` view bound by its `Id`. The
-      // render query projects only the plain (`TypeRef`/`TypeDef`) bases, whose
-      // simple `TypeName` is keyword-escaped here the way the interface's own
-      // name is; a generic (`TypeSpec`) base is resolved by the `bases` view
-      // but omitted from the render, pending the WinRT generic-inheritance
-      // projection redesign. A rootless interface defaults to the spec's COM
-      // root, except the root interface itself — which inherits nothing, so it
-      // never becomes its own base; an empty `root` applies no default.
-      let lineage =
-          try Shell.select(Shell.query(named: "bases", search: search))
-      let bases = try session.run(lineage, routines,
-                                  bindings: ["parent": id])
-      let base: String? = if let inherited = bases.first {
-        language.escape(inherited[0].text)
-      } else if language.root.isEmpty || found[2].text == language.root {
-        nil
-      } else {
-        language.root
-      }
-      // A generic interface's own `TypeName` carries the CLR arity suffix
-      // (`IVector``1`); strip it — the decode tier strips it only for a
-      // `GENERICINST` use, so the declaration name must be stripped here — so
-      // the emitted name is `IVector`, its `<T>` clause supplied separately.
-      // The keyword escape (`SANITIZE`) is applied HERE, on the STRIPPED name,
-      // not in the `interfaces` query: escaping the suffixed name would spare a
-      // generic whose stripped name is a keyword (`protocol``1` is not the
-      // reserved word `protocol`), leaving `public struct protocol` to be
-      // emitted. Escaping after the strip is why the query projects the raw
-      // `TypeName` — the interface's own name is the one identifier the strip
-      // must precede the escape for, so its escape lives in Swift, not the SQL.
-      let stripped = String(found[2].text.prefix { $0 != "`" })
-      let name = language.escape(stripped)
-      // The ABI-protocol name is the wrapper's own name suffixed with `ABI`,
-      // used for BOTH the ABI protocol's declaration and the wrapper's `base:
-      // any …ABI<…>` existential. The `ABI` suffix must precede the escape (the
-      // same order the base-name spelling uses): a keyword name's `<name>ABI`
-      // is never itself a keyword (no Swift keyword ends in `ABI`), so escaping
-      // the SUFFIXED name is a no-op yielding a plain `protocolABI` — whereas
-      // escaping FIRST then appending `ABI` would splice a backtick pair into
-      // the middle (`` `protocol`ABI ``), which Swift cannot parse.
-      let abi = language.escape(stripped + "ABI")
-      var context: Dictionary<String, Any> = [
-        "name": name,
-        "abi": abi,
-        "iid": found[3].text,
-        "namespace": found[1].text,
-        "methods": methods,
-      ]
-      // An absent `base` skips the template's `{{#base}}` inheritance clause.
-      if let base { context["base"] = base }
-      // A generic interface carries its `generic` flag and its ordered clause
-      // `generics` (each with a `last` flag for comma separation); a
-      // non-generic one carries neither, so the template's `{{#generic}}` guard
-      // leaves its output byte-identical to today's.
-      if let generics {
-        context["generic"] = true
-        context["generics"] = generics.enumerated().map { index, name in
-          ["name": name, "last": index == generics.count - 1]
-        }
-      }
-      sources.append(mustache.render(context))
+      sources.append(try emit(found, through: mustache, routines: routines,
+                              in: dialect, language: language, search: search))
     }
     return sources.joined(separator: "\n")
+  }
+
+  /// Renders the transitive closure of the interface named `root` and its plain
+  /// (`spec IS NULL`) base and required interfaces — the E1 edges — through the
+  /// named Mustache template.
+  ///
+  /// The setup is the flat render's: the template names its target language, and
+  /// the render resolves against the language spec's UDFs merged with the
+  /// session's routines. The root selection is the same `interfaces` query, so a
+  /// name no interface bears raises `RenderError.interface`; a simple name borne
+  /// by more than one namespace seeds each match. From each seed the walk visits
+  /// the base and required interfaces depth-first, emitting a base before the
+  /// interface that refines it, rendering each interface once (dedup by its local
+  /// `TypeDef` Id). The per-interface body is the one `emit` the flat render
+  /// runs, so the closure reuses the decode and emit rather than duplicating it.
+  internal borrowing func render(closure root: String,
+                                 template: String) throws -> String {
+    var body = try self.template(named: template, search: search)
+    let language = Shell.language(declaredIn: &body, search: search)
+    let routines = language.routines.merging(session.functions)
+    let dialect = language.dialect
+    let selection =
+        try Shell.statement(Shell.query(named: "interfaces", search: search))
+    let roots = try session.run(selection, routines,
+                                bindings: ["name": .text(root)])
+    guard !roots.isEmpty else { throw RenderError.interface(root) }
+
+    let mustache = try MustacheTemplate(string: body)
+    // The interfaces already emitted, keyed on their local `TypeDef` Id, so the
+    // mutually referential interface graph terminates and each renders once.
+    var visited = Set<Int>()
+    var sources = Array<String>()
+    for seed in roots {
+      try walk(seed, visited: &visited, into: &sources, through: mustache,
+               routines: routines, in: dialect, language: language,
+               search: search)
+    }
+    return sources.joined(separator: "\n")
+  }
+
+  /// Emits the interface `found` and, first, the transitive closure of its plain
+  /// (`spec IS NULL`) base and required interfaces — a depth-first post-order
+  /// over the E1 edges, so a base precedes the interface refining it.
+  ///
+  /// The `requires` query resolves each base and required interface to its local
+  /// interface `TypeDef` row keyed on namespace and name, so a base that resolves
+  /// to no local interface `TypeDef` — an external `TypeRef`-only frontier, or a
+  /// local type that is no interface — is not returned and the walk simply stops
+  /// there. The visited set (the local `TypeDef` Id) renders each interface once
+  /// and terminates a cycle; the bases are walked in a stable namespace-then-name
+  /// order so the emission is deterministic.
+  private borrowing func walk(_ found: Array<Value>, visited: inout Set<Int>,
+                              into sources: inout Array<String>,
+                              through mustache: MustacheTemplate,
+                              routines: Routines, in dialect: Dialect,
+                              language: Language,
+                              search: Array<String>) throws {
+    guard visited.insert(found[0].integer).inserted else { return }
+    let query =
+        try Shell.statement(Shell.query(named: "requires", search: search))
+    let bases = try session.run(query, routines,
+                                bindings: ["parent": found[0]])
+    let ordered = bases.sorted {
+      ($0[1].text, $0[2].text) < ($1[1].text, $1[2].text)
+    }
+    for base in ordered {
+      try walk(base, visited: &visited, into: &sources, through: mustache,
+               routines: routines, in: dialect, language: language,
+               search: search)
+    }
+    sources.append(try emit(found, through: mustache, routines: routines,
+                            in: dialect, language: language, search: search))
+  }
+
+  /// Renders the single interface `found` — its `Id`, namespace, name, and
+  /// `iid`, the row shape the `interfaces` and `requires` queries share —
+  /// through `mustache`, the per-interface body the flat render and the
+  /// `--closure` walk both run.
+  ///
+  /// Decoding the interface's declared generics, methods, and base is the same
+  /// work either path needs; wrapping it here is what lets the closure worklist
+  /// reuse the decode and emit rather than duplicate them.
+  private borrowing func emit(_ found: Array<Value>,
+                              through mustache: MustacheTemplate,
+                              routines: Routines, in dialect: Dialect,
+                              language: Language,
+                              search: Array<String>) throws -> String {
+    let id = found[0]
+    // The interface's ordered declared generic-parameter names, through the
+    // `generics` view bound by its `Id` — empty for a non-generic interface.
+    // A generic interface declares at least one; its own name then carries a
+    // CLR arity suffix, stripped below. The names thread into the
+    // method/parameter/return decode so a `VAR` spells its declared name
+    // (`Element`) rather than a positional placeholder (`T0`).
+    let names = try declarations(of: id, routines, search: search)
+    // The names supplied to decode when the interface is generic; `nil`
+    // otherwise, so a non-generic interface decodes exactly as before.
+    let generics: Array<String>? = names.isEmpty ? nil : names
+    // The interface's own methods, decoded with its generic names so a `VAR`
+    // spells its declared name. A generic interface that has a base renders
+    // only its own surface here; forwarding a base's inherited methods onto
+    // the wrapper is a follow-up.
+    let methods = try self.methods(of: id, routines, search: search,
+                                   generics: generics, in: dialect,
+                                   language: language)
+    // The interface's named base, via the `bases` view bound by its `Id`. The
+    // render query projects only the plain (`TypeRef`/`TypeDef`) bases, whose
+    // simple `TypeName` is keyword-escaped here the way the interface's own
+    // name is; a generic (`TypeSpec`) base is resolved by the `bases` view
+    // but omitted from the render, pending the WinRT generic-inheritance
+    // projection redesign. A rootless interface defaults to the spec's COM
+    // root, except the root interface itself — which inherits nothing, so it
+    // never becomes its own base; an empty `root` applies no default.
+    let lineage =
+        try Shell.statement(Shell.query(named: "bases", search: search))
+    let bases = try session.run(lineage, routines, bindings: ["parent": id])
+    let base: String? = if let inherited = bases.first {
+      language.escape(inherited[0].text)
+    } else if language.root.isEmpty || found[2].text == language.root {
+      nil
+    } else {
+      language.root
+    }
+    // A generic interface's own `TypeName` carries the CLR arity suffix
+    // (`IVector``1`); strip it — the decode tier strips it only for a
+    // `GENERICINST` use, so the declaration name must be stripped here — so
+    // the emitted name is `IVector`, its `<T>` clause supplied separately.
+    // The keyword escape (`SANITIZE`) is applied here, on the stripped name,
+    // not in the `interfaces` query: escaping the suffixed name would spare a
+    // generic whose stripped name is a keyword (`protocol``1` is not the
+    // reserved word `protocol`), leaving `public struct protocol` to be
+    // emitted. Escaping after the strip is why the query projects the raw
+    // `TypeName` — the interface's own name is the one identifier the strip
+    // must precede the escape for, so its escape lives in Swift, not the SQL.
+    let stripped = String(found[2].text.prefix { $0 != "`" })
+    let name = language.escape(stripped)
+    // The ABI-protocol name is the wrapper's own name suffixed with `ABI`,
+    // used for both the ABI protocol's declaration and the wrapper's `base:
+    // any …ABI<…>` existential. The `ABI` suffix must precede the escape (the
+    // same order the base-name spelling uses): a keyword name's `<name>ABI`
+    // is never itself a keyword (no Swift keyword ends in `ABI`), so escaping
+    // the suffixed name is a no-op yielding a plain `protocolABI` — whereas
+    // escaping first then appending `ABI` would splice a backtick pair into
+    // the middle (`` `protocol`ABI ``), which Swift cannot parse.
+    let abi = language.escape(stripped + "ABI")
+    var context: Dictionary<String, Any> = [
+      "name": name,
+      "abi": abi,
+      "iid": found[3].text,
+      "namespace": found[1].text,
+      "methods": methods,
+    ]
+    // An absent `base` skips the template's `{{#base}}` inheritance clause.
+    if let base { context["base"] = base }
+    // A generic interface carries its `generic` flag and its ordered clause
+    // `generics` (each with a `last` flag for comma separation); a
+    // non-generic one carries neither, so the template's `{{#generic}}` guard
+    // leaves its output byte-identical to today's.
+    if let generics {
+      context["generic"] = true
+      context["generics"] = generics.enumerated().map { index, name in
+        ["name": name, "last": index == generics.count - 1]
+      }
+    }
+    return mustache.render(context)
   }
 
   /// The template method entries for the interface at `id`, in declaration
@@ -568,12 +679,13 @@ internal struct Shell: ~Escapable {
                                  generics: Array<String>?, in dialect: Dialect,
                                  language: Language) throws
       -> Array<Dictionary<String, Any>> {
-    let plan = try Shell.select(Shell.query(named: "methods", search: search))
+    let plan =
+        try Shell.statement(Shell.query(named: "methods", search: search))
     let rows = try session.run(plan, routines, bindings: ["parent": id])
     var methods = Array<Dictionary<String, Any>>()
     methods.reserveCapacity(rows.count)
     for method in rows {
-      let selection = try Shell.select(Shell.query(named: "params",
+      let selection = try Shell.statement(Shell.query(named: "params",
                                                    search: search))
       let params = try session.run(selection, routines,
                                    bindings: ["parent": method[0]])
@@ -659,7 +771,7 @@ internal struct Shell: ~Escapable {
       -> Array<String> {
     if session.storage.opened("GenericParam") == nil { return [] }
     let clause =
-        try Shell.select(Shell.query(named: "generics", search: search))
+        try Shell.statement(Shell.query(named: "generics", search: search))
     let declared = try session.run(clause, routines, bindings: ["parent": id])
     return declared.map(\.first!.text)
   }
@@ -756,17 +868,24 @@ internal struct Shell: ~Escapable {
     return Headers.syntactic(of: statement, rows)
   }
 
-  /// Parses `text` as a `SELECT`, returning its `SQLEngine.Query`.
+  /// Parses `text` as a row-producing statement, returning its `Statement`.
   ///
-  /// The render's queries are static, well-formed `SELECT`s, so a parse failure
-  /// or a non-`SELECT` is a programming error; it surfaces as the thrown error.
-  /// The return type is spelled `SQLEngine.Query` — the module's own `Query` is
-  /// the `ParsableCommand` subcommand, not the SQL AST.
-  private static func select(_ text: String) throws -> SQLEngine.Query {
-    guard case let .select(query) = try Statement(parsing: text) else {
-      throw SQLError.incomplete(expected: "a SELECT")
+  /// The render's queries are static, well-formed row producers — a plain
+  /// `SELECT` or a `WITH` whose trailing query is one (`requires` resolves a
+  /// reference's scope chain through a recursive CTE) — so a parse failure or a
+  /// non-producing statement (a `CREATE`) is a programming error and surfaces as
+  /// the thrown error. A `Statement` is returned rather than a bare
+  /// `SQLEngine.Query` so the `run(_:routines:bindings:)` Statement overload
+  /// keeps a `WITH`'s CTEs in scope for its trailing query; a plain `SELECT`
+  /// runs identically through it.
+  private static func statement(_ text: String) throws -> SQLEngine.Statement {
+    let parsed = try SQLEngine.Statement(parsing: text)
+    switch parsed {
+    case .select, .with:
+      return parsed
+    case .create, .function, .explain:
+      throw SQLError.incomplete(expected: "a query")
     }
-    return query
   }
 
   /// The target-language spec a template body declares, consuming its leading

--- a/Tests/SQLEngineWinMDTests/RecursiveScopeTests.swift
+++ b/Tests/SQLEngineWinMDTests/RecursiveScopeTests.swift
@@ -1,0 +1,103 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+
+@testable import SQLEngineWinMD
+
+import SQLEngine
+@testable import WinMD
+
+/// De-risks the closure render's scope-chain resolution: a `WITH RECURSIVE` CTE
+/// walking the virtual, decoded coded-index column `ResolutionScope_TypeRef`
+/// through a `TypeRef` nesting chain to its terminal scope, classifying each
+/// reference local or external by whether that terminal resolves to the
+/// `Module`. It proves the planner resolves a decoded coded-index column inside
+/// a recursive CTE arm and that a `WITH RECURSIVE` runs through the adapter's
+/// `run` — the substrate the `requires.sql`/`references.sql` resolution rests
+/// on.
+struct RecursiveScopeTests {
+  // Four `TypeRef` rows (6-byte narrow rows: ResolutionScope coded index,
+  // TypeName, TypeNamespace), forming two nesting chains. ECMA-335 rows are
+  // 1-based, so a stored index `N` names the 0-based row `N - 1`, and a
+  // `ResolutionScope` coded cell is `(row << 2) | tag` with the tag ordering
+  // Module=0, ModuleRef=1, AssemblyRef=2, TypeRef=3.
+  //
+  //   TypeRef[0] Outer(AssemblyRef): RS=(1<<2)|2=6  → external terminal
+  //   TypeRef[1] Inner(TypeRef→[0]): RS=(1<<2)|3=7  → nested under Outer[0]
+  //   TypeRef[2] Outer(Module):      RS=(1<<2)|0=4  → local terminal
+  //   TypeRef[3] Inner(TypeRef→[2]): RS=(3<<2)|3=15 → nested under Outer[2]
+  //
+  // Chain [1]→[0] terminates at an AssemblyRef (external); chain [3]→[2]
+  // terminates at the Module (local). A nested reference carries an empty
+  // namespace, as a real nested `TypeRef` does.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0]: RS=6, TypeName=7 (Outer), TypeNamespace=13 (NS).
+    0x06, 0x00, 0x07, 0x00, 0x0d, 0x00,
+    // TypeRef[1]: RS=7, TypeName=1 (Inner), TypeNamespace=0 (empty).
+    0x07, 0x00, 0x01, 0x00, 0x00, 0x00,
+    // TypeRef[2]: RS=4, TypeName=7 (Outer), TypeNamespace=13 (NS).
+    0x04, 0x00, 0x07, 0x00, 0x0d, 0x00,
+    // TypeRef[3]: RS=15, TypeName=1 (Inner), TypeNamespace=0 (empty).
+    0x0f, 0x00, 0x01, 0x00, 0x00, 0x00,
+  ]
+
+  // "\0Inner\0Outer\0NS\0": Inner@1, Outer@7, NS@13, empty namespace @0.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x49, 0x6e, 0x6e, 0x65, 0x72, 0x00,
+    0x4f, 0x75, 0x74, 0x65, 0x72, 0x00,
+    0x4e, 0x53, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 4, range: 0 ..< 24,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 = 1 << 1
+
+  /// Runs `sql` over a `WinMDDatabase` bound to the assembled `TypeRef` store.
+  private static func run(_ sql: String) throws -> Array<Array<Value>> {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: empty.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    let database = WinMDDatabase(storage)
+    return try database.run(sql)
+  }
+
+  @Test func `walks a nesting chain to its terminal scope`() throws {
+    // The recursive CTE seeds each `TypeRef` as its own chain start, then walks
+    // `ResolutionScope_TypeRef` to the enclosing reference until the terminal
+    // (its `ResolutionScope_TypeRef` NULL) — classified local when that
+    // terminal's `ResolutionScope_Module` is non-null, external otherwise. Both
+    // top-level terminals and both nested references classify by the terminal,
+    // proving the decoded column resolves inside the recursive arm.
+    let rows = try RecursiveScopeTests.run("""
+      WITH RECURSIVE chain(start, node) AS (
+        SELECT r.Id, r.Id FROM TypeRef r
+        UNION ALL
+        SELECT c.start, r.ResolutionScope_TypeRef
+        FROM chain c
+        JOIN TypeRef r ON r.Id = c.node
+        WHERE r.ResolutionScope_TypeRef IS NOT NULL
+      )
+      SELECT
+        c.start,
+        CASE WHEN t.ResolutionScope_Module IS NOT NULL
+             THEN 'local' ELSE 'external' END
+      FROM chain c
+      JOIN TypeRef t ON t.Id = c.node
+      WHERE t.ResolutionScope_TypeRef IS NULL
+      ORDER BY c.start
+      """)
+    #expect(rows == [
+      [.integer(1), .text("external")], // Outer under AssemblyRef
+      [.integer(2), .text("external")], // Inner under Outer[external]
+      [.integer(3), .text("local")],    // Outer under Module
+      [.integer(4), .text("local")],    // Inner under Outer[local]
+    ])
+  }
+}

--- a/Tests/SQLEngineWinMDTests/WinMDDatabaseTests.swift
+++ b/Tests/SQLEngineWinMDTests/WinMDDatabaseTests.swift
@@ -110,12 +110,13 @@ struct WinMDDatabaseTests {
 
   @Test func `enumerates its base relations`() {
     // The store physically holds only `TypeDef`, yet `table(named:)` also
-    // resolves the optional `TypeSpec` (ECMA-335 §II.22.39) to an empty
-    // relation when it is absent, so `relations()` enumerates it too — the
-    // catalog contract that `relations()` names every base relation
-    // `table(named:)` resolves. It is appended once, past the physical tables.
+    // resolves the optional tables — `TypeSpec` (ECMA-335 §II.22.39) and
+    // `NestedClass` (§II.22.32) — to an empty relation when they are absent, so
+    // `relations()` enumerates them too — the catalog contract that
+    // `relations()` names every base relation `table(named:)` resolves. Each is
+    // appended once, past the physical tables.
     WinMDDatabaseTests.with { database in
-      #expect(database.relations() == ["TypeDef", "TypeSpec"])
+      #expect(database.relations() == ["TypeDef", "TypeSpec", "NestedClass"])
     }
   }
 }

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -183,6 +183,10 @@ struct DatabaseSQLTests {
                 wide: 0, stride: 6),
     WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 86 ..< 92,
                 wide: 0, stride: 6),
+    // No `NestedClass` table: this fixture has no nested types, so a real
+    // `.winmd` would omit it from the tables stream. The `requires` recursive
+    // CTE still names it, so the adapter synthesises an empty relation for the
+    // absent optional table rather than faulting the CTE.
   ]
 
   private static let valid: UInt64 =
@@ -634,6 +638,22 @@ struct DatabaseSQLTests {
         }
 
         """)
+    }
+  }
+
+  @Test func `--closure over an interface whose bases are not local interfaces renders only it`() throws {
+    // `IMyInterface`'s `InterfaceImpl` rows name `IInspectable` (an external
+    // `TypeRef` with no local `TypeDef`) and `INotGuid` (a local `TypeDef` that
+    // is no interface — it carries no `GuidAttribute`, so the `interfaces` view
+    // excludes it). Neither resolves to a local interface row, so the closure
+    // walk stops at the root: the closure output is exactly the flat render,
+    // the same per-interface body, proving the worklist reuses `emit`.
+    try DatabaseSQLTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IMyInterface", template: "com")
+      let flat = try shell.render("IMyInterface", template: "com")
+      #expect(closed == flat)
+      #expect(closed.contains("public protocol IMyInterface: IInspectable {"))
     }
   }
 

--- a/Tests/winmd-inspectTests/RenderClosureTests.swift
+++ b/Tests/winmd-inspectTests/RenderClosureTests.swift
@@ -1,0 +1,644 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+
+@testable import winmd_inspect
+@testable import SQLEngineWinMD
+
+import Mustache
+import SQLEngine
+@testable import WinMD
+import WinMDSynthesis
+
+/// Coverage of the `.render … --closure` transitive-closure walk (Stage 0: the
+/// plain base and required-interface edges). Rather than map a `.winmd` file,
+/// the fixture assembles two method-less COM interfaces in memory — `IBase` and
+/// `IDerived`, each carrying a `GuidAttribute` (so the `interfaces` view names
+/// both) with an `InterfaceImpl` naming `IDerived`'s base as the local `IBase`
+/// `TypeDef` — and renders the closure over `IDerived`, asserting it emits the
+/// base before the interface refining it while the flat render emits `IDerived`
+/// alone. The fixture declares no `NestedClass` table, as a real `.winmd`
+/// without nested types omits it, so it also proves the adapter synthesises an
+/// empty relation for that absent optional table rather than faulting the CTE.
+struct RenderClosureTests {
+  // Five narrow (all-index 2-byte) tables packed back to back in table-number
+  // order — TypeRef (#1, 1 row), TypeDef (#2, 2 rows), InterfaceImpl (#9, 1
+  // row), MemberRef (#10, 1 row), CustomAttribute (#12, 2 rows) — plus empty
+  // MethodDef (#6) and Param (#8) tables so the render's `methods` view
+  // resolves a relation. ECMA-335 rows are 1-based; a coded index is
+  // `(row << bits) | tag`.
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IBase"(52),
+  //                TypeNamespace="NS"(49), MethodList=1 (empty) — the base.
+  //   TypeDef[1]:  Flags=0x21, TypeName="IDerived"(58), TypeNamespace="NS"(49),
+  //                MethodList=1 (empty) — the refiner.
+  //   InterfaceImpl[0]: Class=2 (TypeDef row 2, IDerived),
+  //                Interface=TypeDefOrRef(TypeDef row 1)=(1<<2)|0=4 — names the
+  //                local base `IBase`, so `requires` resolves it.
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+  //                `GuidAttribute` ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[1] — `IBase`'s IID.
+  //   CustomAttribute[1]: Parent=HasCustomAttribute(TypeDef row 2)=(2<<5)|3=67,
+  //                Type=11, Value=blob[1] — `IDerived`'s IID.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0]
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeDef[0] (IBase)
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[1] (IDerived)
+    0x21, 0x00, 0x00, 0x00, 0x3a, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // InterfaceImpl[0]
+    0x02, 0x00, 0x04, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x01, 0x00,
+    // CustomAttribute[1]
+    0x43, 0x00, 0x0b, 0x00, 0x01, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IBase\0IDerived\0":
+  // GuidNamespace@1, GuidName@35, NS@49, IBase@52, IDerived@58.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x42, 0x61, 0x73, 0x65, 0x00,
+    0x49, 0x44, 0x65, 0x72, 0x69, 0x76, 0x65, 0x64, 0x00,
+  ]
+
+  // The blob heap: offset 0 is the reserved empty blob; offset 1 is the 20-byte
+  // `GuidAttribute` value (prolog 0x0001, the well-known GUID
+  // `0C733A30-2A1C-11CE-ADE5-00AA0044773D`, then NumNamed 0), preceded by its
+  // length 0x14. Both interfaces name it, so both carry the same IID.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 34 ..< 38,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 38 ..< 44,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 2, range: 44 ..< 56,
+                wide: 0, stride: 6),
+    // No `NestedClass` table: this fixture has no nested types, so a real
+    // `.winmd` would omit it from the tables stream. The `requires` recursive
+    // CTE still names `NestedClass`, so the adapter must synthesise an empty
+    // relation for the absent optional table — `IDerived`'s base resolves
+    // through the `TypeDef` arm regardless.
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 10)
+          | (1 << 12)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure renders the base before the interface refining it`() throws {
+    // The closure over `IDerived` follows its plain base edge to the local
+    // `IBase` interface and emits both, the base first (a depth-first
+    // post-order over the E1 edges). The flat render of `IDerived` emits only
+    // `IDerived`, so `--closure` is what pulls the base declaration in.
+    try RenderClosureTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IDerived", template: "com")
+      #expect(closed.contains("public protocol IBase: IUnknown {"))
+      #expect(closed.contains("public protocol IDerived: IBase {"))
+      let base = try #require(closed.range(of: "public protocol IBase"))
+      let derived = try #require(closed.range(of: "public protocol IDerived"))
+      #expect(base.lowerBound < derived.lowerBound)
+
+      let flat = try shell.render("IDerived", template: "com")
+      #expect(flat.contains("public protocol IDerived: IBase {"))
+      #expect(!flat.contains("public protocol IBase"))
+    }
+  }
+
+  @Test func `--closure resolves a direct TypeDef base with NestedClass omitted`() throws {
+    // A `.winmd` with no nested types omits `NestedClass` from the tables
+    // stream, so this fixture declares no such table — yet the `requires`
+    // recursive CTE names `NestedClass`. The adapter synthesises an empty
+    // relation for the absent optional table, so the closure over `IDerived`
+    // still resolves its direct `TypeDef` base and emits `IBase`. Pre-fix the
+    // CTE faulted on the missing relation, so `--closure` failed for every
+    // otherwise-valid file without nested types.
+    try RenderClosureTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IDerived", template: "com")
+      #expect(closed.contains("public protocol IBase: IUnknown {"))
+      #expect(closed.contains("public protocol IDerived: IBase {"))
+    }
+  }
+}
+
+/// Coverage of the `requires` TypeRef arm's scope gate: an `InterfaceImpl` base
+/// named through an externally scoped `TypeRef` that happens to share a local
+/// interface's (namespace, name) must not resolve to that local interface. The
+/// fixture assembles two method-less COM interfaces — a root `IRoot` and an
+/// unrelated local `IStray`, both in namespace `NS` and both carrying a
+/// `GuidAttribute` (so the `interfaces` view names both) — with an
+/// `InterfaceImpl` naming `IRoot`'s base through a `TypeRef` to (`NS`, `IStray`)
+/// whose `ResolutionScope` is an external `AssemblyRef` (tag 2). The closure
+/// over `IRoot` names `IStray` in the refinement clause (the edge is genuine)
+/// yet must not emit `IStray`'s declaration: the external ref is the frontier.
+/// A pre-fix name-only join would have pulled the local `IStray` (and its whole
+/// closure) in.
+struct RenderClosureScopeTests {
+  // Eight tables packed back to back in table-number order — TypeRef (#1, 2
+  // rows), TypeDef (#2, 2 rows), MethodDef (#6, empty), Param (#8, empty),
+  // InterfaceImpl (#9, 1 row), MemberRef (#10, 1 row), CustomAttribute (#12, 2
+  // rows), AssemblyRef (#35, 1 row) — every index narrow (2-byte). ECMA-335
+  // rows are 1-based; a coded index is `(row << bits) | tag`.
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeRef[1]:  ResolutionScope=ResolutionScope(AssemblyRef row 1)
+  //                =(1<<2)|2=6, TypeName="IStray"(58), TypeNamespace="NS"(49) —
+  //                an externally scoped ref sharing the local `IStray` identity.
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IRoot"(52),
+  //                TypeNamespace="NS"(49), MethodList=1 (empty) — the root.
+  //   TypeDef[1]:  Flags=0x21, TypeName="IStray"(58), TypeNamespace="NS"(49),
+  //                MethodList=1 (empty) — the unrelated local interface.
+  //   InterfaceImpl[0]: Class=1 (TypeDef row 1, IRoot),
+  //                Interface=TypeDefOrRef(TypeRef row 2)=(2<<2)|1=9 — names the
+  //                external `IStray` ref, so `requires` must drop it.
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+  //                `GuidAttribute` ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[1] — `IRoot`'s IID.
+  //   CustomAttribute[1]: Parent=HasCustomAttribute(TypeDef row 2)=(2<<5)|3=67,
+  //                Type=11, Value=blob[1] — `IStray`'s IID.
+  //   AssemblyRef[0]: all-zero (an empty external assembly the ref scopes to).
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeRef[1] (external IStray ref)
+    0x06, 0x00, 0x3a, 0x00, 0x31, 0x00,
+    // TypeDef[0] (IRoot)
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[1] (IStray)
+    0x21, 0x00, 0x00, 0x00, 0x3a, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // InterfaceImpl[0]
+    0x01, 0x00, 0x09, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x01, 0x00,
+    // CustomAttribute[1]
+    0x43, 0x00, 0x0b, 0x00, 0x01, 0x00,
+    // AssemblyRef[0]
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IRoot\0IStray\0":
+  // GuidNamespace@1, GuidName@35, NS@49, IRoot@52, IStray@58.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x52, 0x6f, 0x6f, 0x74, 0x00,
+    0x49, 0x53, 0x74, 0x72, 0x61, 0x79, 0x00,
+  ]
+
+  // The blob heap: offset 0 is the reserved empty blob; offset 1 is the 20-byte
+  // `GuidAttribute` value (prolog 0x0001, the well-known GUID
+  // `0C733A30-2A1C-11CE-ADE5-00AA0044773D`, then NumNamed 0), preceded by its
+  // length 0x14. Both interfaces name it, so both carry the same IID.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 12 ..< 40,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 0, range: 40 ..< 40,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 40 ..< 40,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 40 ..< 44,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 44 ..< 50,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 2, range: 50 ..< 62,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.AssemblyRef.self, rows: 1, range: 62 ..< 82,
+                wide: 0, stride: 20),
+    // No `NestedClass` table: this fixture has no nested types, so a real
+    // `.winmd` would omit it. The `requires` recursive CTE still names it, so
+    // the adapter synthesises an empty relation for the absent optional table;
+    // the external `IStray` ref's chain terminates at the `AssemblyRef`, so
+    // nothing resolves anyway.
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 10)
+          | (1 << 12) | (1 << 35)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure drops an externally scoped base sharing a local name`() throws {
+    // `IRoot`'s only base edge names an external `TypeRef` to (`NS`, `IStray`)
+    // whose `ResolutionScope` is an `AssemblyRef`, so `IRoot` refines `IStray`
+    // in its clause yet the closure must not emit `IStray`'s declaration — the
+    // external ref is the frontier. The pre-fix name-only join matched the
+    // local `IStray` interface and would have emitted `public protocol IStray:
+    // IUnknown {`; the scope gate keeps that declaration out.
+    try RenderClosureScopeTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("public protocol IRoot: IStray {"))
+      // The edge is genuine (the clause names `IStray`) …
+      #expect(closed.contains(": IStray"))
+      // … but the external ref is a frontier, so no `IStray` declaration.
+      #expect(!closed.contains("public protocol IStray"))
+    }
+  }
+}
+
+/// Coverage of the `requires` TypeRef arm's scope-chain walk over a *nested*
+/// external reference — the case the pre-fix immediate-scope gate missed. The
+/// fixture assembles a root `IRoot` whose base is named through a `TypeRef` to a
+/// nested `Widget` whose immediate `ResolutionScope` is another `TypeRef`
+/// (`Outer`), whose own scope is an external `AssemblyRef`. Its immediate scope
+/// is thus a `TypeRef` — the pre-fix gate (`ResolutionScope_AssemblyRef` and
+/// `ResolutionScope_ModuleRef` both null) passed, wrongly localising it — yet
+/// its scope chain terminates externally, so `resolved` never reaches its
+/// anchor and the reference drops. A local nested interface `Widget` (empty
+/// namespace, under a local `Host`) shares the bare name, so the pre-fix
+/// name-only join would have emitted `public protocol Widget`; the scope-chain
+/// walk keeps that unrelated declaration out.
+struct RenderClosureNestedExternalTests {
+  // Nine tables packed back to back in table-number order — TypeRef (#1, 3
+  // rows), TypeDef (#2, 3 rows), MethodDef (#6, empty), Param (#8, empty),
+  // InterfaceImpl (#9, 1 row), MemberRef (#10, 1 row), CustomAttribute (#12, 2
+  // rows), AssemblyRef (#35, 1 row), NestedClass (#41, 1 row) — every index
+  // narrow (2-byte). ECMA-335 rows are 1-based; a coded index is
+  // `(row << bits) | tag`.
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeRef[1]:  ResolutionScope(AssemblyRef row 1)=(1<<2)|2=6,
+  //                TypeName="Outer"(63), TypeNamespace="NS"(49) — the external
+  //                enclosing reference.
+  //   TypeRef[2]:  ResolutionScope(TypeRef row 2)=(2<<2)|3=11,
+  //                TypeName="Widget"(69), TypeNamespace=empty(0) — nested under
+  //                `Outer`, so its immediate scope is a `TypeRef`; the chain
+  //                terminates at the external `AssemblyRef`.
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IRoot"(52),
+  //                TypeNamespace="NS"(49), MethodList=1 (empty) — the root.
+  //   TypeDef[1]:  Flags=0 (a plain class), TypeName="Host"(58),
+  //                TypeNamespace="NS"(49), MethodList=1 — a local enclosing.
+  //   TypeDef[2]:  Flags=0x21, TypeName="Widget"(69), TypeNamespace=empty(0),
+  //                MethodList=1 — a local nested interface sharing the bare name.
+  //   InterfaceImpl[0]: Class=1 (TypeDef row 1, IRoot),
+  //                Interface=TypeDefOrRef(TypeRef row 3)=(3<<2)|1=13 — names the
+  //                nested external `Widget` reference.
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+  //                `GuidAttribute` ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[1] — `IRoot`'s IID.
+  //   CustomAttribute[1]: Parent=HasCustomAttribute(TypeDef row 3)=(3<<5)|3=99,
+  //                Type=11, Value=blob[1] — the local `Widget`'s IID.
+  //   AssemblyRef[0]: all-zero (an empty external assembly the chain scopes to).
+  //   NestedClass[0]: NestedClass=3 (TypeDef row 3, Widget), EnclosingClass=2
+  //                (TypeDef row 2, Host) — the local `Widget` is nested.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeRef[1] (external Outer ref)
+    0x06, 0x00, 0x3f, 0x00, 0x31, 0x00,
+    // TypeRef[2] (nested Widget ref under Outer)
+    0x0b, 0x00, 0x45, 0x00, 0x00, 0x00,
+    // TypeDef[0] (IRoot)
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[1] (Host)
+    0x00, 0x00, 0x00, 0x00, 0x3a, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[2] (local nested Widget)
+    0x21, 0x00, 0x00, 0x00, 0x45, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // InterfaceImpl[0]
+    0x01, 0x00, 0x0d, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x01, 0x00,
+    // CustomAttribute[1]
+    0x63, 0x00, 0x0b, 0x00, 0x01, 0x00,
+    // AssemblyRef[0]
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // NestedClass[0]
+    0x03, 0x00, 0x02, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IRoot\0Host\0Outer\0
+  //  Widget\0": GuidNamespace@1, GuidName@35, NS@49, IRoot@52, Host@58,
+  // Outer@63, Widget@69.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x52, 0x6f, 0x6f, 0x74, 0x00,
+    0x48, 0x6f, 0x73, 0x74, 0x00,
+    0x4f, 0x75, 0x74, 0x65, 0x72, 0x00,
+    0x57, 0x69, 0x64, 0x67, 0x65, 0x74, 0x00,
+  ]
+
+  // The blob heap: offset 0 is the reserved empty blob; offset 1 is the 20-byte
+  // `GuidAttribute` value (prolog 0x0001, the well-known GUID
+  // `0C733A30-2A1C-11CE-ADE5-00AA0044773D`, then NumNamed 0), preceded by its
+  // length 0x14. Both interfaces name it, so both carry the same IID.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 3, range: 0 ..< 18,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 3, range: 18 ..< 60,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 0, range: 60 ..< 60,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 60 ..< 60,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 60 ..< 64,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 64 ..< 70,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 2, range: 70 ..< 82,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.AssemblyRef.self, rows: 1, range: 82 ..< 102,
+                wide: 0, stride: 20),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 1, range: 102 ..< 106,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 10)
+          | (1 << 12) | (1 << 35) | (1 << 41)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure drops a nested external base sharing a local name`() throws {
+    // `IRoot`'s base names a nested `TypeRef` whose immediate scope is another
+    // `TypeRef` (so the pre-fix immediate-scope gate passed) but whose chain
+    // terminates at an `AssemblyRef`. The scope-chain walk classifies it
+    // external, so the local nested `Widget` sharing the bare name is not
+    // pulled in: `IRoot` refines `Widget` in its clause yet no `Widget`
+    // declaration is emitted.
+    try RenderClosureNestedExternalTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("public protocol IRoot: Widget {"))
+      // The edge is genuine (the clause names `Widget`) …
+      #expect(closed.contains(": Widget"))
+      // … but the nested external ref is a frontier, so no `Widget` declaration.
+      #expect(!closed.contains("public protocol Widget"))
+    }
+  }
+}
+
+/// Coverage of the `requires` TypeRef arm resolving two same-named nested types
+/// by their distinct enclosings rather than conflating them. The fixture
+/// assembles a root `IRoot` whose base is named through a nested `TypeRef`
+/// `Widget` scoped to a local enclosing `A`, plus two local enclosings `A` and
+/// `B` each owning a distinct nested interface `Widget` (both empty-namespace,
+/// bare name `Widget`, but with different IIDs). A name-only join is ambiguous
+/// across the two `Widget`s; the scope-chain walk resolves the reference to
+/// `A.Widget` by following its enclosing reference to the local `A`, so only
+/// `A`'s `Widget` (its IID) is emitted, never `B`'s.
+struct RenderClosureNestedConflationTests {
+  // Eight tables packed back to back in table-number order — TypeRef (#1, 3
+  // rows), TypeDef (#2, 5 rows), MethodDef (#6, empty), Param (#8, empty),
+  // InterfaceImpl (#9, 1 row), MemberRef (#10, 1 row), CustomAttribute (#12, 3
+  // rows), NestedClass (#41, 2 rows) — every index narrow (2-byte). ECMA-335
+  // rows are 1-based; a coded index is `(row << bits) | tag`.
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeRef[1]:  ResolutionScope(Module row 1)=(1<<2)|0=4, TypeName="A"(58),
+  //                TypeNamespace="NS"(49) — a top-level, module-scoped
+  //                reference to the local enclosing `A`.
+  //   TypeRef[2]:  ResolutionScope(TypeRef row 2)=(2<<2)|3=11,
+  //                TypeName="Widget"(62), TypeNamespace=empty(0) — nested under
+  //                the `A` reference.
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IRoot"(52),
+  //                TypeNamespace="NS"(49), MethodList=1 — the root.
+  //   TypeDef[1]:  Flags=0 (a plain class), TypeName="A"(58),
+  //                TypeNamespace="NS"(49), MethodList=1 — a local enclosing.
+  //   TypeDef[2]:  Flags=0, TypeName="B"(60), TypeNamespace="NS"(49),
+  //                MethodList=1 — the other local enclosing.
+  //   TypeDef[3]:  Flags=0x21, TypeName="Widget"(62), TypeNamespace=empty(0),
+  //                MethodList=1 — `A`'s nested interface.
+  //   TypeDef[4]:  Flags=0x21, TypeName="Widget"(62), TypeNamespace=empty(0),
+  //                MethodList=1 — `B`'s nested interface, same bare name.
+  //   InterfaceImpl[0]: Class=1 (TypeDef row 1, IRoot),
+  //                Interface=TypeDefOrRef(TypeRef row 3)=(3<<2)|1=13 — the
+  //                nested `Widget` reference under `A`.
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+  //                `GuidAttribute` ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[43] — `IRoot`'s IID (all-0x22).
+  //   CustomAttribute[1]: Parent=HasCustomAttribute(TypeDef row 4)=(4<<5)|3=131,
+  //                Type=11, Value=blob[1] — `A.Widget`'s IID (the well-known
+  //                GUID).
+  //   CustomAttribute[2]: Parent=HasCustomAttribute(TypeDef row 5)=(5<<5)|3=163,
+  //                Type=11, Value=blob[22] — `B.Widget`'s IID (all-0x11).
+  //   NestedClass[0]: NestedClass=4 (TypeDef row 4), EnclosingClass=2 (TypeDef
+  //                row 2, A) — `A.Widget` nested under `A`.
+  //   NestedClass[1]: NestedClass=5 (TypeDef row 5), EnclosingClass=3 (TypeDef
+  //                row 3, B) — `B.Widget` nested under `B`.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeRef[1] (module-scoped A ref)
+    0x04, 0x00, 0x3a, 0x00, 0x31, 0x00,
+    // TypeRef[2] (nested Widget ref under A)
+    0x0b, 0x00, 0x3e, 0x00, 0x00, 0x00,
+    // TypeDef[0] (IRoot)
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[1] (A)
+    0x00, 0x00, 0x00, 0x00, 0x3a, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[2] (B)
+    0x00, 0x00, 0x00, 0x00, 0x3c, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[3] (A.Widget)
+    0x21, 0x00, 0x00, 0x00, 0x3e, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[4] (B.Widget)
+    0x21, 0x00, 0x00, 0x00, 0x3e, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // InterfaceImpl[0]
+    0x01, 0x00, 0x0d, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x2b, 0x00,
+    // CustomAttribute[1]
+    0x83, 0x00, 0x0b, 0x00, 0x01, 0x00,
+    // CustomAttribute[2]
+    0xa3, 0x00, 0x0b, 0x00, 0x16, 0x00,
+    // NestedClass[0]
+    0x04, 0x00, 0x02, 0x00,
+    // NestedClass[1]
+    0x05, 0x00, 0x03, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IRoot\0A\0B\0Widget\0":
+  // GuidNamespace@1, GuidName@35, NS@49, IRoot@52, A@58, B@60, Widget@62.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x52, 0x6f, 0x6f, 0x74, 0x00,
+    0x41, 0x00,
+    0x42, 0x00,
+    0x57, 0x69, 0x64, 0x67, 0x65, 0x74, 0x00,
+  ]
+
+  // The blob heap: offset 0 is the reserved empty blob; each subsequent blob is
+  // a 20-byte `GuidAttribute` value (prolog 0x0001, 16 GUID bytes, NumNamed 0)
+  // preceded by its length 0x14. Offset 1 is the well-known GUID
+  // `0C733A30-2A1C-11CE-ADE5-00AA0044773D` (`A.Widget`); offset 22 is all-0x11
+  // (`B.Widget`); offset 43 is all-0x22 (`IRoot`), so the three IIDs are
+  // distinct.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+    0x14, 0x01, 0x00, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x00, 0x00,
+    0x14, 0x01, 0x00, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 3, range: 0 ..< 18,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 5, range: 18 ..< 88,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 0, range: 88 ..< 88,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 88 ..< 88,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 88 ..< 92,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 92 ..< 98,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 3, range: 98 ..< 116,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.NestedClass.self, rows: 2, range: 116 ..< 124,
+                wide: 0, stride: 4),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 10)
+          | (1 << 12) | (1 << 41)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `--closure resolves a nested base by its enclosing, not its bare name`() throws {
+    // The nested `Widget` reference is scoped to the local `A`, so the
+    // scope-chain walk resolves it to `A.Widget` — never `B.Widget`, which
+    // shares the bare name under a different enclosing. Only `A.Widget`'s IID
+    // is emitted; `B.Widget`'s is not, and exactly one `Widget` declaration
+    // renders (the name-only join would have conflated both).
+    try RenderClosureNestedConflationTests.with { catalog in
+      let shell = Shell(catalog)
+      let closed = try shell.render(closure: "IRoot", template: "com")
+      #expect(closed.contains("public protocol IRoot: Widget {"))
+      // `A.Widget` (the well-known GUID) resolved and emitted …
+      #expect(closed.contains("0C733A30-2A1C-11CE-ADE5-00AA0044773D"))
+      // … while `B.Widget` (the all-0x11 GUID) did not.
+      #expect(!closed.contains("11111111-1111-1111-1111-111111111111"))
+      let count = closed.components(separatedBy: "public protocol Widget").count
+      #expect(count == 2) // one split ⇒ exactly one occurrence
+    }
+  }
+}

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -121,8 +121,28 @@ struct ShellTests {
     let render = Render(" IFoo com ")
     #expect(render.interface == "IFoo")
     #expect(render.template == "com")
+    #expect(!render.closure)
     #expect(Render("IFoo").interface.isEmpty)
     #expect(Render("").template.isEmpty)
+  }
+
+  @Test func `.render parses the --closure flag in any position`() {
+    // `--closure` is a flag, not an operand: it is filtered out before the two
+    // remaining whitespace fields are read as interface and template, so it may
+    // precede, separate, or follow them and the operands still parse.
+    let trailing = Render(" IFoo com --closure ")
+    #expect(trailing.interface == "IFoo")
+    #expect(trailing.template == "com")
+    #expect(trailing.closure)
+    // The flag ahead of the operands parses the same interface and template.
+    let leading = Render(" --closure IFoo com ")
+    #expect(leading.interface == "IFoo")
+    #expect(leading.template == "com")
+    #expect(leading.closure)
+    // Without the flag `closure` is false, and the flag alone (no two operands)
+    // still leaves the operands empty for `execute` to reject.
+    #expect(!Render(" IFoo com ").closure)
+    #expect(Render(" --closure ").interface.isEmpty)
   }
 
   @Test func `.bind parses its name and types its value`() {


### PR DESCRIPTION
`.render <interface> <template>` emitted only the interface's own surface; a base was named in the `: Base` refinement clause but its declaration was never pulled in, so the output was not a self-contained projection. This adds Stage 0 of the transitive-closure render: an optional `--closure` flag that, for a concrete interface, emits the interface plus the transitive closure of its plain (`spec IS NULL`) base and required interfaces — the E1 edges.

`Render.init` filters `--closure` out of the whitespace fields before reading the interface and template, so the flag may sit in any position and the two operands still parse; without it the render path is byte-identical to before. `*` keeps meaning the flat enumeration of every interface, so `--closure` with `*` stays that enumeration.

The walk reuses the existing per-interface body. That body is lifted verbatim into `emit`, and both the flat render and the new closure render call it, so the decode and Mustache emit are not duplicated — the closure is a worklist around the same node rendering. `render(closure:)` seeds the worklist from the `interfaces` selection and walks each root depth-first: a node's plain bases are emitted before the node (a base precedes the interface refining it), the bases visited in a stable namespace-then-name order.

A new `Render/requires.sql` resolves each base and required interface to its local interface `TypeDef` row keyed on namespace and name — never a bare name, which is ambiguous across namespaces — by joining the `InterfaceImpl` edge to the `interfaces` view. A base that resolves to no local interface `TypeDef` (an external `TypeRef`-only frontier, or a local type that is no interface) is not returned, so it is the natural termination boundary; a visited set keyed on the `TypeDef` Id renders each interface once and terminates the mutually referential interface graph.

Tests: `Render.init` parses `--closure` in any position; over the existing single-interface fixture the closure output equals the flat render (its bases resolve to no local interface, proving the reuse and the frontier); and a new two-interface fixture (`IDerived` refining a local `IBase`) renders the base before the refiner under `--closure` while the flat render of `IDerived` emits it alone.