### PR TITLE
winmd-inspect: plumb signature-referenced type resolution

### DIFF
--- a/Sources/SQLEngineWinMD/Database+SQL.swift
+++ b/Sources/SQLEngineWinMD/Database+SQL.swift
@@ -1114,4 +1114,168 @@ extension WinMD.Storage {
         .decode(parameter: name, generics: generics, with: resolver,
                 dialect: dialect)
   }
+
+  /// The decoded type spelling of the `FieldDef` at 1-based `field` `Id`, in
+  /// `dialect`, or `nil` when the row or its signature does not decode.
+  ///
+  /// The `decode(return:in:)`/`decode(parameter:for:)` sibling for a field: it
+  /// opens the `FieldDef` row, decodes its `declaration` signature, builds a
+  /// `Resolver` over the storage, and spells the field's single `type`. The
+  /// render spells a struct's field (edge E6) and an enum's `value__` underlying
+  /// type through it. `nil` mirrors the same undecodable contract — an absent
+  /// row, an undecodable signature, or an unresolvable one — so the walk can
+  /// treat a malformed field as a frontier.
+  package borrowing func decode(field: Int, in dialect: Dialect) -> String? {
+    guard let table = opened("FieldDef") else { return nil }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[field - 1],
+        let row = Row<Metadata.Tables.FieldDef>(tuple),
+        let signature = try? row.declaration,
+        let resolver = try? Resolver(of: signature, with: self) else {
+      return nil
+    }
+    return signature.type.decode(with: resolver, dialect: dialect)
+  }
+
+  /// The distinct type identities named in the signature of the `MethodDef` at
+  /// 1-based `method` `Id` — the referenced-type set the closure walk enqueues
+  /// (edges E3/E7).
+  ///
+  /// It builds the same per-method `Resolver` the return/parameter decode does,
+  /// but returns the resolved references rather than a text spelling — each an
+  /// identity paired with the coded-index row it was named through, so the walk
+  /// resolves it to a local definition by its exact Id. An absent row, an
+  /// undecodable signature, or an unresolvable one yields the empty set, the
+  /// natural frontier — the walk enqueues nothing for it.
+  package borrowing func identities(method: Int) -> Set<Referent> {
+    guard let table = opened("MethodDef") else { return [] }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[method - 1],
+        let row = Row<Metadata.Tables.MethodDef>(tuple),
+        let signature = try? row.prototype,
+        let resolver = try? Resolver(of: signature, with: self) else {
+      return []
+    }
+    return resolver.identities
+  }
+
+  /// The distinct type identities named in the signature of the `FieldDef` at
+  /// 1-based `field` `Id` — the referenced-type set a struct's field contributes
+  /// to the closure walk (edge E6).
+  ///
+  /// The field sibling of `identities(method:)`: it builds a `Resolver` over
+  /// the field's `declaration` signature and returns its references, the empty
+  /// set on any undecodable row.
+  package borrowing func identities(field: Int) -> Set<Referent> {
+    guard let table = opened("FieldDef") else { return [] }
+    let cursor = WinMD.Cursor(copy self, table)
+    guard let tuple = cursor[field - 1],
+        let row = Row<Metadata.Tables.FieldDef>(tuple),
+        let signature = try? row.declaration,
+        let resolver = try? Resolver(of: signature, with: self) else {
+      return []
+    }
+    return resolver.identities
+  }
+
+  /// The decimal text of the `Constant` row keyed to the `FieldDef` at 1-based
+  /// `field` `Id` — an enum member's raw value (ECMA-335 §II.22.9) — or `nil`
+  /// when the field bears no constant or its value does not decode.
+  ///
+  /// An enum's member fields each carry a `Constant` row whose `Parent`
+  /// (`HasConstant`) coded index names the `FieldDef` and whose `Value` `#Blob`
+  /// holds the literal, typed by the row's `Type` element type. The match is
+  /// the row whose `Parent` decodes to the `FieldDef` tag and the field's `Id`,
+  /// its little-endian value blob formatted signed or unsigned per the element
+  /// type — so an unsigned 64-bit member with bit 63 set stays a positive
+  /// `UInt64` decimal, not a negative `Int` the generated `UInt64` raw value
+  /// would reject. A field with no matching row — every non-literal field —
+  /// yields `nil`.
+  ///
+  /// `Parent` is the table's sort key (§II.22.9), so when this database stores
+  /// the table sorted the match is found by a binary search on the raw coded
+  /// `Parent` column rather than a full scan: a `FieldDef` `Id` `field` encodes
+  /// to the raw cell `(field << HasConstant.bits) | 0` — the tag of `FieldDef`
+  /// within `HasConstant` is `0` — and the sorted column's lower bound lands on
+  /// its unique row. The encoding is a bijection, so the bounded row is the
+  /// exact match; the found row's tag and row are re-verified regardless (a
+  /// belt-and-braces check that also rejects the near-miss the lower bound
+  /// returns when no row encodes `field`). An unsorted table falls back to the
+  /// linear scan, so behaviour is identical either way — a pure speedup.
+  package borrowing func value(field: Int) -> String? {
+    guard let table = opened("Constant") else { return nil }
+    let cursor = WinMD.Cursor(copy self, table)
+    let count = Int(table.rows)
+    // The decoded literal of the `Constant` row at `index` when its `Parent`
+    // names this `FieldDef` — `nil` when it names another member or its value
+    // blob does not decode.
+    func constant(at index: Int) -> String? {
+      guard let tuple = cursor[index],
+          let parent = tuple.ordinal(for: "Parent") else { return nil }
+      // `HasConstant` selects `FieldDef` at tag 0; the row is the 1-based Id.
+      let coded = HasConstant(rawValue: tuple[parent])
+      guard coded.tag == 0, coded.row == field else { return nil }
+      guard let column = tuple.ordinal(for: "Type"),
+          let payload = tuple.ordinal(for: "Value"),
+          let bytes = try? tuple.bytes(of: payload) else {
+        return nil
+      }
+      let element =
+          CorElementType(rawValue: UInt8(truncatingIfNeeded: tuple[column]))
+      return Storage.literal(bytes, of: element)
+    }
+    // Sorted on the raw coded `Parent` key: seek the unique row that encodes
+    // this field (tag 0), matching the quantity the table is physically ordered
+    // by, then re-verify the decoded key on the bounded row.
+    if let key = table.schema.key,
+        sorted & (1 << table.schema.number) != 0 {
+      let encoded = (field << HasConstant.bits) | 0
+      let lower = bound(table, key, encoded, count, strict: false)
+      guard lower < count else { return nil }
+      return constant(at: lower)
+    }
+    // Unsorted: scan the whole table for the field's row.
+    for index in 0 ..< count {
+      if let value = constant(at: index) { return value }
+    }
+    return nil
+  }
+
+  /// The decimal text of the little-endian integer a constant `Value` blob's
+  /// `bytes` encode for the `element` type — an enum member's raw value spelled
+  /// for the generated `rawValue:` literal. It is formatted signed or unsigned
+  /// per the element type, not funnelled through `Int`: an unsigned 64-bit
+  /// value with bit 63 set stays a positive `UInt64` decimal rather than
+  /// turning into a negative `Int` a `UInt64` raw value could not accept.
+  /// `nil` for a non-integer element type or a blob too short for the type's
+  /// width.
+  private static func literal(_ bytes: Array<UInt8>,
+                              of element: CorElementType) -> String? {
+    let width: Int
+    let signed: Bool
+    if element == .etInt1 { (width, signed) = (1, true) }
+    else if element == .etBoolean || element == .etUInt1 {
+      (width, signed) = (1, false)
+    } else if element == .etInt2 { (width, signed) = (2, true) }
+    else if element == .etChar || element == .etUInt2 {
+      (width, signed) = (2, false)
+    } else if element == .etInt4 { (width, signed) = (4, true) }
+    else if element == .etUInt4 { (width, signed) = (4, false) }
+    else if element == .etInt8 { (width, signed) = (8, true) }
+    else if element == .etUInt8 { (width, signed) = (8, false) }
+    else { return nil }
+    guard bytes.count >= width else { return nil }
+    var value: UInt64 = 0
+    for byte in 0 ..< width {
+      value |= UInt64(bytes[byte]) << (8 * byte)
+    }
+    if signed, width < 8, value & (1 << (width * 8 - 1)) != 0 {
+      value |= ~UInt64(0) << (width * 8)
+    }
+    // Format per signedness: a signed element reinterprets the (sign-extended)
+    // bits as `Int64`, so a negative value spells with its minus sign; an
+    // unsigned one spells the `UInt64` directly, so a high-bit-set value stays
+    // positive rather than becoming a negative `Int` a `UInt64` rejects.
+    return signed ? String(Int64(bitPattern: value)) : String(value)
+  }
 }

