### PR TITLE
winmd-inspect: cache and batch whole-database render queries

### DIFF
--- a/Sources/SQLEngineWinMD/Database+SQL.swift
+++ b/Sources/SQLEngineWinMD/Database+SQL.swift
@@ -141,6 +141,18 @@ package struct Session: SQLEngine.Catalog, ~Escapable {
   /// The views the session has registered, keyed case-folded.
   package var registered: Dictionary<String, View>
 
+  /// The names of the views a session `CREATE VIEW` has registered this
+  /// session, keyed case-folded — the subset of `registered` the user authored,
+  /// distinct from the bundled seed. `registered` folds the two together (a
+  /// `CREATE VIEW` shadows a bundled view of the same name), so a caller that
+  /// must tell a user override of a bundled view (`methods`, `interfaces`, …)
+  /// apart from the seed reads this instead: `register(_:_:)` — the sole
+  /// `CREATE VIEW` path — records the name here, while the `init` seed writes
+  /// `registered` directly and leaves it empty. The `.render *` batch consults
+  /// it to fall back to the per-node emit when a batch-shortcut view is
+  /// overridden.
+  package private(set) var authored: Set<String> = []
+
   /// The routines the session resolves a call against — the WinMD-domain UDFs
   /// and the standard prelude (`Session.routines`), plus every scalar function a
   /// `CREATE FUNCTION` has defined this session. A `SELECT` and the schema
@@ -170,9 +182,12 @@ package struct Session: SQLEngine.Catalog, ~Escapable {
   }
 
   /// Registers `view` under `name` (case-folded, the way `view(named:)`
-  /// resolves it) — the `CREATE VIEW` path.
+  /// resolves it) — the `CREATE VIEW` path. The name is also recorded in
+  /// `authored`, so a user override of a bundled view is distinguishable from
+  /// the seed.
   package mutating func register(_ name: String, _ view: View) {
     registered[name.lowercased()] = view
+    authored.insert(name.lowercased())
   }
 
   /// Registers the defined scalar `function` under `name` (case-folded) into the

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -509,29 +509,61 @@ internal struct Shell: ~Escapable {
     // query, dropping a guid-less interface, so it reproduces the `interfaces`
     // view's rows without materialising the whole view. Choosing which rows to
     // emit is the seed's job, so render just iterates whatever it returns.
-    let interfaces = try seeds(interface, routines, search: search)
+    // The `*` batch reads raw tables and the `interfaces` view, bypassing the
+    // overridable per-node render queries (`methods`/`params`/`bases`/`guid`)
+    // and the `methods`/`params`/`bases` views they read. When any of those is
+    // overridden — a `-I` file or a session `CREATE VIEW` — the batch would
+    // ignore the override and `*` would diverge from `.render <interface>`, so
+    // `*` falls back to the per-node emit (which honours both override layers).
+    // A LATERAL batch that honoured the override was rejected: `:parent` lives
+    // inside the views, LATERAL cannot correlate a parameter, and a view-body
+    // LATERAL does not decorrelate. Overriding and rendering `*` is rare, so
+    // the fallback's per-node cost is acceptable; with nothing overridden the
+    // fast batch stands.
+    let batched = interface == "*" && !overridden(search: search)
+    let interfaces = try seeds(interface, routines, search: search,
+                               batch: batched)
     guard interface == "*" || !interfaces.isEmpty else {
       throw RenderError.interface(interface)
     }
 
     let mustache = try MustacheTemplate(string: body)
-    // For `*`, decode every interface's first plain base, its methods, and
-    // every method's parameters once (`inherits`/`roster`/`signatures`),
-    // bucketed by owner Id, rather than a `bases`/`methods` query per interface
-    // and a `params` query per method; a concrete render emits one interface,
-    // so it stays per-node. The maps only supply the same base name, method
-    // rows, and parameter rows the per-node queries would — the emit is
-    // otherwise unchanged.
-    let inherits = interface == "*" ? try self.inherits(routines) : nil
-    let roster = interface == "*" ? try self.roster(routines) : nil
-    let signatures = interface == "*" ? try self.signatures(routines) : nil
+    // For `*` with nothing overridden, decode every interface's first plain
+    // base, its methods, and every method's parameters once
+    // (`inherits`/`roster`/`signatures`), bucketed by owner Id, rather than a
+    // `bases`/`methods` query per interface and a `params` query per method; a
+    // concrete render emits one interface, so it stays per-node. The maps only
+    // supply the same base name and method/parameter rows the per-node queries
+    // would — the batch rows carrying raw names the emitted-only `sanitized` map
+    // escapes below — so the emit is otherwise unchanged. When a batch-shortcut
+    // query or view is overridden, the maps are `nil` so `emit` runs the
+    // per-node queries, honouring the override. An empty seed skips them too: a
+    // wildcard that matched no interface emits nothing, and these batches expand
+    // views over `InterfaceImpl`/`MethodDef`/`Param` a valid interface-free file
+    // may omit, so decoding them would fault where there is nothing to render.
+    let expand = batched && !interfaces.isEmpty
+    let inherits = expand ? try self.inherits(routines) : nil
+    let roster = expand ? try self.roster(routines) : nil
+    let signatures = expand ? try self.signatures(routines) : nil
+    // The batch scans carry raw names; escape only the emitted set through the
+    // active `SANITIZE` UDF in one query, keyed raw→escaped, so the emit spells
+    // an emitted name exactly as the per-node `SANITIZE(Name)` would while a
+    // custom UDF is never invoked on a non-emitted name. `nil` in the per-node
+    // path, whose `methods`/`params` queries `SANITIZE` their own rows.
+    let sanitized: Dictionary<String, String>?
+    if let roster, let signatures {
+      sanitized = try self.sanitized(interfaces, roster: roster,
+                                     signatures: signatures, routines)
+    } else {
+      sanitized = nil
+    }
     var sources = Array<String>()
     sources.reserveCapacity(interfaces.count)
     for found in interfaces {
       sources.append(try emit(found, through: mustache, routines: routines,
                               in: dialect, language: language, search: search,
                               inherits: inherits, roster: roster,
-                              signatures: signatures))
+                              signatures: signatures, sanitized: sanitized))
     }
     return sources.joined(separator: "\n")
   }
@@ -576,6 +608,61 @@ internal struct Shell: ~Escapable {
     return sources.joined(separator: "\n")
   }
 
+  /// Whether any render query or view the `.render *` batch shortcuts is
+  /// overridden — a `-I` file over one of them, or a session `CREATE VIEW` of
+  /// one of their names. When true, `.render *` abandons the batch (which reads
+  /// raw `MethodDef`/`Param`/`InterfaceImpl` and the `interfaces` view) for the
+  /// per-node emit, so it honours the override exactly as `.render <interface>`
+  /// does; when false the fast batch stands.
+  ///
+  /// The batch bypasses the per-node `methods`/`params`/`bases`/`guid` render
+  /// queries AND the `methods`/`params`/`bases` views those queries read, so an
+  /// override of any of them makes the batch and per-node paths diverge: a `-I`
+  /// directory carrying `Render/<name>.sql` (a render query) or
+  /// `Queries/<name>.sql` (a view), or a session `CREATE VIEW` of a view name.
+  /// The `interfaces` view is a batch shortcut too — `guids` reads it while the
+  /// per-node path reads `Render/guid.sql` — so its override counts as well.
+  /// Only these specific names trip the predicate: an unrelated `-I` directory
+  /// or a `CREATE VIEW myhelper` does not, so a session with no relevant
+  /// override keeps the fast batch.
+  private borrowing func overridden(search: Array<String>) -> Bool {
+    // A `-I` file over a batch-shortcut render query, shadowing the bundle.
+    // `interfaces` is the seed query itself: the batch assumes the stock
+    // interface-only seed, so overriding it (to name a type the bundled
+    // `interfaces` view's flag gate drops but the ungated per-node `guid.sql`
+    // resolves) must fall `*` back to per-node too.
+    for name in ["methods", "params", "bases", "guid", "interfaces"]
+    where Shell.shadowed(name, "sql", kind: "Render", search: search) {
+      return true
+    }
+    // A `-I` file over a batch-shortcut view, shadowing the bundle.
+    for name in ["methods", "params", "bases", "interfaces"]
+    where Shell.shadowed(name, "sql", kind: "Queries", search: search) {
+      return true
+    }
+    // A session `CREATE VIEW` of a batch-shortcut view name — a user override
+    // of the bundled view, told from the seed by `session.authored`.
+    for name in ["methods", "params", "bases", "interfaces"]
+    where session.authored.contains(name) {
+      return true
+    }
+    return false
+  }
+
+  /// Whether a search directory carries `<name>.<ext>` of the given `kind` — a
+  /// `-I` override shadowing the bundle, checked the same last-first way
+  /// `resource(_:_:kind:search:)` resolves it, but reporting only whether a
+  /// search dir (not the bundle) has it: a search-dir hit is the override the
+  /// `.render *` batch fallback keys off.
+  private static func shadowed(_ name: String, _ ext: String, kind: String,
+                               search: Array<String>) -> Bool {
+    for directory in search.reversed() {
+      let path = "\(directory)/\(kind)/\(name).\(ext)"
+      if FileManager.default.fileExists(atPath: path) { return true }
+    }
+    return false
+  }
+
   /// The seed rows for `name` — the interface `TypeDef` rows the render
   /// `interfaces` query scans — resolved to the full render row shape (`Id`,
   /// namespace, name, `iid`), dropping an interface whose `GuidAttribute`
