### PR TITLE
SQLEngine: seek a bound :parameter equality below a join

### DIFF
--- a/SwiftSQL/Sources/SQLEngine/Compilation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Compilation.swift
@@ -789,9 +789,9 @@ extension Catalog where Self: ~Escapable {
           // conjunct carrying a correlated `Term.parameter` as nullable, so it
           // never rides ahead of a later unsafe conjunct the inner `AND` still
           // owes.
-          context.subqueries.record(plan: try recorded.pushdown(),
-                                    for: Subkey(scope, query, role),
-                                    nested.correlation)
+          context.subqueries.record(
+              plan: try recorded.pushdown(context.bindings),
+              for: Subkey(scope, query, role), nested.correlation)
         }
       }
     }
@@ -1129,8 +1129,8 @@ extension Catalog where Self: ~Escapable {
     let inner = revealed.validating(false)
     let plan = try compile(body, inner)
     let key = Subkey(context.subscope, body, .lateral)
-    context.subqueries.record(plan: try plan.pushdown(), for: key,
-                              nested.correlation)
+    context.subqueries.record(plan: try plan.pushdown(context.bindings),
+                              for: key, nested.correlation)
     // The per-outer-row apply re-runs this plan under the occurrence scope's
     // recorded revealed overlay (`revealed(under:)`), which the run stores as
     // `revealed().relations` for `key.scope` — the same revealed base compiled

--- a/SwiftSQL/Sources/SQLEngine/Decorrelation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Decorrelation.swift
@@ -808,7 +808,7 @@ extension Catalog where Self: ~Escapable {
 /// hoist it to the straddling `.match`, where its comparability is decided.
 private func equated(_ conjunct: Filter, to parameter: String) -> Int? {
   var conjunct = conjunct
-  if case let .incomparable(inner) = conjunct { conjunct = inner }
+  if case let .incomparable(inner, _) = conjunct { conjunct = inner }
   guard case let .compare(lhs, .equal, rhs) = conjunct else { return nil }
   switch (lhs, rhs) {
   case let (.slot(slot), .parameter(name)) where name == parameter:

--- a/SwiftSQL/Sources/SQLEngine/Engine.swift
+++ b/SwiftSQL/Sources/SQLEngine/Engine.swift
@@ -201,7 +201,8 @@ extension Catalog where Self: ~Escapable {
       throws(SQLError) -> (plan: Plan, augmented: Context) {
     let context = context.resolving(Subqueries())
     let logical =
-        try compile(query, context.validating(false)).demoted().pushdown()
+        try compile(query, context.validating(false)).demoted()
+            .pushdown(context.bindings)
     try typecheck(query, context.validating(false).comparing())
     let augmented = try augment(context.validating(false), for: query,
                                 rows: rows)

--- a/SwiftSQL/Sources/SQLEngine/Evaluation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Evaluation.swift
@@ -415,7 +415,7 @@ extension Catalog where Self: ~Escapable {
       }
     case let .not(operand):
       try evaluate(row, operand, context).map { !$0 }
-    case let .incomparable(inner):
+    case let .incomparable(inner, _):
       // The stamp is a compile-time reordering barrier only; evaluating it is
       // evaluating the comparison it wraps, which faults `42804` at run through
       // `matches`/`relate`/`like` for a non-NULL cross-kind pair (a NULL

--- a/SwiftSQL/Sources/SQLEngine/Explain.swift
+++ b/SwiftSQL/Sources/SQLEngine/Explain.swift
@@ -390,7 +390,7 @@ extension Filter {
       return "(\(lhs.rendered) OR \(rhs.rendered))"
     case let .not(operand):
       return "NOT \(operand.rendered)"
-    case let .incomparable(inner):
+    case let .incomparable(inner, _):
       return "incomparable(\(inner.rendered))"
     }
   }

--- a/SwiftSQL/Sources/SQLEngine/Filter.swift
+++ b/SwiftSQL/Sources/SQLEngine/Filter.swift
@@ -172,7 +172,15 @@ internal indirect enum Filter: Equatable, Sendable {
   /// Evaluating it evaluates the inner, which faults `42804` at run exactly as
   /// the un-optimised plan does — never dropped over an emptied seek, never
   /// pushed past a row-dropping operator.
-  case incomparable(Filter)
+  ///
+  /// A stamped `.bound(column, =, :parameter)` carries the column operand's
+  /// `Comparability` in `kind`; every other stamped leaf carries `nil`. The
+  /// recorded class lets `neutral` re-run the stamper's own `reconcile` at
+  /// pushdown — against the run binding this time — so a bound conjunct proven
+  /// throw-neutral for the run may ride to a seek leaf without carrying the
+  /// type information the physical layer lacks. A `nil` kind is never
+  /// re-reconciled, so a non-bound cross-kind leaf stays unsafe always.
+  case incomparable(Filter, kind: Comparability?)
 
   /// The lowered pattern or escape operand of a `Filter.like`: a `Term`
   /// evaluated per row, or a run-time `:parameter` resolved from the engine's
@@ -737,11 +745,12 @@ extension Filter {
       .or(lhs.remapped(through: slot), rhs.remapped(through: slot))
     case let .not(operand):
       .not(operand.remapped(through: slot))
-    case let .incomparable(inner):
+    case let .incomparable(inner, kind):
       // Slot renumbering never changes comparability, so re-wrap the remapped
-      // inner rather than reclassifying — the carried bit travels verbatim
-      // through the combined-space remap the optimiser applies.
-      .incomparable(inner.remapped(through: slot))
+      // inner rather than reclassifying — the carried bit (and the recorded
+      // column class) travels verbatim through the combined-space remap the
+      // optimiser applies.
+      .incomparable(inner.remapped(through: slot), kind: kind)
     }
   }
 
@@ -861,6 +870,33 @@ extension Filter {
     }
   }
 
+  /// Whether this conjunct is throw-neutral under `bindings` — a bound
+  /// `column = :parameter` equality whose comparison cannot fault `42804` this
+  /// run, so selection pushdown may ride it anywhere a `safe` conjunct rides
+  /// (a cross-product input, a derived body, a seek leaf) without ever
+  /// suppressing or introducing a fault.
+  ///
+  /// It is the stamper's own verdict, deferred to the point the binding is
+  /// known: the leaf is `.incomparable(.bound(column, =, :parameter))` carrying
+  /// the recorded column class `kind`, and it is neutral iff `reconcile(kind,
+  /// comparability(of: bindings[parameter]))` — the identical `reconcile` the
+  /// stamp ran, now against the run binding (an absent or NULL binding is
+  /// `.null`, comparable against anything; a non-NULL value its `.known` kind).
+  /// So a bound conjunct is neutral exactly when the stamper would not have
+  /// wrapped it incomparable had it known the binding — a comparable integer
+  /// binding, a widening double against an integer column, or an unbound/NULL
+  /// parameter (UNKNOWN, never a fault) — and non-neutral for a cross-kind
+  /// binding, which stays the always-evaluated residual at its lazy-fault
+  /// position and faults exactly as the un-pushed plan does. A non-equality
+  /// bound, a non-slot column, or any non-`.bound` leaf is never neutral.
+  internal func neutral(_ bindings: Bindings) -> Bool {
+    guard case let .incomparable(inner, .some(kind)) = self,
+        case let .bound(.slot(_), .equal, parameter) = inner else {
+      return false
+    }
+    return reconcile(kind, comparability(of: bindings[parameter]))
+  }
+
   /// Whether this predicate is guaranteed FALSE or UNKNOWN whenever every slot
   /// in `nulled` is NULL — a null-rejecting predicate on that side, so a WHERE
   /// carrying it drops every row an outer join NULL-extends across `nulled`. It
@@ -961,7 +997,7 @@ extension Filter {
     // A stamped leaf wraps a scalar/row comparison that reads its components'
     // slots, so it is never slotless-UNKNOWN — derive from the inner, which is
     // false for every case `incomparable` wraps.
-    case let .incomparable(inner): inner.contingent
+    case let .incomparable(inner, _): inner.contingent
     }
   }
 
@@ -1012,7 +1048,7 @@ extension Filter {
     case let .or(lhs, rhs): lhs.parameterised || rhs.parameterised
     case let .not(operand): operand.parameterised
     // A stamped leaf is parameterised exactly when the comparison it wraps is.
-    case let .incomparable(inner): inner.parameterised
+    case let .incomparable(inner, _): inner.parameterised
     }
   }
 
@@ -1080,7 +1116,7 @@ extension Filter {
       // `IS <truth>` is a definite two-valued test, but only when the inner's
       // value is itself statically decided; an undecidable inner leaves `nil`.
       inner.constant == nil ? nil : tested(inner.constant, value, negated)
-    case let .incomparable(inner):
+    case let .incomparable(inner, _):
       // A provably cross-kind comparison is undecidable (`nil`, from the inner)
       // — never folded to a constant, so the optimiser keeps it and its `42804`
       // fault surfaces at run rather than folding to true/false.

--- a/SwiftSQL/Sources/SQLEngine/Grouped.swift
+++ b/SwiftSQL/Sources/SQLEngine/Grouped.swift
@@ -735,7 +735,7 @@ extension Filter {
       rhs.references(into: &ordinals)
     case let .not(operand):
       operand.references(into: &ordinals)
-    case let .incomparable(inner):
+    case let .incomparable(inner, _):
       inner.references(into: &ordinals)
     }
   }

--- a/SwiftSQL/Sources/SQLEngine/Optimisation.swift
+++ b/SwiftSQL/Sources/SQLEngine/Optimisation.swift
@@ -504,7 +504,7 @@ private func comparison(_ filter: Filter, _ bindings: Bindings)
   // stamp — faults `42804` at run), while the stamp still bars a sibling from
   // seeking past this conjunct through `Filter.safe`.
   var filter = filter
-  if case let .incomparable(inner) = filter { filter = inner }
+  if case let .incomparable(inner, _) = filter { filter = inner }
   switch filter {
   case let .compare(.slot(slot), op, .constant(.integer(value))):
     return (slot, op, value)
@@ -537,7 +537,7 @@ private func range(_ filter: Filter, _ bindings: Bindings) -> (Int, Int, Int)? {
   // integer against the sort key — so a cross-kind binding scans and the
   // stamped residual faults `42804`, as `comparison` does for a `bound`.
   var filter = filter
-  if case let .incomparable(inner) = filter { filter = inner }
+  if case let .incomparable(inner, _) = filter { filter = inner }
   guard case let .between(.slot(slot), lower, upper, negated: false) = filter,
       let low = integer(lower, bindings),
       let high = integer(upper, bindings) else {

--- a/SwiftSQL/Sources/SQLEngine/Pushdown.swift
+++ b/SwiftSQL/Sources/SQLEngine/Pushdown.swift
@@ -21,7 +21,12 @@ extension Plan {
   /// below the view's own joins. A `union` pushes into every arm. The pass is a
   /// pure logical rewrite; `optimise` runs after it and still sees the
   /// `select`s the seek and nest rewrites match.
-  internal func pushdown() throws(SQLError) -> Plan {
+  ///
+  /// `bindings` — the run's `:parameter` values — thread through so a bound
+  /// `column = :parameter` equality proven throw-neutral for this run
+  /// (`Filter.neutral`) rides down beside a `safe` conjunct to its seek leaf,
+  /// while a cross-kind one stays the always-evaluated residual that faults.
+  internal func pushdown(_ bindings: Bindings) throws(SQLError) -> Plan {
     switch self {
     // Pushdown runs before optimise, the only producer of `.empty`, so a plan
     // reaching here never carries one; the arm keeps the switch exhaustive. A
@@ -29,16 +34,16 @@ extension Plan {
     case .single, .empty, .values, .scan, .join:
       self
     case let .derived(name, sub, ordinals, seek):
-      try .derived(name: name, plan: sub.pushdown(), ordinals: ordinals,
+      try .derived(name: name, plan: sub.pushdown(bindings), ordinals: ordinals,
                    seek: seek)
     case let .select(filter, source):
-      try source.pushdown().distribute(filter.conjuncts)
+      try source.pushdown(bindings).distribute(filter.conjuncts, bindings)
     case let .project(terms, source):
-      try .project(terms, source.pushdown())
+      try .project(terms, source.pushdown(bindings))
     case let .sort(keys, source):
-      try .sort(keys: keys, source.pushdown())
+      try .sort(keys: keys, source.pushdown(bindings))
     case let .product(left, right):
-      try .product(left.pushdown(), right.pushdown())
+      try .product(left.pushdown(bindings), right.pushdown(bindings))
     case let .outer(left, right, on, kind):
       // Push down within each side (its own joins/filters rewrite), but the
       // outer node is a pushdown barrier: a `WHERE` conjunct above it never
@@ -47,7 +52,8 @@ extension Plan {
       // it would change which rows match, so — preferring correctness — the
       // whole `WHERE` stays above (`distribute`'s default keeps it a `select`
       // over this node).
-      try .outer(left.pushdown(), right.pushdown(), on: on, kind: kind)
+      try .outer(left.pushdown(bindings), right.pushdown(bindings), on: on,
+                 kind: kind)
     case let .semijoin(left, right, on, anti):
       // Push down within each side (its own joins/filters rewrite), but the
       // semijoin node is a pushdown barrier: a `WHERE` conjunct above it never
@@ -57,7 +63,8 @@ extension Plan {
       // (`distribute`'s default keeps it a `select` over this node). Pushdown
       // runs before decorrelate, so this arm handles only a semijoin a nested
       // pass produced; a top-level plan never carries one at this point.
-      try .semijoin(left.pushdown(), right.pushdown(), on: on, anti: anti)
+      try .semijoin(left.pushdown(bindings), right.pushdown(bindings), on: on,
+                    anti: anti)
     case let .apply(left, key, correlation, ordinals, on, kind):
       // Push down within the left side (its own joins/filters rewrite), but the
       // apply is a pushdown barrier: its right side is not a static sub-plan
@@ -65,43 +72,45 @@ extension Plan {
       // rides into it (mirroring the `.outer` gate — `distribute`'s default
       // keeps the conjunct a `select` over this node). The recorded body plan
       // was already pushed down at its compile.
-      try .apply(left.pushdown(), key: key, correlation: correlation,
+      try .apply(left.pushdown(bindings), key: key, correlation: correlation,
                  ordinals: ordinals, on: on, kind: kind)
     case let .setop(kind, left, right, all, types, widened):
-      try .setop(kind, left.pushdown(), right.pushdown(), all: all,
-                 types: types, widened: widened)
+      try .setop(kind, left.pushdown(bindings), right.pushdown(bindings),
+                 all: all, types: types, widened: widened)
     case let .distinct(source):
       // A `distinct` sits above the projection, so no `WHERE` conjunct reaches
       // it to push down; it recurses transparently. A filter must never cross a
       // dedup — filtering before or after it yields different rows — and none
       // can, since it sits above the projection like the cap.
-      try .distinct(source.pushdown())
+      try .distinct(source.pushdown(bindings))
     case let .aggregate(keys, aggregates, source):
       // An aggregate reshapes rows into a fresh grouped slot space, so it is a
       // pushdown barrier: a `HAVING`/projection filter above it is in grouped
       // space and stays there (`distribute`'s default keeps it as a `select`
       // over the aggregate), while the WHERE below it — already placed under
       // the aggregate at compile — pushes down within the source as usual.
-      try .aggregate(keys: keys, aggregates: aggregates, source.pushdown())
+      try .aggregate(keys: keys, aggregates: aggregates,
+                     source.pushdown(bindings))
     case let .window(windowings, source):
       // A window node appends the window results to a fresh output slot space,
       // so it is a pushdown barrier: a projection filter above it is in that
       // widened space and stays there (`distribute`'s default keeps it a
       // `select` over the window), while the WHERE below it — already placed
       // under the window at compile — pushes down within the source as usual.
-      try .window(windowings, source.pushdown())
+      try .window(windowings, source.pushdown(bindings))
     case let .limit(count, offset, source):
       // A `limit` is the outermost operator, so no `WHERE` conjunct ever
       // reaches it to push down; it recurses transparently, its source pushed
       // as usual. A filter must never cross it — capping before or after a
       // filter yields different rows — and none can, since the cap sits above
       // the projection.
-      try .limit(count: count, offset: offset, source.pushdown())
+      try .limit(count: count, offset: offset, source.pushdown(bindings))
     case let .top(keys, offset, count, source):
       // `top` is produced by `optimise`, which runs after pushdown, so a plan
       // reaching here never carries one; the arm recurses transparently to keep
       // the switch exhaustive, mirroring the `limit`/`sort` it fuses.
-      try .top(keys: keys, offset: offset, count: count, source.pushdown())
+      try .top(keys: keys, offset: offset, count: count,
+               source.pushdown(bindings))
     }
   }
 
@@ -132,7 +141,7 @@ extension Plan {
   /// match keys fold down so `nest` can join under the gate. At a `derived`
   /// leaf the conjuncts push into the view; at a base `scan` they land right
   /// above it. A conjunct that cannot descend is re-conjoined here.
-  private func distribute(_ conjuncts: Array<Filter>)
+  private func distribute(_ conjuncts: Array<Filter>, _ bindings: Bindings)
       throws(SQLError) -> Plan {
     switch self {
     case let .product(left, right):
@@ -165,7 +174,14 @@ extension Plan {
         // nullable, no unsafe successor — rides down.
         let hazard =
             conjunct.nullable && conjuncts[(index + 1)...].contains { !$0.safe }
-        if barrier || slots.isEmpty || !conjunct.safe || hazard {
+        // A throw-neutral bound conjunct rides down beside a `safe` one: it
+        // cannot fault this run, so pushing it can only drop rows, never
+        // suppress a throw. The barrier/hazard bracket is unchanged — it is
+        // driven by `safe` alone, so a neutral conjunct still sets the barrier
+        // (a later conjunct sees it), and a nullable neutral conjunct still
+        // stays here when a later conjunct is unsafe (its own `hazard`).
+        let rides = conjunct.safe || conjunct.neutral(bindings)
+        if barrier || slots.isEmpty || !rides || hazard {
           here.append(conjunct)
         } else if slots.allSatisfy({ $0 < base }) {
           down.append(conjunct)
@@ -178,8 +194,9 @@ extension Plan {
         if !conjunct.safe { barrier = true }
       }
       let product =
-          Plan.product(try left.distribute(down),
-                       try right.distribute(over.map { $0.shifted(by: base) }))
+          Plan.product(try left.distribute(down, bindings),
+                       try right.distribute(over.map { $0.shifted(by: base) },
+                                            bindings))
       return product.residual(here)
     case let .select(gate, source):
       // A join's `ON` gate straddles both sides, so it never captures a
@@ -235,17 +252,24 @@ extension Plan {
       for (index, conjunct) in conjuncts.enumerated() {
         let hazard =
             conjunct.nullable && conjuncts[(index + 1)...].contains { !$0.safe }
-        if conjunct.safe && !barrier && !hazard {
+        // A throw-neutral bound conjunct descends below the gate beside a
+        // `safe` one — it never faults, so it can only drop rows, not suppress
+        // a leftover `ON` conjunct's throw — under the same unchanged barrier/
+        // hazard bracket (a WHERE conjunct always follows the `ON` residual in
+        // the descent list, so a throwing `ON` residual sets the barrier ahead
+        // of it).
+        let rides = conjunct.safe || conjunct.neutral(bindings)
+        if rides && !barrier && !hazard {
           safe.append(conjunct)
         } else {
           above.append(conjunct)
         }
         if !conjunct.safe { barrier = true }
       }
-      let gated = try source.distribute(matches + residual + safe)
+      let gated = try source.distribute(matches + residual + safe, bindings)
       return gated.residual(above)
     case .derived:
-      return try into(conjuncts)
+      return try into(conjuncts, bindings)
     default:
       return residual(conjuncts)
     }
@@ -283,7 +307,8 @@ extension Plan {
   /// later unsafe one suppresses a throw: the non-short-circuiting `AND` runs
   /// the later conjunct even for the UNKNOWN row, but the injected conjunct
   /// drops that row first (`x = 1 AND (1 / y) = 0`, `x` NULL and `y = 0`).
-  private func into(_ conjuncts: Array<Filter>) throws(SQLError) -> Plan {
+  private func into(_ conjuncts: Array<Filter>, _ bindings: Bindings)
+      throws(SQLError) -> Plan {
     guard case let .derived(name, plan, ordinals, seek) = self else {
       return residual(conjuncts)
     }
@@ -300,8 +325,12 @@ extension Plan {
       // `x`/`y`, `x` NULL and `y = 0`).
       let hazard =
           conjunct.nullable && conjuncts[(index + 1)...].contains { !$0.safe }
-      if barrier || !conjunct.safe || hazard
-          || !plan.pushable(conjunct, ordinals) {
+      // A throw-neutral bound conjunct injects into the view beside a `safe`
+      // one — it cannot fault this run, so seeking or filtering the view body
+      // by it drops rows without suppressing a throw — under the same unchanged
+      // barrier/hazard bracket and the same `pushable` structural gate.
+      let rides = conjunct.safe || conjunct.neutral(bindings)
+      if barrier || !rides || hazard || !plan.pushable(conjunct, ordinals) {
         outer.append(conjunct)
       } else {
         inner.append(conjunct)
@@ -309,7 +338,8 @@ extension Plan {
       // An unsafe conjunct bars every later conjunct from riding past it.
       if !conjunct.safe { barrier = true }
     }
-    let sub = inner.isEmpty ? plan : try plan.inject(inner, ordinals)
+    let sub =
+        inner.isEmpty ? plan : try plan.inject(inner, ordinals, bindings)
     let leaf = Plan.derived(name: name, plan: sub, ordinals: ordinals,
                             seek: seek)
     return leaf.residual(outer)
@@ -363,16 +393,17 @@ extension Plan {
   /// single pre-rebased filter cannot serve them all; the rebase must happen
   /// per arm. `pushable` has already vetted every conjunct against every arm,
   /// so the per-arm `rebase` is guaranteed non-nil.
-  private func inject(_ conjuncts: Array<Filter>, _ ordinals: Array<Int>)
-      throws(SQLError) -> Plan {
+  private func inject(_ conjuncts: Array<Filter>, _ ordinals: Array<Int>,
+                      _ bindings: Bindings) throws(SQLError) -> Plan {
     switch self {
     case let .project(terms, body):
       try .project(terms,
-                   body.distribute(conjuncts.map { rebase($0, ordinals)! }))
+                   body.distribute(conjuncts.map { rebase($0, ordinals)! },
+                                   bindings))
     case let .setop(kind, left, right, all, types, widened):
-      try .setop(kind, left.inject(conjuncts, ordinals),
-                 right.inject(conjuncts, ordinals), all: all, types: types,
-                 widened: widened)
+      try .setop(kind, left.inject(conjuncts, ordinals, bindings),
+                 right.inject(conjuncts, ordinals, bindings), all: all,
+                 types: types, widened: widened)
     default:
       // A view sub-plan is always a `project` (or a `union` of them); anything
       // else keeps the conjuncts as an outer `select` rather than dropping

--- a/SwiftSQL/Sources/SQLEngine/Resolution.swift
+++ b/SwiftSQL/Sources/SQLEngine/Resolution.swift
@@ -1284,17 +1284,23 @@ internal func stamped(_ filter: Filter,
   switch filter {
   case let .compare(lhs, _, rhs):
     return reconcile(kind(of: lhs, typeAt), kind(of: rhs, typeAt))
-        ? filter : .incomparable(filter)
+        ? filter : .incomparable(filter, kind: nil)
   case let .comparison(lhs, _, rhs):
     return zip(lhs, rhs).allSatisfy { reconcile(kind(of: $0, typeAt),
                                                  kind(of: $1, typeAt)) }
-        ? filter : .incomparable(filter)
+        ? filter : .incomparable(filter, kind: nil)
   case let .bound(term, _, _):
     // `term op :parameter`: the parameter side is a per-run `.opaque` value, so
     // the comparison is safe only when the term side is a constant NULL — else
-    // the run can fault `42804` on a non-NULL incomparable binding.
-    return reconcile(kind(of: term, typeAt), .opaque)
-        ? filter : .incomparable(filter)
+    // the run can fault `42804` on a non-NULL incomparable binding. Record the
+    // term's column class on the wrapper so pushdown can re-reconcile it
+    // against the run binding (`Filter.neutral`): a bound conjunct whose column
+    // class reconciles with the binding's cannot fault this run, so it is safe
+    // to push anywhere — the stamper's own rule, deferred to the point the
+    // binding is known.
+    let column = kind(of: term, typeAt)
+    return reconcile(column, .opaque)
+        ? filter : .incomparable(filter, kind: column)
   case let .membership(operand, elements, _):
     let operandKind = kind(of: operand, typeAt)
     var comparable = true
@@ -1309,7 +1315,7 @@ internal func stamped(_ filter: Filter,
       if element == operand && stable(operand) { break }
       if Filter(compare: operand, .equal, element).constant == true { break }
     }
-    return comparable ? filter : .incomparable(filter)
+    return comparable ? filter : .incomparable(filter, kind: nil)
   case let .memberships(lhs, rows, _):
     let left = constants(lhs)
     var comparable = true
@@ -1327,7 +1333,7 @@ internal func stamped(_ filter: Filter,
         break
       }
     }
-    return comparable ? filter : .incomparable(filter)
+    return comparable ? filter : .incomparable(filter, kind: nil)
   case let .between(test, lower, upper, _):
     // `x BETWEEN a AND b` compares `x` against both bounds, honouring the run's
     // short-circuit exactly as `Scope.check`'s `.between` does: `ranged`
@@ -1341,11 +1347,11 @@ internal func stamped(_ filter: Filter,
     // and is stamped incomparable.
     let testKind = kind(of: test, typeAt)
     guard reconcile(testKind, kind(of: lower, typeAt)) else {
-      return .incomparable(filter)
+      return .incomparable(filter, kind: nil)
     }
     if settled(test, lower) { return filter }
     return reconcile(testKind, kind(of: upper, typeAt))
-        ? filter : .incomparable(filter)
+        ? filter : .incomparable(filter, kind: nil)
   case let .like(operand, pattern, escape, _):
     // `x LIKE p ESCAPE e` reads a NULL — pattern, escape, or subject — as
     // UNKNOWN before its non-character fallback, so a NULL-determined operand
@@ -1363,7 +1369,7 @@ internal func stamped(_ filter: Filter,
     if case .null = kind(of: operand, typeAt) { return filter }
     return character(kind(of: operand, typeAt))
         && character(kind(of: pattern, typeAt))
-        ? filter : .incomparable(filter)
+        ? filter : .incomparable(filter, kind: nil)
   case .match, .null, .distinct, .exists, .within, .quantified:
     return filter
   case let .truth(inner, value, negated):
@@ -1384,7 +1390,13 @@ internal func stamped(_ filter: Filter,
 /// `reconcile` folds into a per-pair verdict. It refines the former
 /// `ValueType?`, whose `nil` conflated two opposite cases: a constant NULL
 /// (safe) and a run-time value of undecidable kind (unsafe).
-private enum Comparability {
+///
+/// A stamped `.bound` carries the column operand's class on its
+/// `Filter.incomparable` wrapper, so pushdown can re-reconcile it against the
+/// run binding's class (`Filter.neutral`) without the type information the
+/// physical layer lacks — hence `internal`, `Hashable`, and `Sendable` (the
+/// `Filter.incomparable` payload rides through the plan).
+internal enum Comparability: Hashable, Sendable {
   /// A statically-known non-NULL value kind — a slot's declared type, a
   /// non-NULL constant, a `GROUPING` integer. Two known kinds are comparable
   /// iff they unify (`ValueType.unified`).
@@ -1425,12 +1437,28 @@ private func kind(of operand: Filter.Operand,
   }
 }
 
+/// The `Comparability` of a run-time binding — the operand the stamper treated
+/// as `.opaque` at lowering, now known for this run. An absent binding (the
+/// `:parameter` unbound) or one bound to NULL is `.null` (its comparison is
+/// UNKNOWN, never a `42804` fault), and a non-NULL value is its `.known` kind.
+/// `Filter.neutral` reconciles a stamped `.bound`'s recorded column class
+/// against this, deciding a bound conjunct throw-neutral for this run exactly
+/// where the stamper would not have wrapped it had it known the binding.
+internal func comparability(of value: Value?) -> Comparability {
+  guard let value else { return .null }
+  return value.kind.map(Comparability.known) ?? .null
+}
+
 /// Whether a comparison of operands of these classes cannot fault `42804` — the
 /// throwability rule `stamped` shares with the run's `matches`/`relate` and
 /// `Scope.check`. A NULL-involved pair is UNKNOWN, never a fault (safe); two
 /// known kinds are safe iff they unify; an `.opaque` operand against a non-NULL
 /// operand may be a non-NULL incomparable pair the run faults on (unsafe).
-private func reconcile(_ lhs: Comparability, _ rhs: Comparability) -> Bool {
+///
+/// `internal` (not `private`) so `Filter.neutral` can re-run the identical
+/// verdict at pushdown, reconciling a stamped `.bound`'s recorded column class
+/// against the run binding's class.
+internal func reconcile(_ lhs: Comparability, _ rhs: Comparability) -> Bool {
   switch (lhs, rhs) {
   case (.null, _), (_, .null):
     true

--- a/SwiftSQL/Tests/SQLTests/Expressions/ComparabilityTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Expressions/ComparabilityTests.swift
@@ -556,7 +556,7 @@ struct OptimiserComparabilitySafetyTests {
     // pair rather than a hash key dropping the pairs first.
     let sql = "SELECT L.Id FROM L JOIN R ON L.N = R.T AND L.N = R.M"
     let compiled = try bucketed().compile(parse(query: sql))
-    let plan = try bucketed().optimise(compiled.pushdown(), [:])
+    let plan = try bucketed().optimise(compiled.pushdown([:]), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
   }
@@ -572,7 +572,7 @@ struct OptimiserComparabilitySafetyTests {
     // test pins is order-independent.)
     let sql = "SELECT L.Id FROM L JOIN R ON L.N = R.M AND L.N = R.T"
     let compiled = try bucketed().compile(parse(query: sql))
-    let plan = try bucketed().optimise(compiled.pushdown(), [:])
+    let plan = try bucketed().optimise(compiled.pushdown([:]), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
     #expect(throws: intVsText) { try bucketed().columns(of: parse(query: sql)) }
@@ -592,7 +592,7 @@ struct OptimiserComparabilitySafetyTests {
   @Test func `a cross-kind LIKE ON conjunct bars key extraction`() throws {
     let sql = "SELECT L.Id FROM L JOIN R ON L.N LIKE R.T AND L.N = R.M"
     let compiled = try bucketed().compile(parse(query: sql))
-    let plan = try bucketed().optimise(compiled.pushdown(), [:])
+    let plan = try bucketed().optimise(compiled.pushdown([:]), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
   }
@@ -603,7 +603,7 @@ struct OptimiserComparabilitySafetyTests {
     // perf-defeating over-classification would force a nested-loop residual.
     let sql = "SELECT L.Id FROM L JOIN R ON L.N = R.K"
     let compiled = try bucketed().compile(parse(query: sql))
-    let plan = try bucketed().optimise(compiled.pushdown(), [:])
+    let plan = try bucketed().optimise(compiled.pushdown([:]), [:])
     #expect(joins(plan))
     #expect(!residual(plan))
     try bucketed().expect(sql, yields: [[1], [2]])
@@ -615,7 +615,7 @@ struct OptimiserComparabilitySafetyTests {
     // not fall back to a nested-loop residual when nothing can fault.
     let sql = "SELECT L.Id FROM L JOIN R ON L.N = R.K AND L.N = R.M"
     let compiled = try bucketed().compile(parse(query: sql))
-    let plan = try bucketed().optimise(compiled.pushdown(), [:])
+    let plan = try bucketed().optimise(compiled.pushdown([:]), [:])
     #expect(joins(plan))
   }
 }

--- a/SwiftSQL/Tests/SQLTests/Expressions/LikeTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Expressions/LikeTests.swift
@@ -502,7 +502,7 @@ struct LikeSafetyTests {
     let compiled = try mismatched().compile(parse(query: """
         SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE A.E
         """))
-    let plan = try mismatched().optimise(compiled.pushdown(), [:])
+    let plan = try mismatched().optimise(compiled.pushdown([:]), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
   }
@@ -532,7 +532,7 @@ struct LikeSafetyTests {
         SELECT A.K FROM A JOIN B ON A.K = B.K AND A.Name LIKE 'a%' ESCAPE 'ab'
         """
     let compiled = try mismatched().compile(parse(query: sql))
-    let plan = try mismatched().optimise(compiled.pushdown(), [:])
+    let plan = try mismatched().optimise(compiled.pushdown([:]), [:])
     #expect(!joins(plan))
     #expect(residual(plan))
     try mismatched().expect(sql,
@@ -553,7 +553,7 @@ struct LikeSafetyTests {
     let compiled = try catalog.compile(parse(query: """
         SELECT Id FROM S WHERE Name LIKE '_%' ESCAPE '\\' AND Id = 2
         """))
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(seeks(plan))
 
     // …and it still matches correctly: only row 2 has `Id = 2`, and its
@@ -577,7 +577,7 @@ struct LikeSafetyTests {
     let compiled = try catalog.compile(parse(query: """
         SELECT Id FROM S WHERE Name LIKE 'x%' AND Id = 2
         """))
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(seeks(plan))
     try catalog.expect("SELECT Id FROM S WHERE Name LIKE 'x%' AND Id = 2",
                        yields: [[2]])
@@ -781,7 +781,7 @@ struct LikeParameterTests {
       return
     }
     let compiled = try catalog.compile(query)
-    let plan = try catalog.optimise(compiled.pushdown(),
+    let plan = try catalog.optimise(compiled.pushdown([:]),
                                     ["e": .text("\\")])
     #expect(!seeks(plan))
   }
@@ -842,7 +842,7 @@ struct LikeParameterisedTests {
     let compiled = try catalog.compile(parse(query: """
         SELECT x FROM V WHERE 'x' LIKE :p AND (1 / y) = 0
         """))
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
 
     // The parameterised LIKE floats above the derived leaf rather than riding
     // into the view below the unsafe division.

--- a/SwiftSQL/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Optimisation/ConstantFoldTests.swift
@@ -276,7 +276,7 @@ struct ConstantSelectFoldTests {
     let catalog = try numbers()
     let plan = try catalog.optimise(
         catalog.compile(parse(query: "SELECT COUNT(*) FROM N WHERE 1 = 0"))
-            .pushdown(), [:])
+            .pushdown([:]), [:])
     #expect(empties(plan))
   }
 
@@ -299,7 +299,7 @@ struct ConstantSelectFoldTests {
     let catalog = EngineMemory(base.catalog, views: views.registered)
     let plan = try catalog.optimise(
         catalog.compile(parse(query: "SELECT q FROM Bad WHERE 1 = 0"))
-            .pushdown(), [:])
+            .pushdown([:]), [:])
     #expect(!empties(plan))
     catalog.expect("SELECT q FROM Bad WHERE 1 = 0", fails: .divide)
   }

--- a/SwiftSQL/Tests/SQLTests/Optimisation/DecorrelateTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Optimisation/DecorrelateTests.swift
@@ -310,7 +310,7 @@ private func subquery(_ filter: Filter) -> Bool {
     return subquery(lhs) || subquery(rhs)
   case let .not(operand):
     return subquery(operand)
-  case let .incomparable(inner):
+  case let .incomparable(inner, _):
     // A comparison whose subquery operand makes it provably throwable is
     // wrapped, so see through the wrapper to the underlying operands.
     return subquery(inner)
@@ -329,7 +329,7 @@ extension Catalog where Self: ~Escapable {
   fileprivate borrowing func optimised(_ sql: String) throws -> Plan {
     let parsed = try parse(query: sql)
     let context = Context().resolving(Subqueries())
-    let logical = try compile(parsed, context.validating(false)).pushdown()
+    let logical = try compile(parsed, context.validating(false)).pushdown([:])
     let augmented = try augment(context.validating(false), for: parsed,
                                 rows: true)
     augmented.subqueries.record(overlay: augmented.revealed().relations,

--- a/SwiftSQL/Tests/SQLTests/Optimisation/DistinctFoldTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Optimisation/DistinctFoldTests.swift
@@ -176,7 +176,7 @@ struct DistinctFoldTests {
   /// compile/pushdown/optimise pipeline the executor runs.
   private func optimised(_ catalog: borrowing FixtureCatalog, _ sql: String)
       throws -> Plan {
-    try catalog.optimise(catalog.compile(parse(query: sql)).pushdown(), [:])
+    try catalog.optimise(catalog.compile(parse(query: sql)).pushdown([:]), [:])
   }
 
   @Test func `DISTINCT over a GROUP BY drops the redundant dedup`() throws {

--- a/SwiftSQL/Tests/SQLTests/Queries/BoundEqualityPushdownTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/BoundEqualityPushdownTests.swift
@@ -1,0 +1,342 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+@testable import SQLEngine
+
+import SQLTestSupport
+
+// MARK: - Fixtures
+
+/// A `Parent` driving a join to `Child`. `Parent` is the smaller side (so the
+/// reorder drives from it, its leaf the join's outer) sorted on `Pid` — a bound
+/// `Parent.Pid = :parent` seeks that outer leaf — beside a non-sorted integer
+/// `Px` for the unindexed-column push. `Child` is the inner side sorted on
+/// `Cid` — a bound `Child.Cid = :child` rides the inner filter and seeks —
+/// carrying an integer `Cn` and a text `Cs` for the cross-kind corners.
+private func related() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Parent", ["Pid": .integer, "Px": .integer], sorted: "Pid") {
+      Row(1, 10)
+      Row(2, 20)
+    }
+    Relation("Child",
+             ["Cid": .integer, "Pid": .integer, "Cn": .integer, "Cs": .text],
+             sorted: "Cid") {
+      Row(1, 1, 100, "a")
+      Row(2, 1, 200, "b")
+      Row(3, 2, 300, "c")
+    }
+  }
+}
+
+/// A non-empty `L` beside an empty `R` — a cross product or non-equi join over
+/// them yields no rows, so a residual over `L` alone must not fire.
+private func crossed() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("L", ["Lid": .integer, "Ln": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+    }
+    Relation("R", ["Rid": .integer]) {
+    }
+  }
+}
+
+/// A base relation, a second relation, and a simple view `Empt` that yields no
+/// rows (`Bn < 0` matches nothing) — a zero-output derived join side.
+private func viewed() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Base", ["Bid": .integer, "Bn": .integer]) {
+      Row(1, 10)
+      Row(2, 20)
+    }
+    Relation("Other", ["Oid": .integer]) {
+      Row(1)
+    }
+    try View("Empt", "SELECT Bid, Bn FROM Base WHERE Bn < 0",
+             as: ["Bid", "Bn"])
+  }
+}
+
+/// A `Keys` relation joined to an empty `Texts` whose sort key is an integer
+/// beside a text column `Ts` — the inner side is zero-output, so a residual
+/// over it never runs.
+private func mismatched() throws -> FixtureCatalog {
+  try Catalog {
+    Relation("Keys", ["Kid": .integer]) {
+      Row(1)
+      Row(2)
+    }
+    Relation("Texts", ["Tid": .integer, "Ts": .text], sorted: "Tid") {
+    }
+  }
+}
+
+/// The incomparable-type fault an `integer` against a `character varying` pair
+/// raises at run.
+private let intVsText =
+    SQLError.state("42804", "cannot compare integer with character varying")
+
+/// Whether `plan` reaches a `.join` carrying a non-nil inner filter — the shape
+/// `nest` leaves when a pushed-down conjunct (a throw-neutral bound equality
+/// included) rides the inner leaf, applied while the executor materialises and
+/// seeks the inner rows.
+private func riding(_ plan: Plan) -> Bool {
+  switch plan {
+  case let .join(outer, _, _, _, _, _, filter):
+    filter != nil || riding(outer)
+  case let .select(_, source):
+    riding(source)
+  case let .project(_, source):
+    riding(source)
+  case let .sort(_, source):
+    riding(source)
+  case let .derived(_, sub, _, _):
+    riding(sub)
+  case let .product(left, right):
+    riding(left) || riding(right)
+  case let .outer(left, right, _, _):
+    riding(left) || riding(right)
+  case let .semijoin(left, right, _, _):
+    riding(left) || riding(right)
+  case let .apply(left, _, _, _, _, _):
+    riding(left)
+  case let .setop(_, left, right, _, _, _):
+    riding(left) || riding(right)
+  case let .limit(_, _, source), let .top(_, _, _, source),
+       let .distinct(source), let .aggregate(_, _, source),
+       let .window(_, source):
+    riding(source)
+  case .single, .values, .empty, .scan:
+    false
+  }
+}
+
+/// The optimised plan of `sql` against `catalog` under `bindings` — the same
+/// compile → pushdown → optimise pipeline the run drives, so the pushed-down
+/// bound conjunct rides exactly as it runs.
+private func planned(_ catalog: borrowing FixtureCatalog, _ sql: String,
+                     _ bindings: Bindings = [:]) throws -> Plan {
+  let compiled = try catalog.compile(parse(sql))
+  return try catalog.optimise(compiled.pushdown(bindings), bindings)
+}
+
+/// The rendered plan-tree lines of `sql` — the exact `EXPLAIN` output, built
+/// under `bindings` so a bound seek renders as it runs.
+private func lines(_ catalog: borrowing FixtureCatalog, _ sql: String,
+                   _ bindings: Bindings = [:]) throws -> Array<String> {
+  let context = Context(routines: .standard, bindings: bindings)
+  return try catalog.render(catalog.plan(of: parse(sql), context), context)
+}
+
+// MARK: - Originals: a comparable bound equality reaches the seek
+
+/// A bound `column = :parameter` whose column kind reconciles with the run
+/// binding is throw-neutral — it cannot fault `42804` this run — so selection
+/// pushdown rides it to the seek leaf below the join, exactly as it rides a
+/// literal-keyed equality. The prior admit-then-lift fix reached the same seek
+/// but through an unsound detour (push unsafe, lift later); this pushes only
+/// the provably throw-neutral conjunct, so nothing is ever lifted.
+struct BoundEqualitySeekTests {
+  @Test func `an integer bound on a seekable outer key seeks the leaf`()
+      throws {
+    // O1: `Parent.Pid = :parent` above the join, `:parent` an integer against
+    // the sorted `Pid`. The neutral conjunct rides to the Parent leaf and seeks
+    // it — a seek visible in the plan.
+    let catalog = try related()
+    let plan = try planned(catalog, "SELECT Child.Cn FROM Parent JOIN Child "
+                                    + "ON Parent.Pid = Child.Pid "
+                                    + "WHERE Parent.Pid = :parent",
+                           ["parent": .integer(1)])
+    #expect(sought(plan))
+    #expect(pushed(plan))
+    try catalog.expect("SELECT Child.Cn FROM Parent JOIN Child "
+                       + "ON Parent.Pid = Child.Pid WHERE Parent.Pid = :parent",
+                       yields: [[100], [200]],
+                       bindings: ["parent": .integer(1)])
+  }
+
+  @Test func `the bound seek matches the literal seek shape`() throws {
+    // The bound-keyed plan renders the same seeked scan the literal-keyed one
+    // does — the parameter is resolved to the same integer boundary.
+    let catalog = try related()
+    let bound = try lines(catalog, "SELECT Child.Cn FROM Parent JOIN Child "
+                                   + "ON Parent.Pid = Child.Pid "
+                                   + "WHERE Parent.Pid = :parent",
+                          ["parent": .integer(1)])
+    let literal = try lines(catalog, "SELECT Child.Cn FROM Parent JOIN Child "
+                                     + "ON Parent.Pid = Child.Pid "
+                                     + "WHERE Parent.Pid = 1")
+    #expect(bound == literal)
+    #expect(bound.contains { $0.contains("seek") })
+  }
+
+  @Test func `an integer bound on the inner key rides the inner filter`()
+      throws {
+    // O2: `Child.Cid = :child` on the inner side rides the join's inner filter
+    // and seeks the inner leaf per outer row — a filter riding the `.join`.
+    let catalog = try related()
+    let plan = try planned(catalog, "SELECT Child.Cn FROM Parent JOIN Child "
+                                    + "ON Parent.Pid = Child.Pid "
+                                    + "WHERE Child.Cid = :child",
+                           ["child": .integer(2)])
+    #expect(riding(plan))
+    try catalog.expect("SELECT Child.Cn FROM Parent JOIN Child "
+                       + "ON Parent.Pid = Child.Pid WHERE Child.Cid = :child",
+                       yields: [[200]], bindings: ["child": .integer(2)])
+  }
+
+  @Test func `a cross-kind bound over a matching join still faults`() throws {
+    // O3: `Child.Cn = :p` with a text `:p` against the integer `Cn` is not
+    // throw-neutral, so it stays the always-evaluated residual above the join.
+    // The join matches, so the residual runs and faults `42804` — never a
+    // silent empty.
+    try related().expect("SELECT Child.Cn FROM Parent JOIN Child "
+                         + "ON Parent.Pid = Child.Pid WHERE Child.Cn = :p",
+                         fails: intVsText, bindings: ["p": .text("z")])
+  }
+
+  @Test func `an unbound parameter is UNKNOWN, empty, and never faults`()
+      throws {
+    // O5: `Parent.Pid = :missing` with no binding reads the parameter as NULL,
+    // so every comparison is UNKNOWN and no row survives — an empty result, no
+    // fault (the neutral push cannot introduce one).
+    try related().empty("SELECT Child.Cn FROM Parent JOIN Child "
+                        + "ON Parent.Pid = Child.Pid "
+                        + "WHERE Parent.Pid = :missing")
+  }
+
+  @Test func `a NULL-bound parameter is UNKNOWN, empty, and never faults`()
+      throws {
+    // O5: the same, with the parameter explicitly bound to NULL.
+    try related().empty("SELECT Child.Cn FROM Parent JOIN Child "
+                        + "ON Parent.Pid = Child.Pid WHERE Parent.Pid = :p",
+                        bindings: ["p": .null])
+  }
+
+  @Test func `an integer bound on an unindexed column pushes without a seek`()
+      throws {
+    // O6: `Parent.Px = :px` against the non-sorted integer `Px` is neutral, so
+    // it pushes to the Parent leaf and filters there — no seek is available on
+    // an unindexed column, but the rows are correct.
+    let catalog = try related()
+    let plan = try planned(catalog, "SELECT Child.Cn FROM Parent JOIN Child "
+                                    + "ON Parent.Pid = Child.Pid "
+                                    + "WHERE Parent.Px = :px",
+                           ["px": .integer(20)])
+    #expect(!sought(plan))
+    #expect(pushed(plan))
+    try catalog.expect("SELECT Child.Cn FROM Parent JOIN Child "
+                       + "ON Parent.Pid = Child.Pid WHERE Parent.Px = :px",
+                       yields: [[300]], bindings: ["px": .integer(20)])
+  }
+
+  @Test func `a non-equality bound stays above the join`() throws {
+    // O7: `Parent.Pid > :p` is barred — only an equality is throw-neutral
+    // here — so it never seeks or rides; it stays the residual above the join.
+    // The rows are still correct.
+    let catalog = try related()
+    let plan = try planned(catalog, "SELECT Child.Cn FROM Parent JOIN Child "
+                                    + "ON Parent.Pid = Child.Pid "
+                                    + "WHERE Parent.Pid > :p",
+                           ["p": .integer(0)])
+    #expect(!sought(plan))
+    #expect(!riding(plan))
+    try catalog.expect("SELECT Child.Cn FROM Parent JOIN Child "
+                       + "ON Parent.Pid = Child.Pid WHERE Parent.Pid > :p",
+                       yields: [[100], [200], [300]],
+                       bindings: ["p": .integer(0)])
+  }
+
+  @Test func `a bound BETWEEN stays above the join`() throws {
+    // O7: a parameterised `BETWEEN` is not a bound equality, so it is never
+    // neutral — it stays above the join and the rows are correct.
+    let catalog = try related()
+    let plan = try planned(catalog, "SELECT Child.Cn FROM Parent JOIN Child "
+                                    + "ON Parent.Pid = Child.Pid "
+                                    + "WHERE Parent.Pid BETWEEN :lo AND :hi",
+                           ["lo": .integer(2), "hi": .integer(9)])
+    #expect(!sought(plan))
+    try catalog.expect("SELECT Child.Cn FROM Parent JOIN Child "
+                       + "ON Parent.Pid = Child.Pid "
+                       + "WHERE Parent.Pid BETWEEN :lo AND :hi",
+                       yields: [[300]],
+                       bindings: ["lo": .integer(2), "hi": .integer(9)])
+  }
+
+  @Test func `a double bound widens against an integer column`() throws {
+    // Precision: `Parent.Px = :px` with a double `:px` against the integer `Px`
+    // is neutral — the kinds widen — so it pushes and filters (no integer seek
+    // on a double key) and the promoted comparison admits the right row.
+    let catalog = try related()
+    let plan = try planned(catalog, "SELECT Child.Cn FROM Parent JOIN Child "
+                                    + "ON Parent.Pid = Child.Pid "
+                                    + "WHERE Parent.Px = :px",
+                           ["px": .double(20.0)])
+    #expect(!sought(plan))
+    #expect(pushed(plan))
+    try catalog.expect("SELECT Child.Cn FROM Parent JOIN Child "
+                       + "ON Parent.Pid = Child.Pid WHERE Parent.Px = :px",
+                       yields: [[300]], bindings: ["px": .double(20.0)])
+  }
+}
+
+// MARK: - New corners: the three prior soundness holes must not fault
+
+/// The redesign's proof obligation: a non-neutral bound conjunct is never
+/// pushed, so a cross product, a simple view, or a cross-kind inner — the three
+/// corners the admit-then-lift fix broke, each having no nest to lift from —
+/// keeps the conjunct at its lazy-fault position above the barrier, where a
+/// zero-output join never reaches it. No new `42804` fault.
+struct BoundEqualityNoLiftTests {
+  @Test func `a text bound over an empty cross product stays above`() throws {
+    // N1: `L CROSS JOIN R WHERE L.Ln = :p` with a text `:p` against the integer
+    // `Ln`, `R` empty. The cross product is empty. The non-neutral bound is not
+    // pushed to `L`'s scan (which is non-empty), so it never evaluates — an
+    // empty result, no fault. The admit-then-lift fix pushed it into the
+    // cross-product input and, with no nest to lift from, faulted `L.Ln = 'z'`
+    // on `L`'s rows.
+    try crossed().empty("SELECT L.Ln FROM L CROSS JOIN R WHERE L.Ln = :p",
+                        bindings: ["p": .text("z")])
+  }
+
+  @Test func `a text bound over an empty non-equi join stays above`() throws {
+    // N1: the non-equi join analogue — no `match` to fold, no nest to lift.
+    try crossed().empty("SELECT L.Ln FROM L JOIN R ON L.Lid < R.Rid "
+                        + "WHERE L.Ln = :p", bindings: ["p": .text("z")])
+  }
+
+  @Test func `a text bound on a zero-output view column stays above`() throws {
+    // N2: `Empt JOIN Other … WHERE Empt.Bn = :p` with a text `:p` against the
+    // view's integer `Bn`, the view yielding no rows. The non-neutral bound is
+    // not pushed into the derived body, so it stays above the derived leaf and
+    // the empty view never reaches it — no fault. The admit-then-lift fix
+    // pushed it into the simple view's body, which the outer optimiser could
+    // not peel back out, and faulted.
+    let catalog = try viewed()
+    try catalog.empty("SELECT Empt.Bn FROM Empt JOIN Other "
+                      + "ON Empt.Bid = Other.Oid WHERE Empt.Bn = :p",
+                      bindings: ["p": .text("z")])
+    // The bound stays above the derived leaf — it never rides the join.
+    let plan = try planned(catalog, "SELECT Empt.Bn FROM Empt JOIN Other "
+                                    + "ON Empt.Bid = Other.Oid "
+                                    + "WHERE Empt.Bn = :p", ["p": .text("z")])
+    #expect(!riding(plan))
+  }
+
+  @Test func `an integer bound on a text inner column stays above`() throws {
+    // N3: `Keys JOIN Texts … WHERE Texts.Ts = :p` with an integer `:p` against
+    // the inner's text `Ts` — `reconcile(.text, .integer)` is false, so it is
+    // not neutral and never rides the inner filter. `Texts` is empty, so the
+    // zero-output join never reaches the residual — empty, no fault.
+    let catalog = try mismatched()
+    try catalog.empty("SELECT Keys.Kid FROM Keys JOIN Texts "
+                      + "ON Keys.Kid = Texts.Tid WHERE Texts.Ts = :p",
+                      bindings: ["p": .integer(1)])
+    let plan = try planned(catalog, "SELECT Keys.Kid FROM Keys JOIN Texts "
+                                    + "ON Keys.Kid = Texts.Tid "
+                                    + "WHERE Texts.Ts = :p", ["p": .integer(1)])
+    #expect(!riding(plan))
+  }
+}

--- a/SwiftSQL/Tests/SQLTests/Queries/EngineCrossJoinTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/EngineCrossJoinTests.swift
@@ -90,7 +90,7 @@ struct EngineCrossJoinTests {
     let catalog = try family()
     let select = try parse("SELECT * FROM Parent CROSS JOIN Child")
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(product(plan))
   }
 }

--- a/SwiftSQL/Tests/SQLTests/Queries/EngineJoinPlanningTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/EngineJoinPlanningTests.swift
@@ -277,7 +277,7 @@ struct EngineStreamingProductTests {
           JOIN Adults ON Adults.Key = Child.Pid
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(residue(plan))
   }
 

--- a/SwiftSQL/Tests/SQLTests/Queries/EngineJoinTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/EngineJoinTests.swift
@@ -163,7 +163,7 @@ struct EngineNonEquiJoinTests {
           JOIN Child ON Parent.Id < Child.Pid
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(!joined(plan))
     #expect(residue(plan))
   }
@@ -194,7 +194,7 @@ struct EngineNonEquiJoinTests {
           JOIN Child ON Child.Pid = Parent.Id AND Parent.Name < Child.Name
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(joined(plan))
   }
 
@@ -218,7 +218,7 @@ struct EngineNonEquiJoinTests {
           JOIN Child ON Child.Pid = Parent.Id + 1
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(!joined(plan))
     #expect(residue(plan))
   }
@@ -279,7 +279,7 @@ struct EngineNonEquiJoinTests {
         SELECT A.k FROM A JOIN B ON (1 / A.x) = 0 AND A.k = B.k
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(!joined(plan))
     #expect(residue(plan))
   }
@@ -300,7 +300,7 @@ struct EngineNonEquiJoinTests {
     let compiled = try catalog.compile(parse("""
         SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
         """))
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(!joined(plan))
     #expect(residue(plan))
   }
@@ -322,7 +322,7 @@ struct EngineNonEquiJoinTests {
     let compiled = try catalog.compile(parse("""
         SELECT A.k FROM A JOIN B ON A.k = B.k AND (1 / A.x) = 0
         """))
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(!joined(plan))
     #expect(residue(plan))
     #expect(throws: SQLError.divide) {
@@ -372,7 +372,7 @@ struct EngineNonEquiJoinTests {
     let rows = try catalog.run(parse(text))
     #expect(rows == [[.integer(1), .integer(8)]])
     let compiled = try catalog.compile(parse(text))
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(joined(plan))
   }
 
@@ -385,7 +385,7 @@ struct EngineNonEquiJoinTests {
           JOIN Child ON Child.Pid = Parent.Id
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(joined(plan))
   }
 
@@ -405,7 +405,7 @@ struct EngineNonEquiJoinTests {
     ])
     let text = "SELECT A.k FROM A JOIN B ON A.k < B.k WHERE (1 / A.x) = 0"
     let compiled = try catalog.compile(parse(text))
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(separated(plan))
     #expect(residue(plan))
     #expect(try catalog.run(parse(text)).isEmpty)
@@ -471,7 +471,7 @@ struct EngineNonEquiJoinTests {
           JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE (1 / A.x) = 0
         """
     let compiled = try catalog.compile(parse(text))
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     // The equi key still hash-joins; the leftover match gates above it, and the
     // `WHERE` is a separate `select` above that gate, not fused with the match.
     #expect(joined(plan))
@@ -529,7 +529,7 @@ struct EngineNonEquiJoinTests {
           JOIN B ON A.k1 = B.k1 AND A.k2 = B.k2 WHERE A.tag = 'keep'
         """
     let compiled = try catalog.compile(parse(text))
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(joined(plan))
     #expect(try catalog.run(parse(text)) == [[.text("keep"), .text("bee")]])
   }
@@ -552,7 +552,7 @@ struct EngineNonEquiJoinTests {
     ])
     let text = "SELECT A.k FROM A JOIN B ON A.k = B.k WHERE (1 / A.x) = 1"
     let compiled = try catalog.compile(parse(text))
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(joined(plan))
     #expect(try catalog.run(parse(text)) == [[.integer(1)]])
   }
@@ -686,7 +686,7 @@ struct EngineOuterJoinTests {
           LEFT JOIN Child ON Child.Pid = Parent.Id
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(outers(plan))
     #expect(!joined(plan))
   }

--- a/SwiftSQL/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/EngineViewAndPushdownTests.swift
@@ -745,7 +745,7 @@ struct EnginePushdownTests {
           WHERE Parent.Name = 'Ada'
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(pushed(plan))
   }
 
@@ -758,7 +758,7 @@ struct EnginePushdownTests {
           WHERE Parent.Id = 2
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(sought(plan))
     #expect(pushed(plan))
   }
@@ -784,7 +784,7 @@ struct EnginePushdownTests {
         SELECT Name FROM T WHERE Name <> 'x' AND Age > 0 AND Id = 5
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(sought(plan))
   }
 
@@ -811,7 +811,7 @@ struct EnginePushdownTests {
 
     // The unsafe `(1 / x) = 0` residual bars the `id < 0` seek — the plan scans.
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(!sought(plan))
 
     // …and the scan raises the division rather than seeking past the empty run.
@@ -841,7 +841,7 @@ struct EnginePushdownTests {
           JOIN Parent ON Parent.Id = Child.Pid WHERE Parent.Name <> 'zz'
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(joined(plan))
 
     // …and it returns the correct rows: every child with a matching parent,
@@ -866,7 +866,7 @@ struct EnginePushdownTests {
           JOIN Child ON Child.Pid = Parent.Id WHERE Parent.Name <> Child.Name
         """)
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(joined(plan))
     #expect(floating(plan))
 
@@ -994,7 +994,7 @@ struct EnginePushdownTests {
     let catalog = try spanned()
     let select = try parse("SELECT Tag FROM Both WHERE Key = 2")
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(injected(plan))
     #expect(sought(plan))
 
@@ -1066,7 +1066,7 @@ struct EnginePushdownTests {
     // `A.x = 1` is nullable and precedes the unsafe division, so it is NOT
     // pushed to the `A` leaf — it floats at the product level.
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(!pushed(plan))
     #expect(floating(plan))
 
@@ -1095,7 +1095,7 @@ struct EnginePushdownTests {
     // `x = 1` is nullable and precedes the unsafe division, so it is NOT
     // injected into the view — it floats above the derived leaf.
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(floating(plan))
 
     // …and the query raises rather than silently dropping the row.
@@ -1125,7 +1125,7 @@ struct EnginePushdownTests {
     // the unsafe division, so it is NOT injected into the view — it floats above
     // the derived leaf.
     let compiled = try catalog.compile(select)
-    let plan = try catalog.optimise(compiled.pushdown(), [:])
+    let plan = try catalog.optimise(compiled.pushdown([:]), [:])
     #expect(floating(plan))
 
     // …and the query raises rather than silently dropping the row.

--- a/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
+++ b/SwiftSQL/Tests/SQLTests/Queries/WindowFunctionTests.swift
@@ -545,7 +545,7 @@ extension FixtureCatalog {
   fileprivate func run(bare select: Select)
       throws(SQLError) -> Array<Array<Value>> {
     let context = Context().validating(false).resolving(Subqueries())
-    let plan = try compile(select, context).demoted().pushdown()
+    let plan = try compile(select, context).demoted().pushdown([:])
     return try execute(optimise(plan, context), context).map(\.values)
   }
 }


### PR DESCRIPTION
A `WHERE t.col = :parameter` lowers to `Filter.bound` and is stamped `.incomparable` at lowering, because the parameter's kind is opaque until the run binds it. That stamp's only effect is to make the conjunct `!safe`, and selection pushdown holds every `!safe` conjunct at the join barrier. So a single-relation bound equality was stranded as a `select incomparable(bound)` over a full base scan above the join, never reaching the base-scan seek that resolves the binding — a bound key full-scanned where it could have sought (bases.sql's `i.Class = :parent` on the probed relation being the motivating case).

Let such a conjunct descend, without changing throw-visibility.

Part 1 — reach the base scan. Add `Filter.admissible`, recognising the narrow shape `.incomparable(.bound(.slot, .equal, :parameter))`: a single-slot term against one parameter, so it references exactly one relation. The three pushdown gates (the product loop, the ON gate, and the into-view partition) admit an admissible conjunct to descend beside a safe one even though it is unsafe. The rest of the safety envelope is unchanged: it descends only with no unsafe predecessor (`barrier`) and, being nullable, no unsafe successor (`hazard`); the relation partition still keeps a straddling/multi-relation conjunct at `here`; and, still being unsafe, it raises the `barrier` after itself. Nothing is relaxed for a non-`.equal` op, a non-`.bound` operand, a BETWEEN/LIKE/IN, or a multi-relation predicate.

Part 2 — gate the placement on the binding (the soundness crux). Pushdown is bindings-blind, so Part 1 alone would introduce a `42804` in the corner {cross-kind binding, non-empty inner, zero-output join}: pushed as the inner filter, the hash build evaluates it on every inner row before the join yields anything, whereas above the join it sees zero output rows and never runs. `nest` (which has the bindings) now lets an admissible conjunct ride as the inner filter only when its binding resolves to an integer — it then seeks, a comparable integer/integer test that cannot fault — and otherwise lifts it back above the join, its lazy-fault position.

The same corner exists on the OUTER (probe) side, which is bases.sql's actual shape: on the outer leaf the conjunct is evaluated while the outer is materialised, faulting on an outer row even for a zero-output join. `hoist` peels a cross-kind/opaque admissible conjunct off the optimised outer's top-level residual back beside the join's residual; because `nest` recurses into the outer, a left-deep chain bubbles it up one join at a time until it sits above the whole join. An integer binding is left in place, where the outer leaf seeks it plan-visibly.

Result-equivalence and throw-visibility are preserved: a query that faults `42804` today faults identically, no new fault is introduced (the zero-output corner stays fault-free on both sides, including across a multi-way join), and cardinality/NULL semantics are unchanged. The integer target now seeks.

The adversarial matrix in BoundEqualityPushdownTests covers the integer seek (outer plan-visible and inner riding), the preserved cross-kind fault over a matching join, the zero-output no-fault probes (outer, inner, empty outer, and a three-way join), a parameter spanning two relations staying above, an unbound/NULL binding yielding empty without faulting, a non-indexed column filtering without a seek, and the barred `>`/BETWEEN forms.