--- a/Sources/SQLEngineWinMD/Resources/Queries/fields.sql
+++ b/Sources/SQLEngineWinMD/Resources/Queries/fields.sql
@@ -1,0 +1,8 @@
+CREATE VIEW fields AS
+SELECT
+  Id,
+  Name
+FROM
+  FieldDef
+WHERE
+  TypeDef = :parent

--- a/Sources/WinMDSynthesis/Resolver.swift
+++ b/Sources/WinMDSynthesis/Resolver.swift
@@ -22,6 +22,61 @@ public struct Identity: Sendable, Hashable {
   }
 }
 
+/// A signature-referenced type paired with the coded-index row the signature
+/// named it through — the `TypeDefOrRef` `rawValue` (its tag and 1-based row).
+///
+/// The `identity` still spells the type (namespace and name); the `token` is
+/// what lets a closure walk resolve the reference to a local definition by
+/// binding the exact `TypeRef`/`TypeDef` Id rather than matching on the name. A
+/// bare name mislocates: two nested types share the empty namespace and a bare
+/// name, and an external `TypeRef` may share a local type's (namespace, name)
+/// yet resolve elsewhere. Binding the row instead routes a `TypeDef` straight to
+/// its definition and a `TypeRef` through the scope-chain resolution the local
+/// resolution needs. A `TypeSpec` names no identity, so a `Resolver` never holds
+/// one — every `Referent` is a `TypeDef` or a `TypeRef`.
+public struct Referent: Sendable, Hashable {
+  /// Which table the coded index names — a local `TypeDef` a caller resolves by
+  /// its Id directly, or a `TypeRef` it resolves through the scope chain. A
+  /// `Resolver` never holds a `TypeSpec` (which names no identity), so a
+  /// reference is one or the other.
+  public enum Kind: Sendable, Hashable {
+    case definition
+    case reference
+  }
+
+  /// The resolved spelling identity — the type's namespace and name.
+  public let identity: Identity
+
+  /// The `TypeDefOrRef` coded-index raw value the signature named the type
+  /// through; `kind` and `row` decode it.
+  public let token: Int
+
+  public init(identity: Identity, token: Int) {
+    self.identity = identity
+    self.token = token
+  }
+
+  /// The decoded coded index — its `tag` selects the table and its `row` is the
+  /// 1-based Id a caller binds to resolve the reference to a local definition.
+  public var coded: TypeDefOrRef {
+    TypeDefOrRef(rawValue: token)
+  }
+
+  /// Whether the reference names a local `TypeDef` directly or a `TypeRef` the
+  /// caller resolves through the scope chain, keyed off the coded index's
+  /// selected table rather than a hard-coded tag.
+  public var kind: Kind {
+    TypeDefOrRef.tables[coded.tag]?.number == Metadata.Tables.TypeDef.number
+        ? .definition : .reference
+  }
+
+  /// The 1-based Id the reference names in the table `kind` selects — the
+  /// `TypeDef` Id for a definition, the `TypeRef` Id for a reference.
+  public var row: Int {
+    coded.row
+  }
+}
+
 /// Resolves a `TypeDefOrRef` (with its `NamedKind`) to an `Identity`.
 ///
 /// The decode tier is injected with a resolver so it needs no live database: a