@@ -595,7 +682,7 @@ internal struct Shell: ~Escapable {
   /// ascending-`Id` row order, so the emitted set and its order stay
   /// byte-identical.
   private borrowing func seeds(_ name: String, _ routines: Routines,
-                               search: Array<String>) throws
+                               search: Array<String>, batch: Bool = true) throws
       -> Array<Array<Value>> {
     let selection = try statement(named: "interfaces")
     let rows = try session.run(selection, routines,
@@ -606,8 +693,17 @@ internal struct Shell: ~Escapable {
     // per interface `Id`, so a lookup here returns exactly the iid a per-
     // interface `guid` query's `.first` would — the emit set and order still
     // come from the `interfaces` scan above (`ORDER BY Id`). A concrete seed
-    // stays per-node: it seeks one interface, not the whole view.
-    let iids = name == "*" ? try guids(routines) : nil
+    // stays per-node: it seeks one interface, not the whole view. When `batch`
+    // is false — an override makes the batch and per-node paths diverge, so `*`
+    // falls back to per-node — each `iid` is fetched through the per-interface
+    // `guid` query, which honours a `Render/guid.sql` override the batch view
+    // read would bypass. An empty scan skips the batch entirely: with no
+    // interface `TypeDef` to render there is no `iid` to look up, and expanding
+    // the `interfaces` view (a three-way UNION over `CustomAttribute`/
+    // `MemberRef`) would fault on a valid file that omits a relation the view
+    // reads but a file with no interfaces need not carry.
+    let iids = name == "*" && batch && !rows.isEmpty
+             ? try guids(routines) : nil
     var interfaces = Array<Array<Value>>()
     interfaces.reserveCapacity(rows.count)
     for row in rows {
@@ -672,16 +768,19 @@ internal struct Shell: ~Escapable {
   /// batch — the `.render *` path's replacement for the per-method `params`
   /// query.
   ///
-  /// It projects the same `Id`, `SANITIZE(Name)`, and `Sequence` the per-method
-  /// render query does — over the whole `Param` table at once, bucketed by the
-  /// owning `MethodDef` in table (declaration) order — so a method's parameter
-  /// list here is identical, row for row, to what its own `params` query
-  /// returns. The return pseudo-parameter (`Sequence = 0`) rides along and is
+  /// It projects the same `Id`, raw `Name`, and `Sequence` the per-method render
+  /// query reads — over the whole `Param` table at once, bucketed by the owning
+  /// `MethodDef` in table (declaration) order — so a method's parameter list
+  /// here is identical, row for row, to what its own `params` query returns. As
+  /// with `roster`, the name is raw, not `SANITIZE`d: this batch scans every
+  /// parameter, including those of methods `.render *` never emits, so escaping
+  /// is deferred to `sanitized(_:roster:signatures:_:)` over the emitted names
+  /// only. The return pseudo-parameter (`Sequence = 0`) rides along and is
   /// dropped by the caller's filter, exactly as in the per-method path; a `Param`
   /// row's `Id` is the signature position the caller decodes the type from.
   private borrowing func signatures(_ routines: Routines) throws -> Buckets {
     let batch = try Shell.statement("""
-      SELECT MethodDef, Id, SANITIZE(Name) AS Name, Sequence
+      SELECT MethodDef, Id, Name, Sequence
       FROM Param
       """)
     let rows = try session.run(batch, routines, bindings: [:])
@@ -696,15 +795,19 @@ internal struct Shell: ~Escapable {
   /// batch — the `.render *` path's replacement for the per-interface `methods`
   /// query.
   ///
-  /// It projects the same `Id` and `SANITIZE(Name)` the per-interface render
-  /// query does — over the whole `MethodDef` table at once, bucketed by the
-  /// owning `TypeDef` in table (declaration) order — so an interface's method
-  /// list here is identical, row for row, to what its own `methods` query
-  /// returns. A method's `Id` is the signature the caller decodes its return
-  /// and parameters from.
+  /// It projects the same `Id` and raw `Name` the per-interface render query
+  /// reads — over the whole `MethodDef` table at once, bucketed by the owning
+  /// `TypeDef` in table (declaration) order — so an interface's method list here
+  /// is identical, row for row, to what its own `methods` query returns. The
+  /// name is deliberately raw, not `SANITIZE`d: the per-node `methods` query
+  /// runs the UDF over its (emitted-only) rows, but this batch scans every
+  /// method, including methods of types `.render *` never emits — so escaping is
+  /// deferred to `sanitized(_:roster:signatures:_:)`, which runs the active UDF
+  /// over only the emitted names. A method's `Id` is the signature the caller
+  /// decodes its return and parameters from.
   private borrowing func roster(_ routines: Routines) throws -> Buckets {
     let batch = try Shell.statement("""
-      SELECT TypeDef, Id, SANITIZE(Name) AS Name
+      SELECT TypeDef, Id, Name
       FROM MethodDef
       """)
     let rows = try session.run(batch, routines, bindings: [:])
@@ -713,6 +816,63 @@ internal struct Shell: ~Escapable {
       roster[row[0].integer, default: []].append([row[1], row[2]])
     }
     return roster
+  }
+
+  /// The raw→escaped name map for exactly the emitted interfaces' method and
+  /// parameter names — the `.render *` batch's single application of the active
+  /// `SANITIZE` UDF, run over only the names that will be emitted.
+  ///
+  /// The batch `roster`/`signatures` scans carry raw names, so the UDF never
+  /// runs over a method or parameter of a type `.render *` does not emit (a
+  /// class, a guid-less interface). A session `CREATE FUNCTION SANITIZE` (or a
+  /// language-spec UDF) that is value-sensitive — one that would fault on such a
+  /// non-emitted name — therefore no longer aborts the render. The emitted names
+  /// are each emitted interface's methods (from `roster`) and those methods'
+  /// non-return (`Sequence != 0`) parameters (from `signatures`), deduped and
+  /// escaped through the same `routines` the per-node path resolves (a session
+  /// `CREATE FUNCTION SANITIZE` included), so an emitted name's escape is
+  /// byte-identical to the per-node path's. `interfaces` is the post-guid-drop
+  /// emitted set (`seeds`), so a guid-less interface — dropped in Swift — is
+  /// absent here even though its `TypeDef` bears the interface flag. An empty
+  /// emitted set runs no query.
+  private borrowing func sanitized(_ interfaces: Array<Array<Value>>,
+                                   roster: Buckets, signatures: Buckets,
+                                   _ routines: Routines) throws
+      -> Dictionary<String, String> {
+    var names = Set<String>()
+    for found in interfaces {
+      for method in roster[found[0].integer] ?? [] {
+        names.insert(method[1].text)
+        for parameter in signatures[method[0].integer] ?? []
+        where parameter[2] != .integer(0) {
+          names.insert(parameter[1].text)
+        }
+      }
+    }
+    guard !names.isEmpty else { return [:] }
+    // One `SELECT n, SANITIZE(n) FROM (VALUES …) AS t(n)` over the deduped
+    // emitted names — sorted for a deterministic query text — so the UDF runs
+    // exactly once per distinct emitted name. A name is a SQL string literal,
+    // so a contained `'` is doubled.
+    let tuples = names.sorted().map { "(\(Shell.literal($0)))" }
+        .joined(separator: ", ")
+    let batch = try Shell.statement(
+        "SELECT n, SANITIZE(n) FROM (VALUES \(tuples)) AS t(n)")
+    let rows = try session.run(batch, routines, bindings: [:])
+    var map = Dictionary<String, String>(minimumCapacity: rows.count)
+    for row in rows { map[row[0].text] = row[1].text }
+    return map
+  }
+
+  /// `text` as a single-quoted SQL string literal, a contained `'` doubled — so
+  /// a name spliced into a `VALUES` list stays one literal.
+  private static func literal(_ text: String) -> String {
+    var quoted = "'"
+    for character in text {
+      if character == "'" { quoted += "''" } else { quoted.append(character) }
+    }
+    quoted += "'"
+    return quoted
   }
 
   /// The interface `iid` the `TypeDef` at `id` bears through its
@@ -777,7 +937,8 @@ internal struct Shell: ~Escapable {
                               search: Array<String>,
                               inherits: Dictionary<Int, String>? = nil,
                               roster: Buckets? = nil,
-                              signatures: Buckets? = nil)
+                              signatures: Buckets? = nil,
+                              sanitized: Dictionary<String, String>? = nil)
       throws -> String {
     let id = found[0]
     // The interface's ordered declared generic-parameter names, through the
@@ -797,7 +958,7 @@ internal struct Shell: ~Escapable {
     let methods = try self.methods(of: id, routines, search: search,
                                    generics: generics, in: dialect,
                                    language: language, roster: roster,
-                                   signatures: signatures)
+                                   signatures: signatures, sanitized: sanitized)
     // The interface's named base, via the `bases` view bound by its `Id`. The
     // render query projects only the plain (`TypeRef`/`TypeDef`) bases, whose
     // simple `TypeName` is keyword-escaped here the way the interface's own
@@ -883,8 +1044,18 @@ internal struct Shell: ~Escapable {
                                  generics: Array<String>?, in dialect: Dialect,
                                  language: Language,
                                  roster: Buckets? = nil,
-                                 signatures: Buckets? = nil) throws
-      -> Array<Dictionary<String, Any>> {
+                                 signatures: Buckets? = nil,
+                                 sanitized: Dictionary<String, String>? = nil)
+      throws -> Array<Dictionary<String, Any>> {
+    // The batch scans (`roster`/`signatures`) carry raw names escaped through
+    // the emitted-only `sanitized` map; the per-node queries `SANITIZE` their
+    // own rows, so their names arrive already escaped. `escaped` bridges the
+    // two: it looks a name up in the batch map (present iff batching), else
+    // returns it unchanged — so a per-node name is spelled as-is and a batch
+    // name is escaped exactly as the per-node `SANITIZE(Name)` would spell it.
+    func escaped(_ raw: String) -> String {
+      sanitized.map { $0[raw] ?? raw } ?? raw
+    }
     // The interface's methods: from the batch `roster` map for `*`, else a
     // per-interface `methods` query. Both return the same `Id`/`Name` rows in
     // the same (declaration) order, so the emitted method list is unchanged.
@@ -911,9 +1082,10 @@ internal struct Shell: ~Escapable {
         session.storage.decode(parameter: $0[0].integer, generics: generics,
                                for: dialect) ?? ""
       }
-      let parameters = Shell.parameters(kept.map(\.[1].text), types: types)
+      let parameters = Shell.parameters(kept.map { escaped($0[1].text) },
+                                        types: types)
       var entry: Dictionary<String, Any> = [
-        "name": method[1].text,
+        "name": escaped(method[1].text),
         "params": parameters,
       ]
       let returned = session.storage.decode(return: method[0].integer,

--- a/Sources/winmd-inspect/Shell.swift
+++ b/Sources/winmd-inspect/Shell.swift
@@ -306,6 +306,22 @@ internal struct Shell: ~Escapable {
   /// earlier one and the bundle (the last `-I` wins).
   private let search: Array<String>
 
+  /// The parsed render queries memoised by name for the span of one render (see
+  /// `Cache`). Each `Render/<name>.sql` is loaded and parsed once per render,
+  /// then reused on every interface a `.render *` emits rather than re-loaded
+  /// and re-parsed per call. Each top-level render clears the memo first
+  /// (`queries.statements.removeAll()`), so a `-I`/`CREATE VIEW` override edited
+  /// between renders is re-resolved on the next render rather than served stale
+  /// from a shell-lifetime cache — while a `:parent`/`:name` binding still
+  /// varies per execution, so only the parse is shared, changing no result.
+  private let queries = Cache()
+
+  /// A batch decode bucketed by owning row `Id` — the `.render *` maps that
+  /// replace a per-owner query (`roster` for an interface's methods,
+  /// `signatures` for a method's parameters): each owner `Id` maps to the rows
+  /// its own per-owner query would return, in the same order.
+  private typealias Buckets = Dictionary<Int, Array<Array<Value>>>
+
   /// Opens a shell over `storage`, seeding the session's bundled views.
   /// `strict` defaults to the forgiving shell policy; an explicit batch passes
   /// `true`. `search` is the `-I` override directories, tried before the
@@ -454,6 +470,15 @@ internal struct Shell: ~Escapable {
   /// decided in Swift (`returned(_:)`) — neither is baked into the binary.
   internal borrowing func render(_ interface: String,
                                  template: String) throws -> String {
+    // Scope the parsed-query memo to this single render: clear it so every
+    // named query re-resolves its resource once here — picking up a `-I`
+    // `Render/<name>.sql`/`Queries/<name>.sql` override (or a `CREATE VIEW`)
+    // added or edited since the last render — then is reused within this
+    // render. The within-render dedup (the reason the memo exists — the `*`
+    // batch parses each query once) survives; only cross-render staleness,
+    // where an override edited between renders was silently ignored while
+    // templates and language specs reloaded, is dropped.
+    queries.statements.removeAll()
     // The template names its own target language through a leading `{{! language:
     // <name> }}` directive; stripping it yields the body and loads the matching
     // spec, whose render UDF (`SANITIZE`) makes identifier escaping the
@@ -490,11 +515,23 @@ internal struct Shell: ~Escapable {
     }
 
     let mustache = try MustacheTemplate(string: body)
+    // For `*`, decode every interface's first plain base, its methods, and
+    // every method's parameters once (`inherits`/`roster`/`signatures`),
+    // bucketed by owner Id, rather than a `bases`/`methods` query per interface
+    // and a `params` query per method; a concrete render emits one interface,
+    // so it stays per-node. The maps only supply the same base name, method
+    // rows, and parameter rows the per-node queries would — the emit is
+    // otherwise unchanged.
+    let inherits = interface == "*" ? try self.inherits(routines) : nil
+    let roster = interface == "*" ? try self.roster(routines) : nil
+    let signatures = interface == "*" ? try self.signatures(routines) : nil
     var sources = Array<String>()
     sources.reserveCapacity(interfaces.count)
     for found in interfaces {
       sources.append(try emit(found, through: mustache, routines: routines,
-                              in: dialect, language: language, search: search))
+                              in: dialect, language: language, search: search,
+                              inherits: inherits, roster: roster,
+                              signatures: signatures))
     }
     return sources.joined(separator: "\n")
   }
@@ -515,6 +552,10 @@ internal struct Shell: ~Escapable {
   /// runs, so the closure reuses the decode and emit rather than duplicating it.
   internal borrowing func render(closure root: String,
                                  template: String) throws -> String {
+    // Scope the parsed-query memo to this single render (see the flat render):
+    // clear it so each named query re-resolves its resource once, honouring an
+    // override edited since the last render, then is reused within this one.
+    queries.statements.removeAll()
     var body = try self.template(named: template, search: search)
     let language = Shell.language(declaredIn: &body, search: search)
     let routines = language.routines.merging(session.functions)
@@ -537,34 +578,141 @@ internal struct Shell: ~Escapable {
 
   /// The seed rows for `name` — the interface `TypeDef` rows the render
   /// `interfaces` query scans — resolved to the full render row shape (`Id`,
-  /// namespace, name, `iid`) by fetching each interface's `iid` through the
-  /// seekable `guid` query, dropping an interface whose `GuidAttribute` resolves
-  /// nothing.
+  /// namespace, name, `iid`), dropping an interface whose `GuidAttribute`
+  /// resolves nothing.
   ///
-  /// The scan replaces materialising the `interfaces` view (a three-way UNION
-  /// over the whole `CustomAttribute` table) for the one seed: the view's
-  /// `:name` predicate does not push into it, so it GUID-decodes every interface
-  /// before filtering. This seeks the `TypeDef` rows and fetches only the
-  /// matched interfaces' IIDs. Dropping a guid-less interface reproduces the
-  /// view's INNER-join membership exactly — a `tdInterface` `TypeDef` with no
-  /// decodable `GuidAttribute` is absent from the view and so is not rendered —
-  /// and the query's `ORDER BY Id` preserves the view's ascending-`Id` row
-  /// order, so the emitted set and its order stay byte-identical.
+  /// The scan seeks the interface `TypeDef` rows by name (`interfaces.sql`), and
+  /// the `iid` is fetched separately so a concrete seed does not materialise the
+  /// whole `interfaces` view (a three-way UNION over the whole `CustomAttribute`
+  /// table): the view's `:name` predicate does not push into it, so it
+  /// GUID-decodes every interface before filtering. A concrete seed fetches only
+  /// the matched interface's IID through the seekable `guid` query; `*`, which
+  /// needs them all, decodes them in one batch over the `interfaces` view
+  /// (`guids`) rather than a `guid` query per interface. Either way, dropping a
+  /// guid-less interface reproduces the view's INNER-join membership exactly — a
+  /// `tdInterface` `TypeDef` with no decodable `GuidAttribute` is absent and so
+  /// is not rendered — and the scan's `ORDER BY Id` preserves the view's
+  /// ascending-`Id` row order, so the emitted set and its order stay
+  /// byte-identical.
   private borrowing func seeds(_ name: String, _ routines: Routines,
                                search: Array<String>) throws
       -> Array<Array<Value>> {
-    let selection =
-        try Shell.statement(Shell.query(named: "interfaces", search: search))
+    let selection = try statement(named: "interfaces")
     let rows = try session.run(selection, routines,
                                bindings: ["name": .text(name)])
+    // For `*`, decode every interface's `iid` in one batch over the `interfaces`
+    // view rather than a `guid` query per interface. The view is the same
+    // three-arm `GuidAttribute` union in the same arm order and yields one row
+    // per interface `Id`, so a lookup here returns exactly the iid a per-
+    // interface `guid` query's `.first` would — the emit set and order still
+    // come from the `interfaces` scan above (`ORDER BY Id`). A concrete seed
+    // stays per-node: it seeks one interface, not the whole view.
+    let iids = name == "*" ? try guids(routines) : nil
     var interfaces = Array<Array<Value>>()
     interfaces.reserveCapacity(rows.count)
     for row in rows {
-      guard let iid = try guid(of: row[0], routines, search: search)
-      else { continue }
+      let iid = if let iids { iids[row[0].integer] }
+                else { try guid(of: row[0], routines, search: search) }
+      guard let iid else { continue }
       interfaces.append([row[0], row[1], row[2], .text(iid)])
     }
     return interfaces
+  }
+
+  /// Every interface's `iid`, keyed by its `TypeDef` `Id`, decoded in one batch
+  /// over the `interfaces` view — the `.render *` path's replacement for a
+  /// per-interface `guid` query.
+  ///
+  /// The view is the same three-arm `GuidAttribute` union in the same arm order
+  /// the per-interface `guid` query walks, and it yields one row per interface
+  /// (one iid per `Id`), so a lookup here returns exactly the iid that query's
+  /// `.first` would — decoding all interfaces once instead of thousands of
+  /// times. The first iid per `Id` is kept (defensively, though the view's Ids
+  /// are already distinct), matching the per-interface `.first`.
+  private borrowing func guids(_ routines: Routines) throws
+      -> Dictionary<Int, String> {
+    let batch = try Shell.statement("SELECT Id, iid FROM interfaces")
+    let rows = try session.run(batch, routines, bindings: [:])
+    var iids = Dictionary<Int, String>(minimumCapacity: rows.count)
+    for row in rows where iids[row[0].integer] == nil {
+      iids[row[0].integer] = row[1].text
+    }
+    return iids
+  }
+
+  /// Every interface's first plain (`TypeRef`/`TypeDef`) base interface name,
+  /// keyed by its `TypeDef` `Id`, decoded in one batch — the `.render *` path's
+  /// replacement for the per-interface `bases` query.
+  ///
+  /// It mirrors the two plain (`spec IS NULL`) arms of the `bases` view over
+  /// every `InterfaceImpl` at once, in the same arm order (a `TypeRef` base
+  /// before a `TypeDef` one), keeping the first base per interface `Id` —
+  /// exactly the `bases.first` the per-interface render query yields. A generic
+  /// (`TypeSpec`) base is excluded here as the render's `spec IS NULL` excludes
+  /// it there, so the emitted inheritance is unchanged. `i.Class` is the
+  /// interface's own 1-based `Id` (a simple index, stored directly).
+  private borrowing func inherits(_ routines: Routines) throws
+      -> Dictionary<Int, String> {
+    let batch = try Shell.statement("""
+      SELECT i.Class AS parent, b.TypeName AS base
+      FROM InterfaceImpl i JOIN TypeRef b ON i.Interface_TypeRef = b.Id
+      UNION
+      SELECT i.Class AS parent, d.TypeName AS base
+      FROM InterfaceImpl i JOIN TypeDef d ON i.Interface_TypeDef = d.Id
+      """)
+    let rows = try session.run(batch, routines, bindings: [:])
+    var inherits = Dictionary<Int, String>(minimumCapacity: rows.count)
+    for row in rows where inherits[row[0].integer] == nil {
+      inherits[row[0].integer] = row[1].text
+    }
+    return inherits
+  }
+
+  /// Every method's parameters, keyed by its `MethodDef` `Id`, decoded in one
+  /// batch — the `.render *` path's replacement for the per-method `params`
+  /// query.
+  ///
+  /// It projects the same `Id`, `SANITIZE(Name)`, and `Sequence` the per-method
+  /// render query does — over the whole `Param` table at once, bucketed by the
+  /// owning `MethodDef` in table (declaration) order — so a method's parameter
+  /// list here is identical, row for row, to what its own `params` query
+  /// returns. The return pseudo-parameter (`Sequence = 0`) rides along and is
+  /// dropped by the caller's filter, exactly as in the per-method path; a `Param`
+  /// row's `Id` is the signature position the caller decodes the type from.
+  private borrowing func signatures(_ routines: Routines) throws -> Buckets {
+    let batch = try Shell.statement("""
+      SELECT MethodDef, Id, SANITIZE(Name) AS Name, Sequence
+      FROM Param
+      """)
+    let rows = try session.run(batch, routines, bindings: [:])
+    var signatures = Buckets()
+    for row in rows {
+      signatures[row[0].integer, default: []].append([row[1], row[2], row[3]])
+    }
+    return signatures
+  }
+
+  /// Every interface's methods, keyed by its `TypeDef` `Id`, decoded in one
+  /// batch — the `.render *` path's replacement for the per-interface `methods`
+  /// query.
+  ///
+  /// It projects the same `Id` and `SANITIZE(Name)` the per-interface render
+  /// query does — over the whole `MethodDef` table at once, bucketed by the
+  /// owning `TypeDef` in table (declaration) order — so an interface's method
+  /// list here is identical, row for row, to what its own `methods` query
+  /// returns. A method's `Id` is the signature the caller decodes its return
+  /// and parameters from.
+  private borrowing func roster(_ routines: Routines) throws -> Buckets {
+    let batch = try Shell.statement("""
+      SELECT TypeDef, Id, SANITIZE(Name) AS Name
+      FROM MethodDef
+      """)
+    let rows = try session.run(batch, routines, bindings: [:])
+    var roster = Buckets()
+    for row in rows {
+      roster[row[0].integer, default: []].append([row[1], row[2]])
+    }
+    return roster
   }
 
   /// The interface `iid` the `TypeDef` at `id` bears through its
@@ -576,8 +724,7 @@ internal struct Shell: ~Escapable {
   /// INNER-join membership.
   private borrowing func guid(of id: Value, _ routines: Routines,
                               search: Array<String>) throws -> String? {
-    let query =
-        try Shell.statement(Shell.query(named: "guid", search: search))
+    let query = try statement(named: "guid")
     let rows = try session.run(query, routines, bindings: ["parent": id])
     return rows.first.map { $0[0].text }
   }
@@ -600,8 +747,7 @@ internal struct Shell: ~Escapable {
                               language: Language,
                               search: Array<String>) throws {
     guard visited.insert(found[0].integer).inserted else { return }
-    let query =
-        try Shell.statement(Shell.query(named: "requires", search: search))
+    let query = try statement(named: "requires")
     let bases = try session.run(query, routines,
                                 bindings: ["parent": found[0]])
     let ordered = bases.sorted {
@@ -628,7 +774,11 @@ internal struct Shell: ~Escapable {
                               through mustache: MustacheTemplate,
                               routines: Routines, in dialect: Dialect,
                               language: Language,
-                              search: Array<String>) throws -> String {
+                              search: Array<String>,
+                              inherits: Dictionary<Int, String>? = nil,
+                              roster: Buckets? = nil,
+                              signatures: Buckets? = nil)
+      throws -> String {
     let id = found[0]
     // The interface's ordered declared generic-parameter names, through the
     // `generics` view bound by its `Id` — empty for a non-generic interface.
@@ -646,7 +796,8 @@ internal struct Shell: ~Escapable {
     // the wrapper is a follow-up.
     let methods = try self.methods(of: id, routines, search: search,
                                    generics: generics, in: dialect,
-                                   language: language)
+                                   language: language, roster: roster,
+                                   signatures: signatures)
     // The interface's named base, via the `bases` view bound by its `Id`. The
     // render query projects only the plain (`TypeRef`/`TypeDef`) bases, whose
     // simple `TypeName` is keyword-escaped here the way the interface's own
@@ -655,11 +806,19 @@ internal struct Shell: ~Escapable {
     // projection redesign. A rootless interface defaults to the spec's COM
     // root, except the root interface itself — which inherits nothing, so it
     // never becomes its own base; an empty `root` applies no default.
-    let lineage =
-        try Shell.statement(Shell.query(named: "bases", search: search))
-    let bases = try session.run(lineage, routines, bindings: ["parent": id])
-    let base: String? = if let inherited = bases.first {
-      language.escape(inherited[0].text)
+    // The first plain base name: from the batch `inherits` map for `*`, else a
+    // per-interface `bases` query (the concrete/closure seed). Both yield the
+    // same first `spec IS NULL` base — the batch mirrors the two plain arms of
+    // the `bases` view in the same arm order — so the emitted inheritance stays
+    // byte-identical.
+    let inherited: String? = if let inherits {
+      inherits[id.integer]
+    } else {
+      try session.run(statement(named: "bases"), routines,
+                      bindings: ["parent": id]).first?[0].text
+    }
+    let base: String? = if let inherited {
+      language.escape(inherited)
     } else if language.root.isEmpty || found[2].text == language.root {
       nil
     } else {
@@ -722,18 +881,31 @@ internal struct Shell: ~Escapable {
   private borrowing func methods(of id: Value, _ routines: Routines,
                                  search: Array<String>,
                                  generics: Array<String>?, in dialect: Dialect,
-                                 language: Language) throws
+                                 language: Language,
+                                 roster: Buckets? = nil,
+                                 signatures: Buckets? = nil) throws
       -> Array<Dictionary<String, Any>> {
-    let plan =
-        try Shell.statement(Shell.query(named: "methods", search: search))
-    let rows = try session.run(plan, routines, bindings: ["parent": id])
+    // The interface's methods: from the batch `roster` map for `*`, else a
+    // per-interface `methods` query. Both return the same `Id`/`Name` rows in
+    // the same (declaration) order, so the emitted method list is unchanged.
+    let rows = if let roster {
+      roster[id.integer] ?? []
+    } else {
+      try session.run(statement(named: "methods"), routines,
+                      bindings: ["parent": id])
+    }
     var methods = Array<Dictionary<String, Any>>()
     methods.reserveCapacity(rows.count)
     for method in rows {
-      let selection = try Shell.statement(Shell.query(named: "params",
-                                                   search: search))
-      let params = try session.run(selection, routines,
-                                   bindings: ["parent": method[0]])
+      // The method's parameters: from the batch `signatures` map for `*`, else
+      // a per-method `params` query. Both return the same rows in the same
+      // (declaration) order, so the decoded parameter list is unchanged.
+      let params = if let signatures {
+        signatures[method[0].integer] ?? []
+      } else {
+        try session.run(statement(named: "params"), routines,
+                        bindings: ["parent": method[0]])
+      }
       let kept = params.filter { $0[2] != .integer(0) }
       let types = kept.map {
         session.storage.decode(parameter: $0[0].integer, generics: generics,
@@ -815,8 +987,7 @@ internal struct Shell: ~Escapable {
                                       search: Array<String>) throws
       -> Array<String> {
     if session.storage.opened("GenericParam") == nil { return [] }
-    let clause =
-        try Shell.statement(Shell.query(named: "generics", search: search))
+    let clause = try statement(named: "generics")
     let declared = try session.run(clause, routines, bindings: ["parent": id])
     return declared.map(\.first!.text)
   }
@@ -933,6 +1104,25 @@ internal struct Shell: ~Escapable {
     }
   }
 
+  /// The parsed render query named `name`, memoised in `queries`: on the first
+  /// request within a render it loads the resource (a `-I` directory's
+  /// `Render/<name>.sql` then the bundle) and parses it, and on every later one
+  /// in that render it returns the cached `Statement`. A `.render *` runs each
+  /// query once per interface — thousands of times — yet the text never changes
+  /// within a render, so re-loading and re-parsing it per call was pure
+  /// repetition; the parse now happens once per name per render. The memo is
+  /// cleared at the start of each top-level render, so a resource edited between
+  /// renders is re-resolved rather than served stale. Only the parse is shared:
+  /// each execution still binds fresh `:parent`/`:name` values, so the memo
+  /// changes no result.
+  private borrowing func statement(named name: String) throws
+      -> SQLEngine.Statement {
+    if let cached = queries.statements[name] { return cached }
+    let parsed = try Shell.statement(Shell.query(named: name, search: search))
+    queries.statements[name] = parsed
+    return parsed
+  }
+
   /// The target-language spec a template body declares, consuming its leading
   /// `{{! language: <name> }}` directive.
   ///
@@ -971,6 +1161,15 @@ internal struct Shell: ~Escapable {
     }
     return Language(parsing: String(decoding: data, as: UTF8.self))
   }
+}
+
+/// A per-render memo of parsed render queries, keyed by name. A reference type
+/// so a `borrowing` render method populates it (and clears it at each render's
+/// start) through the reference; it holds only value-type `Statement`s,
+/// borrowing none of the database storage, so a `~Escapable` `Shell` may own it.
+private final class Cache {
+  /// The parsed render queries loaded so far, keyed by name.
+  var statements: Dictionary<String, SQLEngine.Statement> = [:]
 }
 
 /// Locates resource `<name>.<ext>` of the given `kind` (`Render`, `Queries`,

--- a/SwiftSQL/Sources/SQLEngine/Engine.swift
+++ b/SwiftSQL/Sources/SQLEngine/Engine.swift
@@ -148,8 +148,17 @@ extension Catalog where Self: ~Escapable {
     // reads those rows and runs the `.window` over the lone grouped arm. Both
     // forks decide the single-arm shape by one predicate, so a future routing
     // change cannot handle the multi-arm case yet miss the single arm.
-    if let union = try query.union(windowed: context.routines,
-                                   schemas: schemas(context.relations)) {
+    //
+    // Gate the `union(windowed:)` consult on the cheap structural `unioned`
+    // predicate first: `union(windowed:)` itself returns nil for any query that
+    // is not a multi-set windowed grouping-sets select, and building `schemas`
+    // over every base relation (each resolved by name, its columns and virtuals
+    // reflected) is the dominant per-run cost. A non-`unioned` query — every
+    // ordinary SELECT/UNION the engine runs — skips that build entirely and
+    // takes the plain execute below, unchanged in result.
+    if query.unioned,
+        let union = try query.union(windowed: context.routines,
+                                    schemas: schemas(context.relations)) {
       return try execute(plan, carrying: union, augmented.revealed())
           .map(\.values)
     }

--- a/SwiftSQL/Sources/SQLEngine/Filter.swift
+++ b/SwiftSQL/Sources/SQLEngine/Filter.swift
@@ -1362,8 +1362,14 @@ extension Catalog where Self: ~Escapable {
     // re-materialises its schema-only derived layer — the parity a top-level
     // `run` gets. Without this a correlated windowed grouping-sets body scanned
     // the schema-only source once, dropping the arm rows.
-    if let union = try key.query.union(windowed: context.routines,
-                                       schemas: schemas(context.relations)) {
+    // Gate on the cheap structural `unioned` predicate first: `union(windowed:)`
+    // returns nil for any non-windowed-grouping-sets body, and building
+    // `schemas` over every base relation to feed it is the dominant per-row
+    // cost of a correlated subquery. An ordinary subquery body skips the build
+    // and takes the plain descent below, unchanged in result.
+    if key.query.unioned,
+        let union = try key.query.union(windowed: context.routines,
+                                        schemas: schemas(context.relations)) {
       return try execute(plan, carrying: union, context.revealed())
     }
     // A SET-operation subquery augments per ARM (arm-local derived aliases the
@@ -1492,9 +1498,12 @@ extension Catalog where Self: ~Escapable {
     // descends it carrier-aware over a `revealed()` context, per-arm
     // re-materialising its schema-only derived layer — the parity a top-level
     // `run` gets. Without this a `(windowed grouping-sets) UNION …` arm scanned
-    // the schema-only source once, dropping its per-group rows.
-    if let union = try query.union(windowed: context.routines,
-                                   schemas: schemas(context.relations)) {
+    // the schema-only source once, dropping its per-group rows. Gate on the
+    // cheap structural `unioned` predicate first, so an ordinary arm skips the
+    // per-relation `schemas` build `union(windowed:)` would otherwise force.
+    if query.unioned,
+        let union = try query.union(windowed: context.routines,
+                                    schemas: schemas(context.relations)) {
       return try execute(plan, carrying: union, context.revealed())
     }
     // An arm that is itself a suffix-bearing parenthesised set operation

--- a/SwiftSQL/Sources/SQLEngine/Interpreter.swift
+++ b/SwiftSQL/Sources/SQLEngine/Interpreter.swift
@@ -1039,7 +1039,13 @@ extension Catalog where Self: ~Escapable {
     }
     let rows: Array<Record>
     let view = resolve(view: name)
-    if let view,
+    // Gate the `union(windowed:)` consult on the cheap structural `unioned`
+    // predicate (as the top-level `run` does): only a multi-set windowed
+    // grouping-sets view body needs the arm-union recovery, and building
+    // `schemas` over every base relation to feed it is the dominant per-derive
+    // cost. An ordinary view body skips that build and derives through the
+    // plain branches below, unchanged in result.
+    if let view, view.query.unioned,
         let union = try view.query.union(windowed: context.routines,
                                          schemas: schemas(overlay.relations)) {
       // A windowed `GROUP BY GROUPING SETS` view body keeps a `.select` body
@@ -1138,9 +1144,12 @@ extension Catalog where Self: ~Escapable {
     // descends it carrier-aware over the `overlay` revealed, per-arm
     // re-materialising its schema-only derived layer. Without this a view body
     // `(windowed grouping-sets) UNION …` scanned the schema-only source once,
-    // dropping its per-group rows.
-    if let union = try query.union(windowed: overlay.routines,
-                                   schemas: schemas(overlay.relations)) {
+    // dropping its per-group rows. Gate on the cheap structural `unioned`
+    // predicate first, so an ordinary arm skips the per-relation `schemas`
+    // build `union(windowed:)` would otherwise force.
+    if query.unioned,
+        let union = try query.union(windowed: overlay.routines,
+                                    schemas: schemas(overlay.relations)) {
       return try execute(plan, carrying: union, overlay.revealed())
     }
     if case let .setop(kind, left, right, all, types, _) = plan,

--- a/Tests/winmd-inspectTests/RenderOverrideTests.swift
+++ b/Tests/winmd-inspectTests/RenderOverrideTests.swift
@@ -1,0 +1,633 @@
+// Copyright © 2026 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import Testing
+
+@testable import winmd_inspect
+@testable import SQLEngineWinMD
+
+import Mustache
+import SQLEngine
+@testable import WinMD
+import WinMDSynthesis
+
+import class Foundation.FileManager
+import struct Foundation.Data
+import struct Foundation.URL
+import struct Foundation.UUID
+
+/// Coverage of the `.render *` override fallback: the flat render's batch reads
+/// raw tables and the `interfaces` view, bypassing the overridable per-node
+/// `methods`/`params`/`bases`/`guid` render queries and the
+/// `methods`/`params`/`bases` views they read. So an override honoured by
+/// `.render <interface>` — which runs the per-node queries — was silently
+/// ignored by `.render *`, whose batch shortcut divergently emitted the
+/// un-overridden surface. The fix detects an override (a `-I` file or a session
+/// `CREATE VIEW` of one of those names) and, for `*`, falls back to the same
+/// per-node emit, so `*` and the per-interface renders stay identical.
+///
+/// The fixture assembles two COM interfaces — `IBase` and `IDerived`, each
+/// carrying a `GuidAttribute` (so the `interfaces` view names both), with an
+/// `InterfaceImpl` naming `IDerived`'s base as the local `IBase` `TypeDef` — so
+/// the `bases` layer has an observable row (`IDerived`'s base) to override. An
+/// override that renames that base to `IOverridden` diverges the batch (which
+/// reads the raw `InterfaceImpl`) from the per-node path (which reads the
+/// overridden `bases`) — the exact bug — and the assertion is that `*` matches
+/// the concatenation of the per-interface renders.
+struct RenderOverrideTests {
+  // Five narrow (all-index 2-byte) tables packed back to back in table-number
+  // order — TypeRef (#1, 1 row), TypeDef (#2, 2 rows), InterfaceImpl (#9, 1
+  // row), MemberRef (#10, 1 row), CustomAttribute (#12, 2 rows) — plus empty
+  // MethodDef (#6) and Param (#8) tables so the `methods` view resolves a
+  // relation. ECMA-335 rows are 1-based; a coded index is `(row << bits) | tag`.
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IBase"(52),
+  //                TypeNamespace="NS"(49), MethodList=1 (empty) — the base.
+  //   TypeDef[1]:  Flags=0x21, TypeName="IDerived"(58), TypeNamespace="NS"(49),
+  //                MethodList=1 (empty) — the refiner.
+  //   InterfaceImpl[0]: Class=2 (TypeDef row 2, IDerived),
+  //                Interface=TypeDefOrRef(TypeDef row 1)=(1<<2)|0=4 — names the
+  //                local base `IBase`.
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+  //                `GuidAttribute` ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[1] — `IBase`'s IID.
+  //   CustomAttribute[1]: Parent=HasCustomAttribute(TypeDef row 2)=(2<<5)|3=67,
+  //                Type=11, Value=blob[1] — `IDerived`'s IID.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0]
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeDef[0] (IBase)
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[1] (IDerived)
+    0x21, 0x00, 0x00, 0x00, 0x3a, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // InterfaceImpl[0]
+    0x02, 0x00, 0x04, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x01, 0x00,
+    // CustomAttribute[1]
+    0x43, 0x00, 0x0b, 0x00, 0x01, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IBase\0IDerived\0":
+  // GuidNamespace@1, GuidName@35, NS@49, IBase@52, IDerived@58.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x42, 0x61, 0x73, 0x65, 0x00,
+    0x49, 0x44, 0x65, 0x72, 0x69, 0x76, 0x65, 0x64, 0x00,
+  ]
+
+  // The blob heap: offset 0 is the reserved empty blob; offset 1 is the 20-byte
+  // `GuidAttribute` value (prolog 0x0001, the well-known GUID
+  // `0C733A30-2A1C-11CE-ADE5-00AA0044773D`, then NumNamed 0), preceded by its
+  // length 0x14. Both interfaces name it, so both carry the same IID.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 34 ..< 34,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 1, range: 34 ..< 38,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 38 ..< 44,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 2, range: 44 ..< 56,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 10)
+          | (1 << 12)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  /// `fileprivate` so `RenderCacheTests` reuses this fixture's `IBase`/`IDerived`
+  /// pair (with its observable `bases` row).
+  fileprivate static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  /// Runs `body` with the path of a fresh temporary directory that exists for
+  /// the call and is removed after — the `-I` search directory a file override
+  /// test seeds. `fileprivate` so `RenderCacheTests` reuses it.
+  fileprivate static func withDirectory(_ body: (String) throws -> Void)
+      rethrows {
+    let manager = FileManager.default
+    let directory =
+        manager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try? manager.createDirectory(at: directory,
+                                 withIntermediateDirectories: true)
+    defer { try? manager.removeItem(at: directory) }
+    try body(directory.path)
+  }
+
+  @Test func `* honours a CREATE VIEW override, matching the per-interface renders`() throws {
+    // A session `CREATE VIEW bases` renames `IDerived`'s base to `IOverridden`.
+    // `.render <interface>` runs the per-node `bases` query and honours it; the
+    // pre-fix `.render *` batch read the raw `InterfaceImpl` and emitted the
+    // original `IBase`, diverging. The fix detects the override and falls the
+    // `*` path back to the per-node emit, so `*` equals the concatenation of
+    // the per-interface renders (the seed order — ascending `Id` — is `IBase`
+    // then `IDerived`).
+    try RenderOverrideTests.with { catalog in
+      var shell = Shell(catalog)
+      try shell.execute("""
+        CREATE VIEW bases AS
+        SELECT 'IOverridden' AS base, NULL AS spec
+        FROM InterfaceImpl WHERE Class = :parent
+        """)
+      let star = try shell.render("*", template: "com")
+      let base = try shell.render("IBase", template: "com")
+      let derived = try shell.render("IDerived", template: "com")
+      #expect(star == [base, derived].joined(separator: "\n"))
+      // The override is honoured by `*`: the renamed base appears, the original
+      // does not.
+      #expect(star.contains("public protocol IDerived: IOverridden {"))
+      #expect(!star.contains("public protocol IDerived: IBase {"))
+    }
+  }
+
+  @Test func `* honours a -I file override, matching the per-interface renders`() throws {
+    // A `-I` directory carrying `Render/bases.sql` overrides the per-node base
+    // query to rename `IDerived`'s base to `IOverridden`. As with the session
+    // override, `.render <interface>` honours it while the pre-fix `.render *`
+    // batch ignored it; the fix detects the shadowing file and falls `*` back
+    // to the per-node emit, so `*` equals the concatenation of the
+    // per-interface renders.
+    try RenderOverrideTests.withDirectory { directory in
+      let manager = FileManager.default
+      let render = URL(fileURLWithPath: "\(directory)/Render")
+      try manager.createDirectory(at: render, withIntermediateDirectories: true)
+      let override = """
+        SELECT 'IOverridden' AS base
+        FROM InterfaceImpl WHERE Class = :parent
+        """
+      try Data(override.utf8)
+          .write(to: render.appendingPathComponent("bases.sql"))
+      try RenderOverrideTests.with { catalog in
+        let shell = Shell(catalog, search: [directory])
+        let star = try shell.render("*", template: "com")
+        let base = try shell.render("IBase", template: "com")
+        let derived = try shell.render("IDerived", template: "com")
+        #expect(star == [base, derived].joined(separator: "\n"))
+        #expect(star.contains("public protocol IDerived: IOverridden {"))
+        #expect(!star.contains("public protocol IDerived: IBase {"))
+      }
+    }
+  }
+
+  @Test func `* keeps the fast batch when nothing is overridden`() throws {
+    // With no override the detection predicate is false, so `*` stays batched.
+    // The batch and per-node paths still agree — `*` equals the concatenation
+    // of the per-interface renders — and the un-overridden base (`IBase`) is
+    // the one emitted.
+    try RenderOverrideTests.with { catalog in
+      let shell = Shell(catalog)
+      let star = try shell.render("*", template: "com")
+      let base = try shell.render("IBase", template: "com")
+      let derived = try shell.render("IDerived", template: "com")
+      #expect(star == [base, derived].joined(separator: "\n"))
+      #expect(star.contains("public protocol IDerived: IBase {"))
+      #expect(!star.contains("IOverridden"))
+    }
+  }
+}
+
+/// Coverage of the seed query (`Render/interfaces.sql`) as a batch-shortcut
+/// override the `.render *` fallback must honour. The batch derives each iid
+/// from the bundled `interfaces` view, whose three-arm union gates on
+/// `BITAND(Flags, 32) = 32` (the `tdInterface` bit); the per-node path derives
+/// each iid from the ungated `Render/guid.sql`, which resolves any `TypeDef`
+/// bearing a decodable `GuidAttribute`. So an overridden seed that names a
+/// `TypeDef` without the interface flag — a COM delegate carrying a static IID —
+/// is emitted by `.render <name>` (the ungated per-node guid resolves it) yet
+/// was silently dropped by the pre-fix `.render *` batch (the flag-gated view's
+/// `guids` finds no iid for it, and the seed loop drops a guid-less row). The
+/// fix counts the seed's own name among the batch-shortcut render queries, so
+/// overriding it falls `*` back to the per-node emit and the two paths agree.
+///
+/// The fixture assembles one non-interface `TypeDef` — `Callback`, a `tdSealed`
+/// (`0x100`) type with no `tdInterface` bit — carrying a `GuidAttribute` through
+/// the `CustomAttribute` -> `MemberRef` -> `TypeRef` (`GuidAttribute`) chain the
+/// `interfaces` view and `guid.sql` both read. Because it lacks the flag, the
+/// bundled `interfaces` view (and thus the batch) never names it; only an
+/// overridden, ungated seed does.
+struct RenderSeedOverrideTests {
+  // Four narrow (all-index 2-byte) tables packed back to back in table-number
+  // order — TypeRef (#1, 1 row), TypeDef (#2, 1 row), MemberRef (#10, 1 row),
+  // CustomAttribute (#12, 1 row) — plus empty MethodDef (#6), Param (#8), and
+  // InterfaceImpl (#9) tables so the render's `methods`/`bases` views resolve a
+  // relation. ECMA-335 rows are 1-based; a coded index is `(row << bits) | tag`.
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeDef[0]:  Flags=0x100 (tdSealed, not tdInterface), TypeName=
+  //                "Callback"(52), TypeNamespace="NS"(49), MethodList=1 (empty)
+  //                — the guid-bearing non-interface the flag-gated view drops.
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+  //                `GuidAttribute` ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[1] — `Callback`'s IID.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0]
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeDef[0] (Callback, tdSealed 0x100 — no tdInterface bit 5)
+    0x00, 0x01, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x01, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0Callback\0":
+  // GuidNamespace@1, GuidName@35, NS@49, Callback@52.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x43, 0x61, 0x6c, 0x6c, 0x62, 0x61, 0x63, 0x6b, 0x00,
+  ]
+
+  // The blob heap: offset 0 is the reserved empty blob; offset 1 is the 20-byte
+  // `GuidAttribute` value (prolog 0x0001, the well-known GUID
+  // `0C733A30-2A1C-11CE-ADE5-00AA0044773D`, then NumNamed 0), preceded by its
+  // length 0x14.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 1, range: 6 ..< 20,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 0, range: 20 ..< 20,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 20 ..< 20,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 20 ..< 20,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 20 ..< 26,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 26 ..< 32,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 10)
+          | (1 << 12)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  /// Runs `body` with the path of a fresh temporary directory that exists for
+  /// the call and is removed after — the `-I` search directory the seed override
+  /// test seeds.
+  private static func withDirectory(_ body: (String) throws -> Void) rethrows {
+    let manager = FileManager.default
+    let directory =
+        manager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try? manager.createDirectory(at: directory,
+                                 withIntermediateDirectories: true)
+    defer { try? manager.removeItem(at: directory) }
+    try body(directory.path)
+  }
+
+  @Test func `* honours a seed override naming a guid-bearing non-interface`() throws {
+    // A `-I` directory carrying `Render/interfaces.sql` overrides the seed to
+    // name `Callback` by its own three-column (`Id`, `TypeNamespace`,
+    // `TypeName`) shape with no flag gate. `.render Callback` runs that seed and
+    // resolves its iid through the ungated per-node `guid.sql`, emitting it. The
+    // pre-fix `.render *` kept batching (the seed's own name was not a
+    // batch-shortcut trip), and the batch derives iids from the flag-gated
+    // `interfaces` view, which never names `Callback` — so the seed loop found
+    // no iid for it and dropped it. The fix counts the seed among the
+    // batch-shortcut render queries, so `*` falls back to the per-node emit and
+    // emits `Callback` exactly as the per-interface render does.
+    try RenderSeedOverrideTests.withDirectory { directory in
+      let manager = FileManager.default
+      let render = URL(fileURLWithPath: "\(directory)/Render")
+      try manager.createDirectory(at: render, withIntermediateDirectories: true)
+      let override = """
+        SELECT Id, TypeNamespace, TypeName
+        FROM TypeDef
+        WHERE TypeName = :name OR '*' = :name
+        ORDER BY Id
+        """
+      try Data(override.utf8)
+          .write(to: render.appendingPathComponent("interfaces.sql"))
+      try RenderSeedOverrideTests.with { catalog in
+        let shell = Shell(catalog, search: [directory])
+        let star = try shell.render("*", template: "com")
+        let callback = try shell.render("Callback", template: "com")
+        // `*` falls back to per-node and emits the guid-bearing non-interface,
+        // byte-identical to its per-interface render.
+        #expect(star == callback)
+        #expect(star.contains("public protocol Callback: IUnknown {"))
+        // The ungated per-node guid resolves the IID both paths spell.
+        #expect(star.contains(
+            "@com(interface: \"0C733A30-2A1C-11CE-ADE5-00AA0044773D\")"))
+      }
+    }
+  }
+}
+
+/// Coverage of the `.render *` batch SANITIZE scoping: the batch scans read raw
+/// `MethodDef`/`Param` names and escape only the emitted set through the active
+/// `SANITIZE` UDF in one query, so the UDF is never invoked over a method or
+/// parameter of a type `.render *` does not emit. Because `SANITIZE` is
+/// session-overridable (a `CREATE FUNCTION`), the pre-fix batch — which ran
+/// `SANITIZE(Name)` over every `MethodDef`/`Param` row — let a custom,
+/// value-sensitive `SANITIZE` faulting on a non-emitted name abort the whole
+/// render. The fix defers escaping to the emitted names only, matching the
+/// per-node path (which runs `SANITIZE` over its emitted rows alone).
+///
+/// The fixture assembles two `tdInterface` `TypeDef`s in namespace `NS` —
+/// `IHasGuid`, carrying a `GuidAttribute` (so it is emitted) and owning a method
+/// `Keep`, and `INoGuid`, carrying none (so the seed drops it) and owning a
+/// method `Boom`. A session `CREATE FUNCTION SANITIZE` faults (a runtime
+/// divide-by-zero) on the exact name `Boom` and is identity for every other
+/// name. A custom `SANITIZE` does not trip the override fallback, so the batch
+/// stays active — the exact scenario the bug bit — yet the fix escapes only
+/// `Keep` (the emitted method), never `Boom`, so `.render * com` succeeds.
+struct RenderSanitizeTests {
+  // Seven tables packed back to back in table-number order — TypeRef (#1, 1
+  // row), TypeDef (#2, 2 rows), MethodDef (#6, 2 rows), Param (#8, empty),
+  // InterfaceImpl (#9, empty), MemberRef (#10, 1 row), CustomAttribute (#12, 1
+  // row) — every index narrow (2-byte). ECMA-335 rows are 1-based; a coded
+  // index is `(row << bits) | tag`.
+  //
+  //   TypeRef[0]:  ResolutionScope=0, TypeName="GuidAttribute"(35),
+  //                TypeNamespace="Windows.Win32.Foundation.Metadata"(1).
+  //   TypeDef[0]:  Flags=0x21 (tdInterface), TypeName="IHasGuid"(52),
+  //                TypeNamespace="NS"(49), MethodList=1 — carries a GuidAttribute
+  //                and owns MethodDef row 1 (`Keep`); it is emitted.
+  //   TypeDef[1]:  Flags=0x21, TypeName="INoGuid"(61), TypeNamespace="NS"(49),
+  //                MethodList=2 — carries no GuidAttribute (dropped) and owns
+  //                MethodDef row 2 (`Boom`), a name `.render *` never emits.
+  //   MethodDef[0]: Name="Keep"(69), Signature=blob[0] (empty), ParamList=1 —
+  //                owned by TypeDef row 1 through the MethodList run [1, 2).
+  //   MethodDef[1]: Name="Boom"(74), Signature=blob[0], ParamList=1 — owned by
+  //                TypeDef row 2 through the run [2, end).
+  //   MemberRef[0]: Class=MemberRefParent(TypeRef row 1)=(1<<3)|1=9 — the
+  //                `GuidAttribute` ctor.
+  //   CustomAttribute[0]: Parent=HasCustomAttribute(TypeDef row 1)=(1<<5)|3=35,
+  //                Type=CustomAttributeType(MemberRef row 1)=(1<<3)|3=11,
+  //                Value=blob[1] — `IHasGuid`'s IID. `INoGuid` (row 2) has none.
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] (GuidAttribute)
+    0x00, 0x00, 0x23, 0x00, 0x01, 0x00,
+    // TypeDef[0] (IHasGuid, MethodList 1)
+    0x21, 0x00, 0x00, 0x00, 0x34, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // TypeDef[1] (INoGuid, MethodList 2)
+    0x21, 0x00, 0x00, 0x00, 0x3d, 0x00, 0x31, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x02, 0x00,
+    // MethodDef[0] (Keep, Signature blob[0], ParamList 1)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x45, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // MethodDef[1] (Boom, Signature blob[0], ParamList 1)
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x4a, 0x00, 0x00, 0x00, 0x01, 0x00,
+    // MemberRef[0]
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // CustomAttribute[0]
+    0x23, 0x00, 0x0b, 0x00, 0x01, 0x00,
+  ]
+
+  // "\0Windows.Win32.Foundation.Metadata\0GuidAttribute\0NS\0IHasGuid\0INoGuid
+  // \0Keep\0Boom\0": GuidNamespace@1, GuidName@35, NS@49, IHasGuid@52,
+  // INoGuid@61, Keep@69, Boom@74.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x57, 0x69, 0x6e, 0x64, 0x6f, 0x77, 0x73, 0x2e, 0x57, 0x69, 0x6e, 0x33,
+    0x32, 0x2e, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+    0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x00,
+    0x47, 0x75, 0x69, 0x64, 0x41, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
+    0x65, 0x00,
+    0x4e, 0x53, 0x00,
+    0x49, 0x48, 0x61, 0x73, 0x47, 0x75, 0x69, 0x64, 0x00,
+    0x49, 0x4e, 0x6f, 0x47, 0x75, 0x69, 0x64, 0x00,
+    0x4b, 0x65, 0x65, 0x70, 0x00,
+    0x42, 0x6f, 0x6f, 0x6d, 0x00,
+  ]
+
+  // The blob heap: offset 0 is the reserved empty blob; offset 1 is the 20-byte
+  // `GuidAttribute` value (prolog 0x0001, the well-known GUID
+  // `0C733A30-2A1C-11CE-ADE5-00AA0044773D`, then NumNamed 0), preceded by its
+  // length 0x14. A method's Signature is blob[0] (empty), so its return does not
+  // decode and it emits a `()` no-argument, no-return requirement.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x14, 0x01, 0x00, 0x30, 0x3a, 0x73, 0x0c, 0x1c, 0x2a, 0xce, 0x11,
+    0xad, 0xe5, 0x00, 0xaa, 0x00, 0x44, 0x77, 0x3d, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 2, range: 6 ..< 34,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.MethodDef.self, rows: 2, range: 34 ..< 62,
+                wide: 0, stride: 14),
+    WinMD.Table(Metadata.Tables.Param.self, rows: 0, range: 62 ..< 62,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.InterfaceImpl.self, rows: 0, range: 62 ..< 62,
+                wide: 0, stride: 4),
+    WinMD.Table(Metadata.Tables.MemberRef.self, rows: 1, range: 62 ..< 68,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.CustomAttribute.self, rows: 1, range: 68 ..< 74,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 =
+      (1 << 1) | (1 << 2) | (1 << 6) | (1 << 8) | (1 << 9) | (1 << 10)
+          | (1 << 12)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `* does not SANITIZE a non-emitted method name`() throws {
+    // A session `CREATE FUNCTION SANITIZE` faults (a value-dependent
+    // divide-by-zero, unfoldable, so it faults only at run time) on the exact
+    // name `Boom` and is identity otherwise. `Boom` belongs to `INoGuid`, a
+    // guid-less interface the seed drops, so it is never emitted. The pre-fix
+    // batch ran `SANITIZE(Name)` over every `MethodDef` row — including `Boom` —
+    // and aborted the whole render on the fault. The fix escapes only the
+    // emitted names, so `SANITIZE` runs over `Keep` (identity) and never over
+    // `Boom`, and `.render * com` succeeds — emitting `IHasGuid`'s `Keep`
+    // requirement and nothing of `INoGuid`.
+    try RenderSanitizeTests.with { catalog in
+      var shell = Shell(catalog)
+      try shell.execute("""
+        CREATE FUNCTION SANITIZE(n TEXT) RETURNS TEXT
+        AS CASE WHEN 1 / (CASE WHEN n = 'Boom' THEN 0 ELSE 1 END) = 1
+                THEN n ELSE n END
+        """)
+      let star = try shell.render("*", template: "com")
+      #expect(star.contains("public protocol IHasGuid"))
+      #expect(star.contains("func Keep()"))
+      // The fault-triggering non-emitted name is never SANITIZEd, so it — and
+      // its guid-less owner — is absent rather than aborting the render.
+      #expect(!star.contains("Boom"))
+      #expect(!star.contains("INoGuid"))
+    }
+  }
+}
+
+/// Coverage of the render query memo's scope: the parsed `Render/<name>.sql`
+/// queries were memoised for the shell's lifetime, so editing a `-I`
+/// `Render/<name>.sql` override between renders in one interactive shell had no
+/// effect — the second render served the stale parse — while templates and
+/// language specs reloaded per render, silently mixing fresh presentation with
+/// stale SQL. The fix clears the memo at the start of each top-level render, so
+/// each render re-resolves every named query once (keeping the within-render
+/// dedup); an override edited since the last render takes effect on the next.
+///
+/// The sequence reuses the `RenderOverrideTests` fixture (the `IBase`/`IDerived`
+/// pair with an observable `bases` row): a `-I` `Render/bases.sql` renames
+/// `IDerived`'s base to `IFirst`, a first render observes it, the file is
+/// rewritten to name `ISecond`, and a second render in the same shell must
+/// observe `ISecond` — not the cached `IFirst`.
+struct RenderCacheTests {
+  @Test func `a -I override edited between renders refreshes on the next render`() throws {
+    try RenderOverrideTests.withDirectory { directory in
+      let manager = FileManager.default
+      let render = URL(fileURLWithPath: "\(directory)/Render")
+      try manager.createDirectory(at: render, withIntermediateDirectories: true)
+      let base = render.appendingPathComponent("bases.sql")
+      let first = """
+        SELECT 'IFirst' AS base
+        FROM InterfaceImpl WHERE Class = :parent
+        """
+      try Data(first.utf8).write(to: base)
+      try RenderOverrideTests.with { catalog in
+        let shell = Shell(catalog, search: [directory])
+        // The first render resolves and memoises the override naming `IFirst`.
+        let before = try shell.render("IDerived", template: "com")
+        #expect(before.contains("public protocol IDerived: IFirst {"))
+        // The same shell's override file is rewritten to name `ISecond`.
+        let second = """
+          SELECT 'ISecond' AS base
+          FROM InterfaceImpl WHERE Class = :parent
+          """
+        try Data(second.utf8).write(to: base)
+        // The next render re-resolves the file: the pre-fix shell-lifetime memo
+        // returned the stale `IFirst` parse; the per-render memo reflects the
+        // edit and names `ISecond`.
+        let after = try shell.render("IDerived", template: "com")
+        #expect(after.contains("public protocol IDerived: ISecond {"))
+        #expect(!after.contains("IFirst"))
+      }
+    }
+  }
+}
+
+/// Coverage of the `.render *` empty-seed guard: a metadata file whose `TypeDef`
+/// rows are all non-interface produces no seed, so `.render *` emits nothing.
+/// The batch shortcuts must not fire in that case — `guids` expands the
+/// `interfaces` view (a three-way UNION over `CustomAttribute`/`MemberRef`/
+/// `TypeRef`) and the `inherits`/`roster`/`signatures` trio expands views over
+/// `InterfaceImpl`/`MethodDef`/`Param`, none of which a valid interface-free
+/// file need carry — so running them would fault with a missing relation where
+/// there is nothing to render. The fix skips every batch query on an empty
+/// wildcard seed, so `.render *` returns the empty string rather than faulting.
+struct RenderEmptyTests {
+  // One `TypeDef` (#2) and no other table: a single non-interface row (Flags 0,
+  // so the seed scan's `BITAND(Flags, 32) = 32` drops it), so the `interfaces`
+  // view's `CustomAttribute`/`MemberRef`/`TypeRef` and the trio's
+  // `InterfaceImpl`/`MethodDef`/`Param` are all absent — expanding either would
+  // fault on a missing relation. TypeDef stride 14 (narrow indexes).
+  //   TypeDef[0]: Flags=0, TypeName="Widget"(4), TypeNamespace="NS"(1),
+  //               Extends=0, FieldList=0, MethodList=0.
+  private static let bytes: Array<UInt8> = [
+    0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ]
+
+  // "\0NS\0Widget\0": NS@1, Widget@4.
+  private static let strings: Array<UInt8> = [
+    0x00, 0x4e, 0x53, 0x00, 0x57, 0x69, 0x64, 0x67, 0x65, 0x74, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeDef.self, rows: 1, range: 0 ..< 14,
+                wide: 0, stride: 14),
+  ]
+
+  // Only the `TypeDef` table (#2) is present.
+  private static let valid: UInt64 = (1 << 2)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  private static func with(_ body: (borrowing Storage) throws -> Void)
+      rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: empty.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+
+  @Test func `* renders nothing rather than expanding a batch view on an empty seed`() throws {
+    try RenderEmptyTests.with { catalog in
+      let shell = Shell(catalog)
+      // Pre-fix, the batch fired unconditionally for `*`: `guids` expanded the
+      // `interfaces` view and faulted on the absent `CustomAttribute`. The fix
+      // skips the batch on an empty seed, so the render returns "".
+      let star = try shell.render("*", template: "com")
+      #expect(star.isEmpty)
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces significant performance improvements and code simplification to the `Shell` struct in `Sources/winmd-inspect/Shell.swift`, primarily by batching and memoizing SQL query executions that were previously performed repeatedly in tight loops. The changes reduce redundant parsing and execution of SQL queries, especially for the `.render *` path, by introducing batch queries and a cache for parsed statements. Additionally, minor optimizations are made in the SQL engine to avoid unnecessary expensive operations for common query types.

**Performance and Query Optimization:**

* Added batch query methods (`inherits`, `roster`, `signatures`, `guids`) that fetch all required data in a single pass, replacing thousands of per-interface or per-method SQL queries in the `.render *` path. This greatly reduces redundant database work and ensures emitted results remain byte-identical to the previous logic.
* Updated the main render loop to use these batch results when rendering all interfaces, passing the batch data into the emit and method decoding routines. [[1]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R507-R523) [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L631-R766) [[3]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L649-R785) [[4]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L658-R806) [[5]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L725-R893)

**Memoization and Code Simplification:**

* Introduced a `Cache` class to memoize parsed SQL render queries by name for the lifetime of a `Shell`, avoiding repeated parsing of the same query text for each interface or method. [[1]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R309-R322) [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R1092-R1107) [[3]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425R1148-R1156)
* Replaced repeated calls to `Shell.statement(Shell.query(...))` with a new `statement(named:)` helper that consults the cache, further reducing redundant work. [[1]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L579-R712) [[2]](diffhunk://#diff-16d3e7b998069953aac4c3c9c79bbb97698398edcfe6731900f481e311d3c425L818-R975)

**SQL Engine Optimizations:**

* In the SQL engine (`SwiftSQL/Sources/SQLEngine/Engine.swift` and `Filter.swift`), added a cheap structural predicate (`unioned`) to gate expensive schema-building logic, so ordinary queries skip unnecessary work, improving performance for the common case. [[1]](diffhunk://#diff-6c214f9dcc3df36d160cb73f3df66c04c352ed9a6b4db71f275e3705607c6a46L151-R160) [[2]](diffhunk://#diff-74bb274611546ebbdc9e1098bffe868a04b233faabe02db1ea0975f948c41e84L1365-R1371)

These changes collectively make the `.render *` path in `winmd-inspect` much more efficient, especially when rendering large numbers of interfaces, and simplify the code by centralizing query parsing and execution logic.