### PR TITLE
winmd-inspect: seed the render from a TypeDef scan, not the interfaces view

### DIFF
--- a/Sources/winmd-inspect/Resources/Render/guid.sql
+++ b/Sources/winmd-inspect/Resources/Render/guid.sql
@@ -1,0 +1,44 @@
+-- The GUID a `TypeDef` bears through its `GuidAttribute`, decoded through the
+-- `GUID` UDF the way the `interfaces` view spells an interface's `iid` — the
+-- same three attribute-encoding shapes (a `MemberRef` to a `TypeRef`, a
+-- `MethodDef` on the attribute `TypeDef`, a `MemberRef` to a `TypeDef`) — but
+-- keyed by the `TypeDef` `Id` and ungated by the interface flag, so a delegate
+-- `TypeDef` (a COM interface, not flagged an interface) still yields its
+-- runtime IID for the `@com(interface:)` the render emits. A parameterised
+-- delegate carries no static GUID, so this resolves nothing and the render
+-- treats it as a frontier.
+SELECT
+  GUID(c.Value) AS iid
+FROM
+  TypeDef t
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.Id
+  JOIN MemberRef r ON c.Type_MemberRef = r.Id
+  JOIN TypeRef g ON r.Class_TypeRef = g.Id
+WHERE
+  g.TypeNamespace = 'Windows.Win32.Foundation.Metadata'
+  AND g.TypeName = 'GuidAttribute'
+  AND t.Id = :parent
+UNION
+SELECT
+  GUID(c.Value) AS iid
+FROM
+  TypeDef t
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.Id
+  JOIN MethodDef m ON c.Type_MethodDef = m.Id
+  JOIN TypeDef g ON m.TypeDef = g.Id
+WHERE
+  g.TypeNamespace = 'Windows.Win32.Foundation.Metadata'
+  AND g.TypeName = 'GuidAttribute'
+  AND t.Id = :parent
+UNION
+SELECT
+  GUID(c.Value) AS iid
+FROM
+  TypeDef t
+  JOIN CustomAttribute c ON c.Parent_TypeDef = t.Id
+  JOIN MemberRef r ON c.Type_MemberRef = r.Id
+  JOIN TypeDef g ON r.Class_TypeDef = g.Id
+WHERE
+  g.TypeNamespace = 'Windows.Win32.Foundation.Metadata'
+  AND g.TypeName = 'GuidAttribute'
+  AND t.Id = :parent

--- a/Sources/winmd-inspect/Resources/Render/interfaces.sql
+++ b/Sources/winmd-inspect/Resources/Render/interfaces.sql
@@ -1,10 +1,34 @@
+-- The render seed: the interface `TypeDef` rows to render, a name-filtered raw
+-- scan rather than the `interfaces` view. The view INNER-joins each interface's
+-- `GuidAttribute` across a three-way UNION over the whole `CustomAttribute`
+-- table, so the `:name` predicate does not push into it: selecting one
+-- interface still GUID-decodes every interface before filtering, and rendering
+-- one pays the cost of decoding all of them. This scan seeks the interface
+-- `TypeDef` rows directly (the `tdInterface` flag, bit 5) and the render fetches
+-- each `iid` through the seekable `guid` query keyed by the interface's `Id`, so
+-- rendering one interface no longer materialises the whole view.
+--
+-- The `iid` is not projected here: the render fetches it per interface and
+-- drops an interface whose `guid` resolves nothing, reproducing the view's
+-- INNER-join membership (a `tdInterface` `TypeDef` with no decodable
+-- `GuidAttribute` is absent from the view and is therefore not rendered).
+-- `ORDER BY Id` matches the ascending-`Id` row order the `interfaces` view
+-- yields, so the emitted set and its order stay byte-identical.
+-- This seed's schema is deliberately three columns (`Id`, `TypeNamespace`,
+-- `TypeName`): the render fetches each `iid` through the seekable `guid`
+-- query, not a four-column `interfaces`-view row. It is an intentional
+-- performance change from the view-based seed — a caller overriding this
+-- file must match the three-column schema (a fourth `iid` column is not
+-- read).
+--
 SELECT
   Id,
   TypeNamespace,
-  TypeName,
-  iid
+  TypeName
 FROM