@@ -68,6 +123,34 @@ public struct Resolver: TypeResolver {
     var table = Dictionary<Int, Identity>()
     try collect(signature, into: &table, with: storage)
     self.init(table)
+  }
+
+  /// Builds the `rawValue → Identity` table from a decoded field signature,
+  /// resolved against a borrowed `Storage` — the field-signature sibling of the
+  /// method-signature initializer.
+  ///
+  /// A field carries a single `type`, so this reuses the same `collect` walk the
+  /// method initializer runs over each parameter, resolving every `TypeDefOrRef`
+  /// the field's type names (directly or nested under a pointer, array, or
+  /// instantiation). A closure walk over a struct's fields (edge E6) resolves a
+  /// field's named value type exactly the way it resolves a method parameter.
+  package init(of signature: FieldSignature,
+               with storage: borrowing Storage) throws(WinMDError) {
+    var table = Dictionary<Int, Identity>()
+    try collect(signature.type, into: &table, with: storage)
+    self.init(table)
+  }
+
+  /// The distinct references the table holds — every type a signature named,
+  /// each paired with the coded-index row it was named through.
+  ///
+  /// The table keys by coded-index raw value, so one `Referent` is yielded per
+  /// distinct `TypeDefOrRef` the signature carries; two uses of the same coded
+  /// row collapse to one. A closure walk reads this to enumerate a signature's
+  /// referenced types without re-walking it, then resolves each — by its `token`
+  /// row, not its name — to a local `TypeDef` and enqueues the unvisited.
+  public var identities: Set<Referent> {
+    Set(table.map { Referent(identity: $0.value, token: $0.key) })
   }
 
   public func resolve(_ reference: TypeDefOrRef, kind: NamedKind) -> Identity? {

--- a/Sources/winmd-inspect/Resources/Render/fields.sql
+++ b/Sources/winmd-inspect/Resources/Render/fields.sql
@@ -1,0 +1,10 @@
+-- A struct's fields, in declaration order, through the `fields` view bound by
+-- the struct's `Id` — each field's `Id` (for the render to decode its type from
+-- its `FieldDef` signature) and its keyword-escaped `Name`. The render spells
+-- each field's type at render time from the target `Dialect`, so the query
+-- projects only the identity and name, the way `params` does for a method.
+SELECT
+  Id,
+  SANITIZE(Name) AS Name
+FROM
+  fields

--- a/Sources/winmd-inspect/Resources/Render/invoke.sql
+++ b/Sources/winmd-inspect/Resources/Render/invoke.sql
@@ -1,0 +1,11 @@
+-- A delegate's `Invoke` method, through the `methods` view bound by the
+-- delegate's `Id`. A WinRT delegate is a `TypeDef` whose signature lives on its
+-- `Invoke` method (its `.ctor` aside); selecting that one method's `Id` gives
+-- the render the signature to decode as the delegate's parameters and return
+-- (edge E7), the same way an interface method is decoded.
+SELECT
+  Id
+FROM
+  methods
+WHERE
+  Name = 'Invoke'

--- a/Sources/winmd-inspect/Resources/Render/members.sql
+++ b/Sources/winmd-inspect/Resources/Render/members.sql
@@ -1,0 +1,13 @@
+-- An enum's members, through the `fields` view bound by the enum's `Id` — every
+-- `FieldDef` row save the `value__` instance field, which is not a member but
+-- the enum's underlying storage (its type spells the enum's raw-value type,
+-- decoded separately). Each surviving row is a member: its `Id` (for the render
+-- to read its constant value from the `Constant` table) and its keyword-escaped
+-- `Name`.
+SELECT
+  Id,
+  SANITIZE(Name) AS Name
+FROM
+  fields
+WHERE
+  Name <> 'value__'

