### PR TITLE
SQLEngineWinMD: optimize 2 queries

### DIFF
--- a/Sources/SQLEngineWinMD/Resources/Queries/bases.sql
+++ b/Sources/SQLEngineWinMD/Resources/Queries/bases.sql
@@ -18,18 +18,33 @@ WHERE
   i.Class = :parent
 UNION
 -- A generic base interface is named through a TypeSpec: the InterfaceImpl's
--- Interface coded index tags TypeSpec, which has no TypeName of its own, so it
--- resolves through `identities` — whose TypeSpec arm names the TypeSpec by its
--- generic base's identity. Without this arm the generic base is dropped. The
--- TypeSpec's own Id rides alongside as `spec` (NULL on a plain base): the
--- generic definition's TypeName carries an invalid arity suffix and drops the
--- type arguments, so the render decodes the complete constructed spelling from
--- the TypeSpec signature rather than emitting that TypeName.
+-- Interface coded index tags TypeSpec, which has no TypeName of its own. A
+-- generic instantiation (GENERICINST <base> <args…>) resolves to its generic
+-- base, whose Id the adapter decodes to the TypeSpec's Base_TypeRef or
+-- Base_TypeDef key -- the 1-based Id of the base in its table. So the name
+-- reads through a seekable join against the TypeRef and TypeDef base tables,
+-- mirroring the `identities` view's two TypeSpec arms without re-evaluating a
+-- four-way UNION per InterfaceImpl row. Without these arms the generic base is
+-- dropped. The TypeSpec's own Id rides alongside as `spec` (NULL on a plain
+-- base): the generic definition's TypeName carries an invalid arity suffix and
+-- drops the type arguments, so the render decodes the complete constructed
+-- spelling from the TypeSpec signature rather than emitting that TypeName.
 SELECT
-  s.TypeName AS base,
+  r.TypeName AS base,
   i.Interface_TypeSpec AS spec
 FROM
   InterfaceImpl i
-  JOIN identities s ON i.Interface_TypeSpec = s.Id AND s.kind = 'TypeSpec'
+  JOIN TypeSpec ts ON i.Interface_TypeSpec = ts.Id
+  JOIN TypeRef r ON ts.Base_TypeRef = r.Id
+WHERE
+  i.Class = :parent
+UNION
+SELECT
+  d.TypeName AS base,
+  i.Interface_TypeSpec AS spec
+FROM
+  InterfaceImpl i
+  JOIN TypeSpec ts ON i.Interface_TypeSpec = ts.Id
+  JOIN TypeDef d ON ts.Base_TypeDef = d.Id
 WHERE
   i.Class = :parent

--- a/Sources/SQLEngineWinMD/Resources/Queries/types.sql
+++ b/Sources/SQLEngineWinMD/Resources/Queries/types.sql
@@ -17,9 +17,15 @@ SELECT
   COALESCE(r.TypeNamespace, d.TypeNamespace) AS base_namespace,
   COALESCE(r.TypeName, d.TypeName) AS base_name
 FROM
+  -- `Extends_TypeRef`/`Extends_TypeDef` are the 1-based Id of the base type in
+  -- its own table, so the base resolves by a seekable join against the TypeRef
+  -- and TypeDef base tables directly. The `identities` view's TypeRef and
+  -- TypeDef arms are exactly `SELECT … FROM TypeRef`/`… FROM TypeDef`, so the
+  -- COALESCE and CASE below read the same namespace and name they would have
+  -- through that view -- but without re-evaluating a four-way UNION per row.
   TypeDef t
-  LEFT JOIN identities r ON t.Extends_TypeRef = r.Id AND r.kind = 'TypeRef'
-  LEFT JOIN identities d ON t.Extends_TypeDef = d.Id AND d.kind = 'TypeDef'
+  LEFT JOIN TypeRef r ON t.Extends_TypeRef = r.Id
+  LEFT JOIN TypeDef d ON t.Extends_TypeDef = d.Id
 WHERE
   -- The first TypeDef is the ECMA-335 `<Module>` pseudo-type (the container for
   -- module-scope functions and variables): no base and no interface flag, so


### PR DESCRIPTION
This pull request refactors the way base type names are resolved in SQL queries for the WinMD engine, optimizing joins to avoid unnecessary UNION operations and improving performance and clarity. The changes focus on replacing joins against the `identities` view with direct joins to the `TypeRef` and `TypeDef` tables, both in type and interface base queries.

**Optimization of base type resolution:**

* [`bases.sql`](diffhunk://#diff-c551127494fbb79665f6fef05677cd3eee96b9ae19a4b5325177b8740ef4b7bcL21-R48): Replaces the join against the `identities` view for generic interface bases with direct joins to `TypeRef` and `TypeDef`, reducing the need for a four-way UNION per `InterfaceImpl` row and improving query efficiency.
* [`types.sql`](diffhunk://#diff-556ed8accda80acf70c8bbfccf5080495de86a6154efe4398a8e634488efbd3bR20-R28): Refactors base type resolution in type queries to join directly against `TypeRef` and `TypeDef` instead of the `identities` view, mirroring the logic but with better performance.