-  interfaces
+  TypeDef
 WHERE
-  TypeName = :name
-  OR '*' = :name
+  BITAND(Flags, 32) = 32
+  AND (TypeName = :name OR '*' = :name)
+ORDER BY
+  Id

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -435,15 +435,16 @@ internal struct Shell: ~Escapable {
   /// through the named Mustache template.
   ///
   /// The data tier is the session's bundled views, read through the
-  /// bundled `Resources/Render/*.sql` queries (not Swift literals): the
-  /// `interfaces` query selects the one named interface, or every
-  /// interface for `*` (its `WHERE TypeName = :name OR '*' = :name`), then
-  /// for each its `methods` bound by the interface's `Id`, each
-  /// method's `params` bound by the method's `Id`, and its `bases`
+  /// bundled `Resources/Render/*.sql` queries (not Swift literals): the seed
+  /// (`seeds`) scans the interface `TypeDef` rows the `interfaces` query names —
+  /// the one named interface, or every one for `*` — and fetches each `iid`
+  /// through the seekable `guid` query rather than materialising the whole
+  /// `interfaces` view, then for each its `methods` bound by the interface's
+  /// `Id`, each method's `params` bound by the method's `Id`, and its `bases`
   /// bound by the interface's `Id`. The presentation tier is the named
-  /// template loaded from `Resources/Templates`. A single interface that
-  /// no view names raises `RenderError.interface`; a missing template
-  /// resource raises `RenderError.template`.
+  /// template loaded from `Resources/Templates`. A single interface no seed
+  /// resolves raises `RenderError.interface`; a missing template resource
+  /// raises `RenderError.template`.
   ///
   /// The base inheritance is derived through the `bases` view (the interface's
   /// `InterfaceImpl` rows navigated to their base type names); a rootless
@@ -477,14 +478,13 @@ internal struct Shell: ~Escapable {
     // SQL layer — spells a return/parameter, navigating the signature with the
     // storage's `decode(return:in:)`/`decode(parameter:for:)` methods.
     let dialect = language.dialect
-    // The rows to render come straight from the bundled selection query, bound
-    // by `:name`: it returns the one named interface, or — for `*` — every one
-    // (`WHERE TypeName = :name OR '*' = :name`). Choosing which rows to emit is
-    // the query's job, so render just iterates whatever it returns.
-    let selection =
-        try Shell.statement(Shell.query(named: "interfaces", search: search))
-    let interfaces = try session.run(selection, routines,
-                                     bindings: ["name": .text(interface)])
+    // The rows to render come from the seed scan bound by `:name`: the one
+    // named interface, or — for `*` — every one. `seeds` scans the interface
+    // `TypeDef` rows directly and fetches each `iid` through the seekable `guid`
+    // query, dropping a guid-less interface, so it reproduces the `interfaces`
+    // view's rows without materialising the whole view. Choosing which rows to
+    // emit is the seed's job, so render just iterates whatever it returns.
+    let interfaces = try seeds(interface, routines, search: search)
     guard interface == "*" || !interfaces.isEmpty else {
       throw RenderError.interface(interface)
     }
@@ -505,9 +505,10 @@ internal struct Shell: ~Escapable {
   ///
   /// The setup is the flat render's: the template names its target language, and
   /// the render resolves against the language spec's UDFs merged with the
-  /// session's routines. The root selection is the same `interfaces` query, so a
-  /// name no interface bears raises `RenderError.interface`; a simple name borne
-  /// by more than one namespace seeds each match. From each seed the walk visits
+  /// session's routines. The root selection is the same `seeds` scan the flat
+  /// render uses, so a name no interface bears raises `RenderError.interface`; a
+  /// simple name borne by more than one namespace seeds each match. From each
+  /// seed the walk visits
   /// the base and required interfaces depth-first, emitting a base before the
   /// interface that refines it, rendering each interface once (dedup by its local
   /// `TypeDef` Id). The per-interface body is the one `emit` the flat render
@@ -518,10 +519,7 @@ internal struct Shell: ~Escapable {
     let language = Shell.language(declaredIn: &body, search: search)
     let routines = language.routines.merging(session.functions)
     let dialect = language.dialect
-    let selection =
-        try Shell.statement(Shell.query(named: "interfaces", search: search))
-    let roots = try session.run(selection, routines,
-                                bindings: ["name": .text(root)])
+    let roots = try seeds(root, routines, search: search)
     guard !roots.isEmpty else { throw RenderError.interface(root) }
 
     let mustache = try MustacheTemplate(string: body)
@@ -535,6 +533,53 @@ internal struct Shell: ~Escapable {
                search: search)
     }
     return sources.joined(separator: "\n")
+  }
+
+  /// The seed rows for `name` — the interface `TypeDef` rows the render
+  /// `interfaces` query scans — resolved to the full render row shape (`Id`,
+  /// namespace, name, `iid`) by fetching each interface's `iid` through the
+  /// seekable `guid` query, dropping an interface whose `GuidAttribute` resolves
+  /// nothing.
+  ///
+  /// The scan replaces materialising the `interfaces` view (a three-way UNION
+  /// over the whole `CustomAttribute` table) for the one seed: the view's
+  /// `:name` predicate does not push into it, so it GUID-decodes every interface
+  /// before filtering. This seeks the `TypeDef` rows and fetches only the
+  /// matched interfaces' IIDs. Dropping a guid-less interface reproduces the
+  /// view's INNER-join membership exactly — a `tdInterface` `TypeDef` with no
+  /// decodable `GuidAttribute` is absent from the view and so is not rendered —
+  /// and the query's `ORDER BY Id` preserves the view's ascending-`Id` row
+  /// order, so the emitted set and its order stay byte-identical.
+  private borrowing func seeds(_ name: String, _ routines: Routines,
+                               search: Array<String>) throws
+      -> Array<Array<Value>> {
+    let selection =
+        try Shell.statement(Shell.query(named: "interfaces", search: search))
+    let rows = try session.run(selection, routines,
+                               bindings: ["name": .text(name)])
+    var interfaces = Array<Array<Value>>()
+    interfaces.reserveCapacity(rows.count)
+    for row in rows {
+      guard let iid = try guid(of: row[0], routines, search: search)
+      else { continue }
+      interfaces.append([row[0], row[1], row[2], .text(iid)])
+    }
+    return interfaces
+  }
+
+  /// The interface `iid` the `TypeDef` at `id` bears through its
+  /// `GuidAttribute`, decoded through the seekable `guid` query keyed by the
+  /// interface's `Id` — the same three attribute encodings the `interfaces` view
+  /// spells its `iid` through, but seeking `CustomAttribute.Parent_TypeDef`
+  /// rather than materialising the whole view. `nil` when the interface bears no
+  /// decodable `GuidAttribute`, the signal the seed drops it to match the view's
+  /// INNER-join membership.
+  private borrowing func guid(of id: Value, _ routines: Routines,
+                              search: Array<String>) throws -> String? {
+    let query =
+        try Shell.statement(Shell.query(named: "guid", search: search))
+    let rows = try session.run(query, routines, bindings: ["parent": id])
+    return rows.first.map { $0[0].text }
   }
 
   /// Emits the interface `found` and, first, the transitive closure of its plain

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -209,9 +209,29 @@ struct DatabaseSQLTests {
   /// from a `generics` view override the caller registers, so the table need
   /// hold no rows (an empty range past the last real table); the shared
   /// fixture omits it (no generics), which the render treats as no generics.
+  ///
+  /// The interface `TypeDef`'s `TypeName` is repointed at `named`, appended to
+  /// the string heap: the render seeds from a `TypeName = :name` `TypeDef` scan
+  /// (not the `interfaces` view a caller may override), so the fixture's
+  /// IID-bearing interface `TypeDef` Id 1 — `tdInterface`, its `GuidAttribute`
+  /// chain intact — must carry the generic name the render is asked for. Its
+  /// stored `iid` is the well-known GUID; the render's generic arm emits no
+  /// `@com(interface:)`, so the iid is ignored and the rendered output is the
+  /// same the `interfaces`-view override produced.
   private static func withGenerics(
+      named name: String,
       _ body: (borrowing Storage) throws -> Void) rethrows {
     var relations = DatabaseSQLTests.relations
+    var bytes = DatabaseSQLTests.bytes
+    var strings = DatabaseSQLTests.strings
+    // Append `name` (NUL-terminated) to the string heap and repoint TypeDef[0]
+    // (`TypeName` is the `u16` at byte 16 — the TypeDef table opens at byte 12,
+    // a row is Flags(4) then TypeName(2)) at it.
+    let offset = strings.count
+    strings.append(contentsOf: Array(name.utf8))
+    strings.append(0)
+    bytes[16] = UInt8(offset & 0xff)
+    bytes[17] = UInt8(offset >> 8)
     relations.append(WinMD.Table(Metadata.Tables.GenericParam.self, rows: 0,
                                  range: bytes.count ..< bytes.count,
                                  wide: 0, stride: 8))
@@ -994,18 +1014,12 @@ struct DatabaseSQLTests {
     // Swift cannot parse. The wrapper `struct` keeps the escaped bare name
     // (`` `protocol`<Element> ``); the ABI protocol's declaration and the
     // wrapper's `base: any …<Element>` existential both spell `protocolABI`.
-    // Overriding `interfaces` to yield a suffixed keyword name over the
-    // fixture's generic-aware storage drives the render's generic arm;
-    // `methods` and `bases` are emptied so the output is the declaration shell
-    // alone.
-    try DatabaseSQLTests.withGenerics { catalog in
+    // The fixture's interface `TypeDef` carries the suffixed keyword name, so
+    // the render's `TypeName = :name` seed finds it and its generic-aware
+    // storage drives the generic arm; `methods` and `bases` are emptied so the
+    // output is the declaration shell alone.
+    try DatabaseSQLTests.withGenerics(named: "protocol`1") { catalog in
       var shell = Shell(catalog)
-      let interfaces = """
-        CREATE VIEW interfaces AS
-        SELECT Id, TypeNamespace, 'protocol`1' AS TypeName,
-               '00000000-0000-0000-0000-000000000000' AS iid
-        FROM TypeDef WHERE Id = 1
-        """
       let generics = """
         CREATE VIEW generics AS
         SELECT 'Element' AS Name, 0 AS Number FROM TypeDef WHERE Id = :parent
@@ -1018,7 +1032,7 @@ struct DatabaseSQLTests {
         CREATE VIEW bases AS
         SELECT '' AS base, NULL AS spec FROM TypeDef WHERE 0 = 1
         """
-      for query in [interfaces, generics, methods, bases] {
+      for query in [generics, methods, bases] {
         let (name, view) = try DatabaseSQLTests.create(query)
         shell.session.register(name, view)
       }
@@ -1047,15 +1061,11 @@ struct DatabaseSQLTests {
     // names that base UNCHANGED (`: IInspectable`, no `ABI` suffix and no
     // arguments): the base is already a protocol and carries no wrapper/ABI
     // split. The `bases` override supplies the plain name; `methods` are
-    // emptied so the output is the declaration shell.
-    try DatabaseSQLTests.withGenerics { catalog in
+    // emptied so the output is the declaration shell. The fixture's interface
+    // `TypeDef` carries `IVector``1`, so the render's `TypeName = :name` seed
+    // finds it.
+    try DatabaseSQLTests.withGenerics(named: "IVector`1") { catalog in
       var shell = Shell(catalog)
-      let interfaces = """
-        CREATE VIEW interfaces AS
-        SELECT Id, TypeNamespace, 'IVector`1' AS TypeName,
-               '00000000-0000-0000-0000-000000000000' AS iid
-        FROM TypeDef WHERE Id = 1
-        """
       let generics = """
         CREATE VIEW generics AS
         SELECT 'Element' AS Name, 0 AS Number FROM TypeDef WHERE Id = :parent
@@ -1069,7 +1079,7 @@ struct DatabaseSQLTests {
         SELECT 'IInspectable' AS base, NULL AS spec
         FROM TypeDef WHERE Id = :parent
         """
-      for query in [interfaces, generics, methods, bases] {
+      for query in [generics, methods, bases] {
         let (name, view) = try DatabaseSQLTests.create(query)
         shell.session.register(name, view)
       }
@@ -1104,21 +1114,15 @@ struct DatabaseSQLTests {
     // it. The `bases` view still resolves the generic base for queries and
     // tooling; only the render omits it. `Widget`'s sole declared base is the
     // generic one, so with it omitted the interface falls to the COM root
-    // default (`IUnknown`).
-    // `interfaces`/`methods` are overridden to name `Widget` without a
-    // `GuidAttribute` chain and to emit no requirements.
+    // default (`IUnknown`). `Widget` is a `tdInterface` `TypeDef` bearing a
+    // (placeholder) `GuidAttribute`, so the render's `TypeName = :name` seed
+    // finds it; `methods` is overridden to emit no requirements.
     try GenericBaseFixture.with { catalog in
       var shell = Shell(catalog)
-      let interfaces = """
-        CREATE VIEW interfaces AS
-        SELECT Id, TypeNamespace, TypeName,
-               '00000000-0000-0000-0000-000000000000' AS iid
-        FROM TypeDef WHERE Id = 1
-        """
       let methods = """
         CREATE VIEW methods AS SELECT Id, '' AS Name FROM TypeDef WHERE 0 = 1
         """
-      for query in [interfaces, methods] {
+      for query in [methods] {
         let (name, view) = try DatabaseSQLTests.create(query)
         shell.session.register(name, view)
       }
@@ -1193,18 +1197,13 @@ struct DatabaseSQLTests {
     // named one keeps its name, so a mix renders `_ arg0: …, _ named: …, _
     // arg2: …`. A single blank parameter forwards as `base.M(arg0)` — no empty
     // argument — and a named parameter is untouched. The fixture's storage
-    // decodes the parameter types; `interfaces`/`methods`/`params` are
-    // overridden so the one method takes a blank then a named parameter over
-    // the fixture's `MethodDef` signature. The forwarding call passes both
-    // locals.
-    try DatabaseSQLTests.withGenerics { catalog in
+    // decodes the parameter types; `methods`/`params` are overridden so the one
+    // method takes a blank then a named parameter over the fixture's
+    // `MethodDef` signature. The fixture's interface `TypeDef` carries
+    // `IThing``1`, so the render's `TypeName = :name` seed finds it. The
+    // forwarding call passes both locals.
+    try DatabaseSQLTests.withGenerics(named: "IThing`1") { catalog in
       var shell = Shell(catalog)
-      let interfaces = """
-        CREATE VIEW interfaces AS
-        SELECT Id, TypeNamespace, 'IThing`1' AS TypeName,
-               '00000000-0000-0000-0000-000000000000' AS iid
-        FROM TypeDef WHERE Id = 1
-        """
       let generics = """
         CREATE VIEW generics AS
         SELECT 'Element' AS Name, 0 AS Number FROM TypeDef WHERE Id = :parent
@@ -1233,7 +1232,7 @@ struct DatabaseSQLTests {
         CREATE VIEW bases AS
         SELECT '' AS base, NULL AS spec FROM TypeDef WHERE 0 = 1
         """
-      for query in [interfaces, generics, methods, params, bases] {
+      for query in [generics, methods, params, bases] {
         let (name, view) = try DatabaseSQLTests.create(query)
         shell.session.register(name, view)
       }
@@ -1943,67 +1942,109 @@ private enum RootInterfaceFixture {
 }
 
 /// A metadata fixture whose interface inherits a generic base — the render's
-/// generic-base decode. Four narrow (all-index 2-byte) tables packed back to
-/// back in table-number order; a stored index `N` names the 0-based row
-/// `N - 1`, and a `TypeDefOrRef` coded token is `(row << 2) | tag`, tag 1
-/// selecting `TypeRef` and tag 2 selecting `TypeSpec`.
+/// generic-base decode. Narrow (all-index 2-byte) tables packed back to back in
+/// table-number order; a stored index `N` names the 0-based row `N - 1`, and a
+/// `TypeDefOrRef` coded token is `(row << 2) | tag`, tag 1 selecting `TypeRef`
+/// and tag 2 selecting `TypeSpec`.
 ///
 ///   TypeRef[0]:  ResolutionScope=0, TypeName="IVector`1"(4),
 ///                TypeNamespace="NS"(1) — the generic base interface, its name
 ///                carrying the CLR arity suffix the decode strips.
-///   TypeDef[0]:  Flags=0, TypeName="Widget"(14), TypeNamespace="NS"(1),
-///                null Extends/Field/Method — the interface implementing the
-///                generic base.
+///   TypeRef[1]:  ResolutionScope=0, TypeName="GuidAttribute"(55),
+///                TypeNamespace="Windows.Win32.Foundation.Metadata"(21) — the
+///                attribute type `Widget`'s `GuidAttribute` names, so the
+///                seed's `guid` fetch resolves an IID and keeps `Widget`.
+///   TypeDef[0]:  Flags=0x20 (tdInterface), TypeName="Widget"(14),
+///                TypeNamespace="NS"(1), null Extends/Field/Method — the
+///                interface implementing the generic base. The render seeds
+///                from a `tdInterface` `TypeName = :name` `TypeDef` scan, so
+///                `Widget` is flagged an interface and bears a `GuidAttribute`.
 ///   InterfaceImpl[0]: Class=1 (TypeDef row 1, Widget),
 ///                Interface=6 ((1 << 2) | 2 — TypeSpec row 1).
+///   MemberRef[0]: Class=(2 << 3) | 1 = 0x11 — the ctor whose declaring type is
+///                the `GuidAttribute` TypeRef (row 2).
+///   CustomAttribute[0]: Parent=(1 << 5) | 3 = 0x23 (TypeDef row 1, Widget),
+///                Type=(1 << 3) | 3 = 0x0b (MemberRef row 1), Value=blob[7] —
+///                `Widget`'s (placeholder) GUID value.
 ///   TypeSpec[0]: Signature=1 (blob offset 1 — GENERICINST of TypeRef row 1
 ///                over one STRING argument, i.e. `IVector<String>`).
 private enum GenericBaseFixture {
   private static let bytes: Array<UInt8> = [
     // TypeRef[0]: ResolutionScope, TypeName=4, TypeNamespace=1.
     0x00, 0x00, 0x04, 0x00, 0x01, 0x00,
-    // TypeDef[0]: Flags, TypeName=14, TypeNamespace=1, Extends, FieldList,
+    // TypeRef[1]: ResolutionScope, TypeName=55, TypeNamespace=21.
+    0x00, 0x00, 0x37, 0x00, 0x15, 0x00,
+    // TypeDef[0]: Flags=0x20, TypeName=14, TypeNamespace=1, Extends, FieldList,
     // MethodList.
-    0x00, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x01, 0x00,
+    0x20, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x01, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     // InterfaceImpl[0]: Class=1, Interface=6.
     0x01, 0x00, 0x06, 0x00,
+    // MemberRef[0]: Class=0x11, Name, Signature.
+    0x11, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]: Parent=0x23, Type=0x0b, Value=7.
+    0x23, 0x00, 0x0b, 0x00, 0x07, 0x00,
     // TypeSpec[0]: Signature=1.
     0x01, 0x00,
   ]
 
-  // "\0NS\0IVector`1\0Widget\0": NS@1, IVector`1@4, Widget@14.
+  // "\0NS\0IVector`1\0Widget\0Windows.Win32.Foundation.Metadata\0GuidAttribute
+  // \0": NS@1, IVector`1@4, Widget@14, GuidNamespace@21, GuidName@55.
   private static let strings: Array<UInt8> = [
     0x00,
     0x4e, 0x53, 0x00,
     0x49, 0x56, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x60, 0x31, 0x00,
     0x57, 0x69, 0x64, 0x67, 0x65, 0x74, 0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
   ]
 
-  // The blob heap: the empty blob at 0, then one length-prefixed signature.
+  // The blob heap: the empty blob at 0, then one length-prefixed signature,
+  // then the `GuidAttribute` value.
   //   @1: [0x05] GENERICINST(0x15) CLASS(0x12) TypeRef#1(token 0x05) 1 arg
   //       STRING(0x0e) — `IVector<String>`, its base TypeRef row 1.
+  //   @7: [0x14] the 20-byte GuidAttribute value — prolog 0x0001, an all-zero
+  //       placeholder GUID, then NumNamed 0. The render's generic-omitting path
+  //       ignores the iid, so the value is a placeholder.
   private static let blob: Array<UInt8> = [
     0x00,
     0x05, 0x15, 0x12, 0x05, 0x01, 0x0e,
+    0x14, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00,
   ]
 
   private static let empty = Array<UInt8>()
 
   private static let relations: Array<WinMD.Table> = [
-    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 2, range: 0 ..< 12,
                 wide: 0, stride: 6),
-    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 1, range: 6 ..< 20,
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 1, range: 12 ..< 26,
                 wide: 0, stride: 14),
-    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 20 ..< 24,
+    // An empty `MethodDef` (this fixture has no methods) so the render seed's
+    // `guid` fetch — whose `MethodDef`-ctor arm joins it — plans over a present
+    // relation rather than faulting on an absent one.
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 0, range: 44 ..< 44,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 26 ..< 30,
                 wide: 0, stride: 4),
-    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 1, range: 24 ..< 26,
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 30 ..< 36,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 36 ..< 42,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeSpec.self, rows: 1, range: 42 ..< 44,
                 wide: 0, stride: 2),
   ]
 
-  // TypeRef (#1), TypeDef (#2), InterfaceImpl (#9), TypeSpec (#27).
+  // TypeRef (#1), TypeDef (#2), MethodDef (#6), InterfaceImpl (#9),
+  // MemberRef (#10), CustomAttribute (#12), TypeSpec (#27).
   private static let valid: UInt64 =
-      (1 << 1) | (1 << 2) | (1 << 9) | (1 << 27)
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 9) | (1 << 10) | (1 << 12)
+          | (1 << 27)
 
   /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
   static func with(_ body: (borrowing Storage) throws -> Void) rethrows {

--- a/Tests/winmd-inspectTests/RenderSeedTests.swift
+++ b/Tests/winmd-inspectTests/RenderSeedTests.swift
@@ -1,0 +1,145 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+
+@testable import winmd_inspect
+@testable import SQLEngineWinMD
+
+import Mustache
+import SQLEngine
+@testable import WinMD
+import WinMDSynthesis
+
+/// Coverage of the render seed's membership: the flat render seeds from a
+/// name-filtered `TypeDef` scan (the `tdInterface` flag) and fetches each
+/// interface's `iid` through the seekable `guid` query, rather than
+/// materialising the `interfaces` view. The view INNER-joins the
+/// `GuidAttribute`, so a `tdInterface` `TypeDef` with no decodable
+/// `GuidAttribute` is absent from it and is not rendered; the seed must
+/// reproduce that exactly by dropping a guid-less interface. The fixture
+/// assembles two method-less `tdInterface` `TypeDef`s in namespace `NS` —
+/// `IHasGuid`, carrying a `GuidAttribute`, and `INoGuid`, carrying none — so a
+/// `*` render emits only `IHasGuid`, a named render of `INoGuid` raises
+/// `RenderError.interface` (the empty view names it none), and the emitted
+/// `@com(interface:)` spells the fetched IID.
+struct RenderSeedTests {
+  // Seven tables packed back to back in table-number order — TypeRef (#1, 1
+  // row), TypeDef (#2, 2 rows), MethodDef (#6, empty), Param (#8, empty),
+  // InterfaceImpl (#9, empty), MemberRef (#10, 1 row), CustomAttribute (#12, 1
+  // row) — every index narrow (2-byte). ECMA-335 rows are 1-based; a coded
+  // index is `(row << bits) | tag`.
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IHasGuid"(52),
+  //                TypeNamespace="NS"(49), MethodList=1 — carries a GuidAttribute.
+  //   TypeDef[1]:  Flags=0x21, TypeName="INoGuid"(61), TypeNamespace="NS"(49),
+  //                MethodList=1 — carries no GuidAttribute, so the view drops it.
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+  //                `GuidAttribute` ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[1] — `IHasGuid`'s IID. `INoGuid` (row 2) has none.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeDef[0] (IHasGuid)
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[1] (INoGuid)
+    0x21, 0x00, 0x00, 0x00, 0x3d, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x01, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IHasGuid\0INoGuid\0":
+  // GuidNamespace@1, GuidName@35, NS@49, IHasGuid@52, INoGuid@61.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x48, 0x61, 0x73, 0x47, 0x75, 0x69, 0x64, 0x00,
+    0x49, 0x4e, 0x6f, 0x47, 0x75, 0x69, 0x64, 0x00,
+  ]
+
+  // The blob heap: offset 0 is the reserved empty blob; offset 1 is the 20-byte
+  // `GuidAttribute` value (prolog 0x0001, the well-known GUID
+  // `0C733A30-2A1C-11CE-ADE5-00AA0044773D`, then NumNamed 0), preceded by its
+  // length 0x14.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 34 ..< 40,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 40 ..< 46,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 10)
+          | (1 << 12)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `a * render drops a tdInterface bearing no GuidAttribute`() throws {
+    // The `interfaces` view INNER-joins the `GuidAttribute`, so `INoGuid` — a
+    // `tdInterface` `TypeDef` carrying none — is absent from it. The TypeDef
+    // scan finds both interfaces, but the seed fetches each `iid` and drops the
+    // one whose `guid` resolves nothing, so the `*` render emits only
+    // `IHasGuid`, its `@com(interface:)` spelling the fetched IID.
+    try RenderSeedTests.with { catalog in
+      let shell = Shell(catalog)
+      let rendered = try shell.render("*", template: "com")
+      #expect(rendered.contains("public protocol IHasGuid"))
+      #expect(!rendered.contains("public protocol INoGuid"))
+      #expect(rendered.contains("0C733A30-2A1C-11CE-ADE5-00AA0044773D"))
+    }
+  }
+
+  @Test func `a named render of a guid-less interface faults as unnamed`() throws {
+    // A named render of `INoGuid` resolves no seed (the view names it none), so
+    // it raises `RenderError.interface` exactly as a name no interface bears
+    // would — the seed's drop preserves the view's membership fault. `IHasGuid`,
+    // which carries a `GuidAttribute`, still renders.
+    try RenderSeedTests.with { catalog in
+      let shell = Shell(catalog)
+      #expect(throws: Shell.RenderError.interface("INoGuid")) {
+        try shell.render("INoGuid", template: "com")
+      }
+      let rendered = try shell.render("IHasGuid", template: "com")
+      #expect(rendered.contains("public protocol IHasGuid"))
+      #expect(rendered.contains("0C733A30-2A1C-11CE-ADE5-00AA0044773D"))
+    }
+  }
+}


### PR DESCRIPTION
The render seeded from the `interfaces` view (`WHERE TypeName = :name`), but the `:name` predicate does not push into that view — it materialises the whole three-way GuidAttribute UNION over CustomAttribute and decodes every interface's IID before filtering, so rendering one interface paid the cost of decoding them all (~3.4s on Windows.Win32.winmd, whether the target was one interface or `*`).

Seed instead from a filtered TypeDef scan
(`WHERE BITAND(Flags, 32) = 32 AND (TypeName = :name OR '*' = :name) ORDER BY Id`) and fetch each interface's IID by a per-Id GuidAttribute lookup (`guid.sql`, keyed `:parent`), which now seeks its CustomAttribute run since a bound integer `:parameter` equality reaches a base-scan seek. An interface whose GuidAttribute does not decode is dropped, reproducing the `interfaces` view's INNER join membership exactly (7925 interfaces, ascending Id — identical set and order). Output is byte-identical; a single-interface render drops from ~3.4s to milliseconds.

`guid.sql` is byte-identical to the one the signature-edge closure adds, so the two merge cleanly.

The four generic-interface render tests injected a synthetic interface by overriding the `interfaces` view (often with a placeholder iid, since a generic interface carries no static GuidAttribute). The seed reads the `TypeDef` table and `guid.sql` directly, bypassing that view, so it drops a synthetic interface the override named but storage cannot resolve. Make each synthetic interface seed-reachable instead: the shared generic fixture repoints its IID-bearing interface `TypeDef`'s name at the rendered name (appended to the string heap), and `GenericBaseFixture`'s `Widget` becomes a `tdInterface` `TypeDef` bearing a placeholder `GuidAttribute` (plus an empty `MethodDef` so the `guid` fetch's ctor arm plans). The `interfaces` overrides are dropped; the `methods`/`bases`/ `generics`/`params` overrides — which the seed does not bypass — and the asserted output stay unchanged. The generic branch emits no `@com(interface:)`, so a placeholder iid renders identically.