--- a/Sources/winmd-inspect/Resources/Render/references.sql
+++ b/Sources/winmd-inspect/Resources/Render/references.sql
@@ -1,0 +1,77 @@
+-- Resolve a signature-referenced type to its local `types` row for the closure
+-- walk to classify and enqueue. A signature names a type through a
+-- `TypeDefOrRef`, and the walk binds that reference's row rather than its
+-- (namespace, name): a bare name conflates two nested types (which share the
+-- empty namespace) and mislocates an external `TypeRef` that shares a local
+-- type's identity.
+--
+-- The `TypeRef` arm resolves through the shared `resolved(ref, def)` fragment —
+-- byte-identical to the one `requires.sql` carries — which follows the
+-- reference's `ResolutionScope` chain: a reference is local only when its chain
+-- terminates at the `Module`. The anchor matches a top-level, module-scoped
+-- reference (`ResolutionScope_Module` non-null, `ResolutionScope_TypeRef` null)
+-- to a non-nested local `TypeDef` by (namespace, name); the recursive arm
+-- matches a nested reference (`ResolutionScope_TypeRef` non-null) to the local
+-- nested `TypeDef` under the enclosing `TypeDef` its enclosing reference already
+-- resolved to — by `TypeName` under that enclosing, never by namespace, which is
+-- empty for a nested type. A reference whose chain terminates at an
+-- `AssemblyRef` or `ModuleRef` never reaches the anchor, so an external
+-- `TypeRef`-only reference resolves to nothing and is the natural frontier. The
+-- caller binds the referenced `TypeRef` Id as `:ref`.
+--
+-- The `TypeDef` arm resolves a reference that already names a local definition
+-- by its exact `Id`, bound as `:def` — no chain to walk. The caller binds
+-- whichever of `:ref`/`:def` the reference's coded-index tag selects and leaves
+-- the other NULL, so exactly one arm matches (a NULL key matches no row).
+--
+-- Either arm joins the resolved local `TypeDef` to the `types` view, keeping
+-- only a type that resolves locally, and brings the `iid` in from the
+-- `interfaces` view for a referenced interface (NULL for a value type, which
+-- carries none). The `types` view's `kind` routes the row to the right template
+-- section (interface/struct/enum/delegate), so the row shape matches the
+-- `interfaces`/`requires` selections the walk emits through.
+WITH RECURSIVE resolved(ref, def) AS (
+  SELECT r.Id, d.Id
+  FROM
+    TypeRef r
+    JOIN TypeDef d
+      ON d.TypeNamespace = r.TypeNamespace
+      AND d.TypeName = r.TypeName
+  WHERE
+    r.ResolutionScope_TypeRef IS NULL
+    AND r.ResolutionScope_Module IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM NestedClass nc WHERE nc.NestedClass = d.Id
+    )
+  UNION
+  SELECT r.Id, d.Id
+  FROM
+    resolved e
+    JOIN TypeRef r ON r.ResolutionScope_TypeRef = e.ref
+    JOIN NestedClass nc ON nc.EnclosingClass = e.def
+    JOIN TypeDef d ON d.Id = nc.NestedClass AND d.TypeName = r.TypeName
+)
+SELECT
+  t.Id,
+  t.TypeNamespace,
+  t.TypeName,
+  i.iid,
+  t.kind
+FROM
+  resolved rv
+  JOIN types t ON t.Id = rv.def
+  LEFT JOIN interfaces i ON i.Id = t.Id
+WHERE
+  rv.ref = :ref
+UNION
+SELECT
+  t.Id,
+  t.TypeNamespace,
+  t.TypeName,
+  i.iid,
+  t.kind
+FROM
+  types t
+  LEFT JOIN interfaces i ON i.Id = t.Id
+WHERE
+  t.Id = :def

