### PR TITLE
SQLEngineWinMD: resolve a relation by name without reflection

### DIFF
--- a/Sources/SQLEngineWinMD/Database+SQL.swift
+++ b/Sources/SQLEngineWinMD/Database+SQL.swift
@@ -68,25 +68,31 @@ extension WinMD.Storage: SQLEngine.Catalog {
      (name: "NestedClass", schema: Metadata.Tables.NestedClass.self)]
   }
 
-  /// The relation named `name`, resolved case-insensitively against the open
-  /// tables' schema names.
+  /// The relation named `name`, resolved case-insensitively against the
+  /// registered tables' schema names.
   ///
-  /// A `WinMD.Table`'s description is its schema name (e.g. "TypeDef"); a name
-  /// the database has no table for yields `nil`, which the engine reports as
+  /// A `WinMD.Table`'s schema name (e.g. "TypeDef") is its identity, and each
+  /// schema carries a distinct CIL table `number`. Rather than reflect every
+  /// open table's schema through `String(describing:)` per call — this is hit
+  /// tens of thousands of times over a query, and massively during a render —
+  /// the name resolves through the once-built `Metadata.Tables.number(named:)`
+  /// map to that number, then the open tables are matched on their cheap
+  /// `schema.number`. This is order-independent, exactly as the former
+  /// description scan was, so a `Storage` whose tables are not in number order
+  /// resolves identically. A name no registered table bears, or a present table
+  /// the number does not name, yields `nil`, which the engine reports as
   /// `SQLError.relation`.
   @_lifetime(borrow self)
   public borrowing func table(named name: String) -> WinMDRelation? {
-    for index in 0 ..< tables.count {
-      if tables[index].description.caseInsensitiveCompare(name)
-          == .orderedSame {
-        return WinMDRelation(self, tables[index])
-      }
+    guard let number = Metadata.Tables.number(named: name) else { return nil }
+    for index in 0 ..< tables.count
+        where tables[index].schema.number == number {
+      return WinMDRelation(self, tables[index])
     }
     // An optional table (see `optionals`) the tables stream omits resolves to
     // an empty relation, so a bundled view or the closure walk that names it
     // reads no rows rather than faulting on a missing relation.
-    for entry in WinMD.Storage.optionals
-        where name.caseInsensitiveCompare(entry.name) == .orderedSame {
+    for entry in WinMD.Storage.optionals where entry.schema.number == number {
       return WinMDRelation(self, .empty(entry.schema))
     }
     return nil

--- a/Sources/WinMD/CILTables.swift
+++ b/Sources/WinMD/CILTables.swift
@@ -1,10 +1,50 @@
 // Copyright © 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+import Foundation
+
 extension Metadata {
   public enum Tables {
   }
 }
+
+/// The case-insensitive fold that keys the name registry — Foundation's
+/// case-folding (e.g. `ſ` folds to `s`), matching the `caseInsensitiveCompare`
+/// the by-name scan used before, so a delimited relation name resolves the same.
+private func folded(_ name: String) -> String {
+  name.folding(options: .caseInsensitive, locale: nil)
+}
+
+extension Metadata.Tables {
+  /// The CIL table number a schema named `name` carries (case-insensitively),
+  /// or `nil` for a name no registered table bears.
+  ///
+  /// A once-built, reflection-free name resolution. The registry's schema names
+  /// are reflected through `String(describing:)` a single time to seed
+  /// `registry`, so a caller resolving a relation by name — the SQL adapter's
+  /// `table(named:)`, hit tens of thousands of times over a query — consults a
+  /// hashed lookup rather than reflecting every open table's schema per call.
+  /// The map is schema-universal (a table's number does not vary by database),
+  /// so it lives as a module-level `let`, not on a borrowed value.
+  package static func number(named name: String) -> Int? {
+    registry[folded(name)]
+  }
+}
+
+/// The case-folded schema name → CIL table number map, built once over the
+/// registered tables. The one place `String(describing:)` reflects a schema
+/// name; every by-name resolution reads this hashed map thereafter. Keying on
+/// `folded` (not `lowercased`) preserves the case-insensitive contract for a
+/// Unicode case-fold equivalent — e.g. a delimited `"Typeſpec"` resolves to
+/// `TypeSpec` because `ſ` folds to `s`, which `lowercased()` leaves unchanged.
+private let registry: Dictionary<String, Int> = {
+  var registry =
+      Dictionary<String, Int>(minimumCapacity: kRegisteredTables.count)
+  for schema in kRegisteredTables {
+    registry[folded("\(schema)")] = schema.number
+  }
+  return registry
+}()
 
 @usableFromInline
 internal let kRegisteredTables: Array<TableSchema.Type> = [

--- a/Tests/SQLEngineWinMDTests/TypesViewTests.swift
+++ b/Tests/SQLEngineWinMDTests/TypesViewTests.swift
@@ -243,6 +243,14 @@ struct TypesViewTests {
         Issue.record("table(named: \"TypeSpec\") did not resolve")
         return
       }
+      // A delimited name that is a Unicode case-fold equivalent resolves the
+      // same, per the catalog's case-insensitive contract: `ſ` folds to `s`, so
+      // `Typeſpec` must reach `TypeSpec`. The name registry keys on a case-fold
+      // (not `lowercased()`, which leaves `ſ` unchanged) to preserve this.
+      guard catalog.table(named: "Typeſpec") != nil else {
+        Issue.record("table(named: \"Typeſpec\") did not resolve (case-fold)")
+        return
+      }
     }
   }
 


### PR DESCRIPTION
`WinMD.Storage`'s `Catalog` conformance resolved a relation name by scanning the open tables and comparing each `Table.description` — which is `String(describing:)` over the schema metatype — to the name, case-insensitively, on every call. The engine resolves a relation many times over a single query (compilation, optimisation, decorrelation, reordering, interpretation each look one up per reference), so a query reflected every open table's schema thousands of times, and a full render tens of thousands, making the metatype reflection a measured hot spot.

Resolve the name through a precomputed map instead. A single module-level `let` in WinMD reflects each registered schema's name once to build a lowercased name to CIL table-number dictionary, exposed as the package accessor `Metadata.Tables.number(named:)`. The adapter's `table(named:)` now folds the name to that number and matches the open tables on their cheap `schema.number`, with no per-call reflection. The map is schema-universal — a table's number does not vary by database — so a module-level `let` is its natural home; `Storage` is borrowed and `~Escapable`, so no cache belongs on the value itself.

The match stays a scan over the open tables (comparing an integer, not a reflected string) rather than a population-count slot, so it remains order-independent exactly as the description scan was: a `Storage` whose tables are not laid out in number order — as the adapter's own in-memory test fixtures are — resolves identically. Behaviour is otherwise unchanged: the same relations resolve, the synthesised empty optionals (`TypeSpec`, `NestedClass`) still resolve when absent, an unknown name still yields `nil`, and `relations()` enumerates the same set.

Measured over Windows.Win32.winmd, release build:

  - a synthetic batch of 8000 four-relation planning queries: 6.55s -> 4.24s (35% faster)
  - `.render * com`: 125.5s -> 67.9s (1.85x faster)

Root `swift test` (355 tests) and `swift test --package-path SwiftSQL` (3139 tests) are green with no warnings.