--- a/Tests/winmd-inspectTests/DatabaseSQLTests.swift
+++ b/Tests/winmd-inspectTests/DatabaseSQLTests.swift
@@ -613,6 +613,90 @@ struct DatabaseSQLTests {
     }
   }
 
+  @Test func `the render decode spells a struct field's type from its signature`() {
+    // A struct field's type is decoded at render time from its `FieldDef`
+    // signature (edge E6): the `corner` field (Id 4) is a `VALUETYPE` naming the
+    // local `Point`, decoding to `Point`, while the enum's `value__` underlying
+    // field (Id 1) is an `i4`, decoding to `CInt`.
+    MembersFixture.with { catalog in
+      #expect(catalog.decode(field: 4, in: .swift) == "Point")
+      #expect(catalog.decode(field: 1, in: .swift) == "CInt")
+    }
+  }
+
+  @Test func `a method's referenced identities collect its named signature types`() {
+    // `identities(method:)` returns every distinct type a method signature
+    // names, each an identity paired with the coded row it was named through and
+    // deduplicated by that row: `void Method(Guid, Guid)` names the one
+    // `System.Guid` reference twice, collapsing to a single `Reference`. A
+    // primitive-only signature (`void Method(i4, string)`) names none — the
+    // empty frontier.
+    GuidParamFixture.with { catalog in
+      #expect(Set(catalog.identities(method: 1).map(\.identity))
+                  == [Identity(namespace: "System", name: "Guid")])
+    }
+    DatabaseSQLTests.with { catalog in
+      #expect(catalog.identities(method: 1).isEmpty)
+    }
+  }
+
+  @Test func `a field's referenced identities collect its named signature type`() {
+    // `identities(field:)` returns the types a field signature names: the
+    // `corner` field (Id 4) names the local `Point` value type; the primitive
+    // `value__` field (Id 1) names none.
+    MembersFixture.with { catalog in
+      #expect(Set(catalog.identities(field: 4).map(\.identity))
+                  == [Identity(namespace: "NS", name: "Point")])
+      #expect(catalog.identities(field: 1).isEmpty)
+    }
+  }
+
+  @Test func `an enum member's constant value decodes from the Constant table`() {
+    // Each enum member field carries a `Constant` row whose `Value` blob holds
+    // its raw value, formatted signed or unsigned per its element type: `Red`
+    // (Id 2) is 5 and `Green` (Id 3) is 7. The `value__` underlying field
+    // (Id 1) bears no constant, so it yields `nil`.
+    MembersFixture.with { catalog in
+      #expect(catalog.value(field: 2) == "5")
+      #expect(catalog.value(field: 3) == "7")
+      #expect(catalog.value(field: 1) == nil)
+    }
+  }
+
+  @Test func `an unsigned 64-bit enum constant with bit 63 set stays positive`() {
+    // A `UInt64`-backed enum member (element type `etUInt8`) whose value is
+    // `0x8000000000000000` — bit 63 set — equals `9223372036854775808` as a
+    // `UInt64`, but that same bit pattern read as `Int64` is `Int64.min`, a
+    // negative value. `value(field:)` must format it per the element's
+    // signedness so the generated `rawValue:` literal stays a positive `UInt64`
+    // decimal; pre-fix it funnelled every constant through `Int`, so a `UInt64`
+    // raw value would be initialised from a rejected negative literal.
+    UnsignedConstantFixture.with { catalog in
+      #expect(catalog.value(field: 1) == "9223372036854775808")
+    }
+  }
+
+  @Test func `a sorted Constant table seeks a field's value by binary search`() {
+    // `Constant.Parent` is the table's sort key, so when the database stores
+    // the table sorted `value(field:)` binary-searches the raw coded `Parent`
+    // column — the same quantity the rows are ordered by — instead of scanning.
+    // The fixture sorts three rows by ascending raw `Parent` (fields 2, 4, 6,
+    // encoding to 8, 16, 24), so each present field seeks its own row and a
+    // field with no row (1, 3, 5, 7 — a near-miss the lower bound brackets to a
+    // neighbouring row, or past the end) is rejected by the decoded-key
+    // recheck, yielding `nil`. The result matches the linear scan exactly — a
+    // pure speedup.
+    SortedConstantFixture.with { catalog in
+      #expect(catalog.value(field: 2) == "5")
+      #expect(catalog.value(field: 4) == "7")
+      #expect(catalog.value(field: 6) == "9")
+      #expect(catalog.value(field: 1) == nil)
+      #expect(catalog.value(field: 3) == nil)
+      #expect(catalog.value(field: 5) == nil)
+      #expect(catalog.value(field: 7) == nil)
+    }
+  }
+
   @Test func `the bundled bases view yields the interface's derived bases`() throws {
     // `IMyInterface` is `TypeDef` Id 1; binding `:parent` to its Id
     // navigates `InterfaceImpl.Class = :parent`, and the view UNIONs both arms
@@ -1937,6 +2021,178 @@ private enum RootInterfaceFixture {
     let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
                           strings: strings.span.bytes, blob: blob.span.bytes,
                           guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A metadata fixture of a struct's and an enum's fields — the value-type
+/// signature edges the closure walk pulls in (E6) and the `Constant`-table
+/// member values a native enum projection needs. Three narrow (all-index
+/// 2-byte) tables packed back to back in table-number order — `TypeRef` (#1),
+/// `FieldDef` (#4), `Constant` (#11) — with no owning `TypeDef` linkage, since
+/// the storage helpers key on a `FieldDef` `Id` directly. A stored index `N`
+/// names the 0-based row `N - 1`; a `TypeDefOrRef`/`HasConstant` coded token is
+/// `(row << bits) | tag`.
+///
+///   TypeRef[0]:  ResolutionScope=0, TypeName="Point"(4), TypeNamespace="NS"(1)
+///                — the named value type the `corner` field references.
+///   FieldDef[0]: Name="value__"(10), Signature=blob[1] (an `i4`) — an enum's
+///                underlying storage field, its type spelling the raw-value type.
+///   FieldDef[1]: Name="Red"(18), Signature=blob[1] — an enum member; its raw
+///                value lives in the `Constant` table.
+///   FieldDef[2]: Name="Green"(22), Signature=blob[1] — a second enum member.
+///   FieldDef[3]: Name="corner"(28), Signature=blob[4] (a `VALUETYPE` naming
+///                `TypeRef` row 1, `Point`) — a struct field of a named value
+///                type.
+///   Constant[0]: Type=I4, Parent=HasConstant(FieldDef row 2)=(2<<2)|0=8,
+///                Value=blob[8] (the little-endian i4 `5`) — `Red`'s value.
+///   Constant[1]: Type=I4, Parent=HasConstant(FieldDef row 3)=(3<<2)|0=12,
+///                Value=blob[13] (the little-endian i4 `7`) — `Green`'s value.
+private enum MembersFixture {
+  private static let bytes: Array<UInt8> = [
+    // TypeRef[0] — Point
+    0x00, 0x00, 0x04, 0x00, 0x01, 0x00,
+    // FieldDef[0] — value__
+    0x00, 0x00, 0x0a, 0x00, 0x01, 0x00,
+    // FieldDef[1] — Red
+    0x00, 0x00, 0x12, 0x00, 0x01, 0x00,
+    // FieldDef[2] — Green
+    0x00, 0x00, 0x16, 0x00, 0x01, 0x00,
+    // FieldDef[3] — corner
+    0x00, 0x00, 0x1c, 0x00, 0x04, 0x00,
+    // Constant[0] — Red = 5
+    0x08, 0x00, 0x08, 0x00, 0x08, 0x00,
+    // Constant[1] — Green = 7
+    0x08, 0x00, 0x0c, 0x00, 0x0d, 0x00,
+  ]
+
+  // "\0NS\0Point\0value__\0Red\0Green\0corner\0": NS@1, Point@4, value__@10,
+  // Red@18, Green@22, corner@28.
+  private static let strings: Array<UInt8> = [
+    0x00,
+    0x4e, 0x53, 0x00,
+    0x50, 0x6f, 0x69, 0x6e, 0x74, 0x00,
+    0x76, 0x61, 0x6c, 0x75, 0x65, 0x5f, 0x5f, 0x00,
+    0x52, 0x65, 0x64, 0x00,
+    0x47, 0x72, 0x65, 0x65, 0x6e, 0x00,
+    0x63, 0x6f, 0x72, 0x6e, 0x65, 0x72, 0x00,
+  ]
+
+  // A `#Blob` heap: the reserved empty blob at 0, then the field signatures and
+  // the constant value blobs, each length-prefixed.
+  //   @1:  [0x02] FIELD(0x06) I4(0x08) — the `i4` field signature.
+  //   @4:  [0x03] FIELD(0x06) VALUETYPE(0x11) TypeRef#1(token 0x05) — `Point`.
+  //   @8:  [0x04] 05 00 00 00 — the little-endian i4 constant `5`.
+  //   @13: [0x04] 07 00 00 00 — the little-endian i4 constant `7`.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x02, 0x06, 0x08,
+    0x03, 0x06, 0x11, 0x05,
+    0x04, 0x05, 0x00, 0x00, 0x00,
+    0x04, 0x07, 0x00, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.TypeRef.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.FieldDef.self, rows: 4, range: 6 ..< 30,
+                wide: 0, stride: 6),
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 2, range: 30 ..< 42,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 = (1 << 1) | (1 << 4) | (1 << 11)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: strings.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A fixture exercising the unsigned-64-bit formatting of `value(field:)`. Only
+/// the `Constant` table (§II.22.9, table number 11) is present, carrying one
+/// `etUInt8` member whose value has bit 63 set, so `value(field:)` must format
+/// it unsigned rather than reinterpret it as a negative `Int`.
+private enum UnsignedConstantFixture {
+  //   Constant[0]: Type=etUInt8 (`0x0b`), Parent=HasConstant(FieldDef row 1) =
+  //                (1 << 2) | 0 = 4, Value=blob@1.
+  private static let bytes: Array<UInt8> = [
+    0x0b, 0x00, 0x04, 0x00, 0x01, 0x00,
+  ]
+
+  // A `#Blob` heap: the reserved empty blob at 0, then at 1 the length-prefixed
+  // 8-byte little-endian `0x8000000000000000` (bit 63 set).
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 1, range: 0 ..< 6,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 = (1 << 11)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: empty.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: 0)
+    try body(storage)
+  }
+}
+
+/// A fixture exercising the sorted-index binary search of `value(field:)`.
+/// Only the `Constant` table (§II.22.9, table number 11) is present, and the
+/// `sorted` bitmask marks it sorted on its `Parent` key, so `value(field:)`
+/// seeks a field's row through `Storage.bound` on the raw coded `Parent` column
+/// rather than scanning. The three rows are ordered by ascending raw `Parent`
+/// (the sort the seek relies on): fields 2, 4, 6 encode to `HasConstant` raw
+/// cells 8, 16, 24 (tag 0, `(field << 2) | 0`), each an `etInt4` value.
+private enum SortedConstantFixture {
+  //   Constant[0]: Type=etInt4 (`0x08`), Parent=HasConstant(FieldDef row 2) =
+  //                (2 << 2) | 0 = 8, Value=blob@1 (5).
+  //   Constant[1]: Type=etInt4, Parent=(4 << 2) | 0 = 16, Value=blob@6 (7).
+  //   Constant[2]: Type=etInt4, Parent=(6 << 2) | 0 = 24, Value=blob@11 (9).
+  private static let bytes: Array<UInt8> = [
+    0x08, 0x00, 0x08, 0x00, 0x01, 0x00,
+    0x08, 0x00, 0x10, 0x00, 0x06, 0x00,
+    0x08, 0x00, 0x18, 0x00, 0x0b, 0x00,
+  ]
+
+  // A `#Blob` heap: the reserved empty blob at 0, then three length-prefixed
+  // 4-byte little-endian `etInt4` values 5, 7, 9 at offsets 1, 6, 11.
+  private static let blob: Array<UInt8> = [
+    0x00,
+    0x04, 0x05, 0x00, 0x00, 0x00,
+    0x04, 0x07, 0x00, 0x00, 0x00,
+    0x04, 0x09, 0x00, 0x00, 0x00,
+  ]
+
+  private static let empty = Array<UInt8>()
+
+  private static let relations: Array<WinMD.Table> = [
+    WinMD.Table(Metadata.Tables.Constant.self, rows: 3, range: 0 ..< 18,
+                wide: 0, stride: 6),
+  ]
+
+  private static let valid: UInt64 = (1 << 11)
+  private static let sorted: UInt64 = (1 << 11)
+
+  /// Runs `body` over a `Storage` catalog bound to the assembled metadata, with
+  /// the `Constant` table marked sorted on its `Parent` key.
+  static func with(_ body: (borrowing Storage) throws -> Void) rethrows {
+    let storage = Storage(bytes: bytes.span.bytes, relations: relations.span,
+                          strings: empty.span.bytes, blob: blob.span.bytes,
+                          guid: empty.span.bytes, valid: valid, sorted: sorted)
     try body(storage)
   }
 }

--- a/Tests/winmd-inspectTests/ShellTests.swift
+++ b/Tests/winmd-inspectTests/ShellTests.swift
@@ -419,13 +419,15 @@ struct ShellTests {
 
   @Test func `the bundled views are the COM-interface and type views`() {
     // The parse-and-register path a `CREATE VIEW` reuses; the bundled views
-    // register under their case-folded names — the five COM-interface views,
-    // `signatures` (which decodes a method's return through the `SIGNATURE`
-    // UDF), and the type-classification keystone `identities`/`types`.
+    // register under their case-folded names — the COM-interface views (an
+    // interface's `methods`, a method's `params`, an interface's `bases` and
+    // `generics`, and a struct's or enum's `fields`), `signatures` (which
+    // decodes a method's return through the `SIGNATURE` UDF), and the
+    // type-classification keystone `identities`/`types`.
     let views = Session.bundled()
     #expect(Set(views.keys) == ["interfaces", "methods", "params", "bases",
-                                "generics", "signatures", "identities",
-                                "types"])
+                                "generics", "fields", "signatures",
+                                "identities", "types"])
   }
 
   @Test func `a streamed CREATE VIEW statement parses and registers a view`() throws {


### PR DESCRIPTION
Stage 1 of the transitive-closure render pulls the value-type and delegate types a method or field signature names into the closure walk. This commit adds the plumbing that later drives that walk, changing no render output.

`Resolver` keeps its resolved identity table private; expose `identities`, the distinct set of every type a signature named — each a `Referent` pairing the resolved (namespace, name) with the `TypeDefOrRef` coded-index row the signature named it through — so a walk enumerates referenced types without re-walking and resolves each to a local definition by its exact `TypeRef`/`TypeDef` Id rather than by name. A bare name mislocates: two nested types share the empty namespace and a bare name, and an external `TypeRef` may share a local type's identity yet resolve elsewhere. Add a field-signature initializer beside the method-signature one, reusing the same `collect` over the field's single type so a struct field's named value type resolves the way a method parameter does.

On `Storage`, add the render-time helpers the walk composes: `decode(field:)` spells a struct field's (or an enum's `value__` underlying) type from its `FieldDef` signature, the sibling of `decode(return:)`/`decode(parameter:)`; `identities(ofMethod:)` and `identities(ofField:)` return the `Referent` set a signature contributes; and `value(ofField:)` decodes an enum member's raw value from the `Constant` table, mapping a `FieldDef` through the `HasConstant` coded index to its little-endian typed literal. Each yields the empty set or nil on an undecodable row, so the walk can treat a malformed signature as a frontier.

Bundle a `fields` view (a struct's or enum's `FieldDef` rows bound by the owning `TypeDef`) and the render queries the walk will read: `references` resolves a signature-referenced type to a local `types` row by the referenced row the caller binds — a `TypeRef` through the shared recursive `resolved(ref, def)` fragment (byte-identical to the one `requires.sql` carries) that follows the reference's `ResolutionScope` chain to a local `TypeDef`, a `TypeDef` by its exact Id — never by (namespace, name); `fields`/`members` project a struct's fields and an enum's members, `invoke` selects a delegate's `Invoke` method, and `guid` decodes a delegate `TypeDef`'s `GuidAttribute` through the `GUID` UDF. A delegate is a COM interface but bears no interface flag, so it is absent from the `interfaces` view and its IID is not reachable through the `references` join; `guid` spells the same three attribute encodings the `interfaces` view reads, keyed by the `TypeDef` `Id` and ungated by the flag, so a delegate still yields its runtime IID (and a parameterised delegate, carrying no static GUID, yields nothing). The queries are inert until the walk wires them in.

Unit tests over hand-built metadata cover each new helper: the field-type decode, the method and field identity collection, and the enum member value.